### PR TITLE
Infrastructure hardening and community health files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM rust:slim AS builder
+FROM rust:1.94-slim AS builder
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
@@ -16,7 +16,7 @@ COPY src/ src/
 RUN cargo build --release
 
 # Stage 2: Runtime
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Pin `rust:slim` to `rust:1.94-slim` for reproducible Docker builds
- Update `debian:bookworm-slim` to `debian:trixie-slim` (Debian 13, current stable)
- Add `docker` ecosystem to Dependabot config
- Add Dependabot PR grouping and labels to reduce noise
- Pin third-party GitHub Actions (`dtolnay/rust-toolchain`, `softprops/action-gh-release`) to commit SHAs
- Add issue templates (bug report + feature request)
- Add pull request template
- Add Code of Conduct (Contributor Covenant v2.1)
- Add Contributing and Issues links to README
- Bump version to 0.3.4

Closes #29

## Test plan
- [ ] `docker compose build` succeeds with new base images
- [ ] `docker compose run --rm -it dev cargo run` starts correctly
- [ ] CI workflows pass with SHA-pinned actions
- [ ] Issue templates render correctly on GitHub (check /issues/new/choose)
- [ ] Dependabot picks up Docker ecosystem and grouping config after merge