### PR TITLE
Add colored story type badges

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -21,7 +21,6 @@ pub struct Item {
     #[serde(default)]
     pub descendants: Option<i64>,
     #[serde(rename = "type", default)]
-    #[allow(dead_code)]
     pub item_type: Option<String>,
     #[serde(default)]
     pub dead: Option<bool>,
@@ -35,9 +34,71 @@ impl Item {
     }
 
     pub fn domain(&self) -> Option<String> {
-        self.url.as_ref().and_then(|u| {
-            url_domain(u)
-        })
+        self.url.as_ref().and_then(|u| url_domain(u))
+    }
+
+    pub fn badge(&self) -> Option<StoryBadge> {
+        if self.item_type.as_deref() == Some("job") {
+            return Some(StoryBadge::Job);
+        }
+        if self.item_type.as_deref() == Some("poll") {
+            return Some(StoryBadge::Poll);
+        }
+        let title = self.title.as_deref()?;
+        if title.starts_with("Ask HN:") {
+            return Some(StoryBadge::Ask);
+        }
+        if title.starts_with("Show HN:") {
+            return Some(StoryBadge::Show);
+        }
+        if title.starts_with("Tell HN:") {
+            return Some(StoryBadge::Tell);
+        }
+        if title.starts_with("Launch HN:") {
+            return Some(StoryBadge::Launch);
+        }
+        None
+    }
+
+    /// Title with badge prefix stripped (e.g. "Ask HN: Foo" → "Foo")
+    pub fn display_title(&self) -> &str {
+        let title = self.title.as_deref().unwrap_or("[no title]");
+        if let Some(rest) = title.strip_prefix("Ask HN:") {
+            return rest.trim_start();
+        }
+        if let Some(rest) = title.strip_prefix("Show HN:") {
+            return rest.trim_start();
+        }
+        if let Some(rest) = title.strip_prefix("Tell HN:") {
+            return rest.trim_start();
+        }
+        if let Some(rest) = title.strip_prefix("Launch HN:") {
+            return rest.trim_start();
+        }
+        title
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoryBadge {
+    Ask,
+    Show,
+    Tell,
+    Launch,
+    Job,
+    Poll,
+}
+
+impl StoryBadge {
+    pub fn label(self) -> &'static str {
+        match self {
+            StoryBadge::Ask => "Ask HN",
+            StoryBadge::Show => "Show HN",
+            StoryBadge::Tell => "Tell HN",
+            StoryBadge::Launch => "Launch HN",
+            StoryBadge::Job => "Job",
+            StoryBadge::Poll => "Poll",
+        }
     }
 }
 

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -35,10 +35,11 @@ impl<'a> Widget for CommentTree<'a> {
         };
 
         let title = if let Some(story) = &self.state.story {
-            format!(
-                " {} ",
-                story.title.as_deref().unwrap_or("[no title]")
-            )
+            if let Some(badge) = story.badge() {
+                format!(" [{}] {} ", badge.label(), story.display_title())
+            } else {
+                format!(" {} ", story.display_title())
+            }
         } else {
             " Comments ".to_string()
         };

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -65,14 +65,17 @@ impl<'a> Widget for StoryList<'a> {
             let y = inner.top() + (i - scroll) as u16;
             let is_selected = i == self.selected;
 
-            let title = story.title.as_deref().unwrap_or("[no title]");
+            let title = story.display_title();
+            let badge = story.badge();
             let domain = story
                 .domain()
                 .map(|d| format!(" ({})", d))
                 .unwrap_or_default();
 
             let num = format!("{:>3}. ", i + 1);
-            let max_title_width = (inner.width as usize).saturating_sub(num.len() + domain.len() + 2);
+            let badge_text = badge.map(|b| format!("[{}] ", b.label()));
+            let badge_width = badge_text.as_ref().map_or(0, |t| t.len());
+            let max_title_width = (inner.width as usize).saturating_sub(num.len() + badge_width + domain.len() + 2);
             let truncated_title: String = if title.chars().count() > max_title_width {
                 let truncated: String = title.chars().take(max_title_width.saturating_sub(3)).collect();
                 format!("{}...", truncated)
@@ -91,7 +94,7 @@ impl<'a> Widget for StoryList<'a> {
                 buf[(x, y)].set_style(style);
             }
 
-            let line = Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     num,
                     if is_selected {
@@ -100,9 +103,14 @@ impl<'a> Widget for StoryList<'a> {
                         theme::dim_style()
                     },
                 ),
-                Span::styled(truncated_title, style),
-                Span::styled(domain, theme::dim_style().bg(if is_selected { theme::SURFACE } else { theme::BG })),
-            ]);
+            ];
+            if let Some((text, b)) = badge_text.zip(badge) {
+                spans.push(Span::styled(text, theme::badge_style(b)));
+            }
+            spans.push(Span::styled(truncated_title, style));
+            spans.push(Span::styled(domain, theme::dim_style().bg(if is_selected { theme::SURFACE } else { theme::BG })));
+
+            let line = Line::from(spans);
             buf.set_line(inner.left(), y, &line, inner.width);
 
             // Meta line (if space allows: every other row)

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -66,3 +66,19 @@ pub fn inactive_tab_style() -> Style {
 pub fn depth_color(depth: usize) -> Color {
     DEPTH_COLORS[depth % DEPTH_COLORS.len()]
 }
+
+pub fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
+    use crate::api::types::StoryBadge;
+    let color = match badge {
+        StoryBadge::Ask => BLUE,
+        StoryBadge::Show => GREEN,
+        StoryBadge::Tell => MAUVE,
+        StoryBadge::Launch => PEACH,
+        StoryBadge::Job => YELLOW,
+        StoryBadge::Poll => TEAL,
+    };
+    Style::default()
+        .fg(color)
+        .bg(SURFACE)
+        .add_modifier(Modifier::BOLD)
+}


### PR DESCRIPTION
## Summary

- Detect story type from title prefix (`Ask HN:`, `Show HN:`, etc.) or `item_type` field and render a colored badge before the title
- Strip redundant prefix from displayed title text
- Apply badge styling in both story list and comment panel header

Closes #10

## Test plan

- [x] Switch to Ask feed (key `4`) — all stories show `[Ask HN]` badge in blue
- [x] Switch to Show feed (key `5`) — stories show `[Show HN]` badge in green
- [x] Switch to Jobs feed (key `6`) — stories show `[Job]` badge in yellow
- [x] Top feed (key `1`) — mixed badges, most stories have none
- [x] Verify title doesn't repeat the prefix after the badge
- [x] Verify long titles truncate correctly with badge present