### PR TITLE
Fix command injection via open::that() and UTF-8 panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -242,7 +242,11 @@ impl App {
                 Action::OpenInBrowser => {
                     if let Some(ref reader) = self.reader_state {
                         if let Some(ref url) = reader.url {
-                            let _ = open::that(url);
+                            if let Ok(parsed) = url::Url::parse(url) {
+                                if parsed.scheme() == "http" || parsed.scheme() == "https" {
+                                    let _ = open::that(parsed.as_str());
+                                }
+                            }
                         }
                     }
                     return;
@@ -575,7 +579,11 @@ impl App {
         });
 
         if let Some(url) = url {
-            let _ = open::that(url);
+            if let Ok(parsed) = url::Url::parse(&url) {
+                if parsed.scheme() == "http" || parsed.scheme() == "https" {
+                    let _ = open::that(parsed.as_str());
+                }
+            }
         }
     }
 
@@ -861,17 +869,25 @@ fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>
             ]);
         } else {
             // Word-wrap long lines
-            if raw_line.len() > width && width > 0 {
+            if raw_line.chars().count() > width && width > 0 {
                 let mut remaining = raw_line;
                 while !remaining.is_empty() {
-                    let split_at = if remaining.len() <= width {
-                        remaining.len()
-                    } else {
-                        remaining[..width]
-                            .rfind(' ')
-                            .map(|p| p + 1)
-                            .unwrap_or(width)
-                    };
+                    if remaining.chars().count() <= width {
+                        lines.push(vec![StyledFragment {
+                            text: remaining.to_string(),
+                            style: Style::default().fg(theme::TEXT),
+                        }]);
+                        break;
+                    }
+                    let byte_pos = remaining
+                        .char_indices()
+                        .nth(width)
+                        .map(|(i, _)| i)
+                        .unwrap_or(remaining.len());
+                    let split_at = remaining[..byte_pos]
+                        .rfind(' ')
+                        .map(|p| p + 1)
+                        .unwrap_or(byte_pos);
                     lines.push(vec![StyledFragment {
                         text: remaining[..split_at].to_string(),
                         style: Style::default().fg(theme::TEXT),

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -37,8 +37,9 @@ pub fn render_article_overlay(frame: &mut Frame, area: Rect, reader: &ReaderStat
 }
 
 fn build_title(reader: &ReaderState) -> String {
-    let title = if reader.title.len() > 60 {
-        format!("{}...", &reader.title[..57])
+    let title = if reader.title.chars().count() > 60 {
+        let truncated: String = reader.title.chars().take(57).collect();
+        format!("{}...", truncated)
     } else {
         reader.title.clone()
     };


### PR DESCRIPTION
## Summary
- Validate URL scheme is `http`/`https` before passing to `open::that()` to prevent shell injection from attacker-controlled HN story URLs (both main browser action and reader overlay)
- Use char-aware truncation in `build_title` to avoid panic on multi-byte UTF-8 titles
- Use `char_indices()` for word-wrap split positions in `markdown_to_styled_lines` to avoid panic on non-ASCII content
- Bump version to 0.3.3

Closes #27

## Test plan
- [ ] Open a story with a non-ASCII title (e.g. CJK, emoji) in the article reader — should truncate cleanly without panic
- [ ] Read an article with long non-ASCII lines — word-wrap should work without panic
- [ ] Verify `open::that()` only fires for http/https URLs