### PR TITLE
Add unit test suite for core logic modules

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -163,3 +163,53 @@ fn url_encode(s: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_space() {
+        assert_eq!(url_encode("hello world"), "hello+world");
+    }
+
+    #[test]
+    fn url_encode_unreserved() {
+        assert_eq!(url_encode("rust-lang_0.9~"), "rust-lang_0.9~");
+    }
+
+    #[test]
+    fn url_encode_special_chars() {
+        assert_eq!(url_encode("foo@bar.com"), "foo%40bar.com");
+    }
+
+    #[test]
+    fn url_encode_empty() {
+        assert_eq!(url_encode(""), "");
+    }
+
+    #[test]
+    fn url_encode_alphanumeric() {
+        assert_eq!(url_encode("ABCxyz012"), "ABCxyz012");
+    }
+
+    #[test]
+    fn url_encode_percent_sign() {
+        assert_eq!(url_encode("100%"), "100%25");
+    }
+
+    #[test]
+    fn url_encode_ampersand_and_equals() {
+        assert_eq!(url_encode("q=a&b=c"), "q%3Da%26b%3Dc");
+    }
+
+    #[test]
+    fn url_encode_multiple_spaces() {
+        assert_eq!(url_encode("a b c"), "a+b+c");
+    }
+
+    #[test]
+    fn url_encode_slash() {
+        assert_eq!(url_encode("path/to"), "path%2Fto");
+    }
+}

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -199,3 +199,299 @@ impl fmt::Display for FeedKind {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item() -> Item {
+        Item {
+            id: 1,
+            title: None,
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    // --- url_domain ---
+
+    #[test]
+    fn url_domain_https() {
+        assert_eq!(url_domain("https://example.com/path"), Some("example.com".into()));
+    }
+
+    #[test]
+    fn url_domain_http() {
+        assert_eq!(url_domain("http://example.com/path"), Some("example.com".into()));
+    }
+
+    #[test]
+    fn url_domain_strips_www() {
+        assert_eq!(url_domain("https://www.example.com/path"), Some("example.com".into()));
+    }
+
+    #[test]
+    fn url_domain_no_scheme() {
+        assert_eq!(url_domain("ftp://example.com"), None);
+    }
+
+    #[test]
+    fn url_domain_empty_string() {
+        assert_eq!(url_domain(""), None);
+    }
+
+    #[test]
+    fn url_domain_no_trailing_path() {
+        assert_eq!(url_domain("https://example.com"), Some("example.com".into()));
+    }
+
+    // --- is_dead_or_deleted ---
+
+    #[test]
+    fn is_dead_or_deleted_neither() {
+        let item = make_item();
+        assert!(!item.is_dead_or_deleted());
+    }
+
+    #[test]
+    fn is_dead_or_deleted_dead() {
+        let mut item = make_item();
+        item.dead = Some(true);
+        assert!(item.is_dead_or_deleted());
+    }
+
+    #[test]
+    fn is_dead_or_deleted_deleted() {
+        let mut item = make_item();
+        item.deleted = Some(true);
+        assert!(item.is_dead_or_deleted());
+    }
+
+    #[test]
+    fn is_dead_or_deleted_both_true() {
+        let mut item = make_item();
+        item.dead = Some(true);
+        item.deleted = Some(true);
+        assert!(item.is_dead_or_deleted());
+    }
+
+    #[test]
+    fn is_dead_or_deleted_both_false() {
+        let mut item = make_item();
+        item.dead = Some(false);
+        item.deleted = Some(false);
+        assert!(!item.is_dead_or_deleted());
+    }
+
+    // --- domain ---
+
+    #[test]
+    fn domain_some_url() {
+        let mut item = make_item();
+        item.url = Some("https://example.com/page".into());
+        assert_eq!(item.domain(), Some("example.com".into()));
+    }
+
+    #[test]
+    fn domain_none_url() {
+        let item = make_item();
+        assert_eq!(item.domain(), None);
+    }
+
+    // --- badge ---
+
+    #[test]
+    fn badge_job() {
+        let mut item = make_item();
+        item.item_type = Some("job".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Job));
+    }
+
+    #[test]
+    fn badge_poll() {
+        let mut item = make_item();
+        item.item_type = Some("poll".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Poll));
+    }
+
+    #[test]
+    fn badge_ask_hn() {
+        let mut item = make_item();
+        item.title = Some("Ask HN: What is Rust?".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Ask));
+    }
+
+    #[test]
+    fn badge_show_hn() {
+        let mut item = make_item();
+        item.title = Some("Show HN: My project".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Show));
+    }
+
+    #[test]
+    fn badge_tell_hn() {
+        let mut item = make_item();
+        item.title = Some("Tell HN: Something".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Tell));
+    }
+
+    #[test]
+    fn badge_launch_hn() {
+        let mut item = make_item();
+        item.title = Some("Launch HN: New product".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Launch));
+    }
+
+    #[test]
+    fn badge_no_badge() {
+        let mut item = make_item();
+        item.title = Some("Regular title".into());
+        assert_eq!(item.badge(), None);
+    }
+
+    #[test]
+    fn badge_no_title() {
+        let item = make_item();
+        assert_eq!(item.badge(), None);
+    }
+
+    #[test]
+    fn badge_job_takes_priority_over_title() {
+        let mut item = make_item();
+        item.item_type = Some("job".into());
+        item.title = Some("Ask HN: Something".into());
+        assert_eq!(item.badge(), Some(StoryBadge::Job));
+    }
+
+    // --- display_title ---
+
+    #[test]
+    fn display_title_strips_ask_hn() {
+        let mut item = make_item();
+        item.title = Some("Ask HN: What is Rust?".into());
+        assert_eq!(item.display_title(), "What is Rust?");
+    }
+
+    #[test]
+    fn display_title_strips_show_hn() {
+        let mut item = make_item();
+        item.title = Some("Show HN: My project".into());
+        assert_eq!(item.display_title(), "My project");
+    }
+
+    #[test]
+    fn display_title_no_prefix() {
+        let mut item = make_item();
+        item.title = Some("Regular title".into());
+        assert_eq!(item.display_title(), "Regular title");
+    }
+
+    #[test]
+    fn display_title_none() {
+        let item = make_item();
+        assert_eq!(item.display_title(), "[no title]");
+    }
+
+    #[test]
+    fn display_title_strips_tell_hn() {
+        let mut item = make_item();
+        item.title = Some("Tell HN: Something".into());
+        assert_eq!(item.display_title(), "Something");
+    }
+
+    #[test]
+    fn display_title_strips_launch_hn() {
+        let mut item = make_item();
+        item.title = Some("Launch HN: New product".into());
+        assert_eq!(item.display_title(), "New product");
+    }
+
+    #[test]
+    fn display_title_case_sensitive() {
+        let mut item = make_item();
+        item.title = Some("ask hn: lowercase".into());
+        assert_eq!(item.display_title(), "ask hn: lowercase");
+    }
+
+    // --- StoryBadge::label ---
+
+    #[test]
+    fn badge_labels() {
+        assert_eq!(StoryBadge::Ask.label(), "Ask HN");
+        assert_eq!(StoryBadge::Show.label(), "Show HN");
+        assert_eq!(StoryBadge::Tell.label(), "Tell HN");
+        assert_eq!(StoryBadge::Launch.label(), "Launch HN");
+        assert_eq!(StoryBadge::Job.label(), "Job");
+        assert_eq!(StoryBadge::Poll.label(), "Poll");
+    }
+
+    // --- FeedKind ---
+
+    #[test]
+    fn feed_kind_endpoints() {
+        assert_eq!(FeedKind::Top.endpoint(), "topstories");
+        assert_eq!(FeedKind::New.endpoint(), "newstories");
+        assert_eq!(FeedKind::Best.endpoint(), "beststories");
+        assert_eq!(FeedKind::Ask.endpoint(), "askstories");
+        assert_eq!(FeedKind::Show.endpoint(), "showstories");
+        assert_eq!(FeedKind::Jobs.endpoint(), "jobstories");
+    }
+
+    #[test]
+    fn feed_kind_display() {
+        assert_eq!(format!("{}", FeedKind::Top), "Top");
+        assert_eq!(format!("{}", FeedKind::New), "New");
+        assert_eq!(format!("{}", FeedKind::Best), "Best");
+        assert_eq!(format!("{}", FeedKind::Ask), "Ask");
+        assert_eq!(format!("{}", FeedKind::Show), "Show");
+        assert_eq!(format!("{}", FeedKind::Jobs), "Jobs");
+    }
+
+    // --- From<SearchHit> for Item ---
+
+    #[test]
+    fn search_hit_to_item() {
+        let hit = SearchHit {
+            object_id: "12345".into(),
+            title: Some("Test".into()),
+            url: Some("https://example.com".into()),
+            author: Some("user".into()),
+            points: Some(42),
+            num_comments: Some(10),
+            created_at_i: Some(1000),
+            story_text: Some("body".into()),
+        };
+        let item = Item::from(hit);
+        assert_eq!(item.id, 12345);
+        assert_eq!(item.title.as_deref(), Some("Test"));
+        assert_eq!(item.by.as_deref(), Some("user"));
+        assert_eq!(item.score, Some(42));
+        assert_eq!(item.descendants, Some(10));
+        assert_eq!(item.text.as_deref(), Some("body"));
+        assert_eq!(item.item_type.as_deref(), Some("story"));
+    }
+
+    #[test]
+    fn search_hit_invalid_object_id() {
+        let hit = SearchHit {
+            object_id: "not_a_number".into(),
+            title: None,
+            url: None,
+            author: None,
+            points: None,
+            num_comments: None,
+            created_at_i: None,
+            story_text: None,
+        };
+        let item = Item::from(hit);
+        assert_eq!(item.id, 0);
+    }
+}

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -225,17 +225,26 @@ mod tests {
 
     #[test]
     fn url_domain_https() {
-        assert_eq!(url_domain("https://example.com/path"), Some("example.com".into()));
+        assert_eq!(
+            url_domain("https://example.com/path"),
+            Some("example.com".into())
+        );
     }
 
     #[test]
     fn url_domain_http() {
-        assert_eq!(url_domain("http://example.com/path"), Some("example.com".into()));
+        assert_eq!(
+            url_domain("http://example.com/path"),
+            Some("example.com".into())
+        );
     }
 
     #[test]
     fn url_domain_strips_www() {
-        assert_eq!(url_domain("https://www.example.com/path"), Some("example.com".into()));
+        assert_eq!(
+            url_domain("https://www.example.com/path"),
+            Some("example.com".into())
+        );
     }
 
     #[test]
@@ -250,7 +259,10 @@ mod tests {
 
     #[test]
     fn url_domain_no_trailing_path() {
-        assert_eq!(url_domain("https://example.com"), Some("example.com".into()));
+        assert_eq!(
+            url_domain("https://example.com"),
+            Some("example.com".into())
+        );
     }
 
     // --- is_dead_or_deleted ---

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -83,3 +83,117 @@ pub fn map_key(
         _ => Action::None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    // --- Priority chain ---
+
+    #[test]
+    fn search_input_always_returns_none() {
+        assert_eq!(map_key(key(KeyCode::Char('q')), false, false, InputMode::SearchInput), Action::None);
+        assert_eq!(map_key(key(KeyCode::Char('q')), true, true, InputMode::SearchInput), Action::None);
+    }
+
+    #[test]
+    fn help_visible_closes_on_any_key() {
+        assert_eq!(map_key(key(KeyCode::Char('q')), true, false, InputMode::Normal), Action::ToggleHelp);
+        assert_eq!(map_key(key(KeyCode::Enter), true, false, InputMode::Normal), Action::ToggleHelp);
+    }
+
+    #[test]
+    fn help_takes_priority_over_reader() {
+        assert_eq!(map_key(key(KeyCode::Char('j')), true, true, InputMode::Normal), Action::ToggleHelp);
+    }
+
+    // --- Reader mode ---
+
+    #[test]
+    fn reader_navigation() {
+        let r = |code| map_key(key(code), false, true, InputMode::Normal);
+        assert_eq!(r(KeyCode::Char('j')), Action::MoveDown);
+        assert_eq!(r(KeyCode::Down), Action::MoveDown);
+        assert_eq!(r(KeyCode::Char('k')), Action::MoveUp);
+        assert_eq!(r(KeyCode::Up), Action::MoveUp);
+        assert_eq!(r(KeyCode::Char('g')), Action::JumpTop);
+        assert_eq!(r(KeyCode::Char('G')), Action::JumpBottom);
+        assert_eq!(r(KeyCode::Char('o')), Action::OpenInBrowser);
+        assert_eq!(r(KeyCode::Esc), Action::Back);
+        assert_eq!(r(KeyCode::Char('q')), Action::Back);
+    }
+
+    #[test]
+    fn reader_ctrl_keys() {
+        assert_eq!(map_key(ctrl('d'), false, true, InputMode::Normal), Action::PageDown);
+        assert_eq!(map_key(ctrl('u'), false, true, InputMode::Normal), Action::PageUp);
+    }
+
+    #[test]
+    fn reader_unmapped_returns_none() {
+        assert_eq!(map_key(key(KeyCode::Char('p')), false, true, InputMode::Normal), Action::None);
+        assert_eq!(map_key(key(KeyCode::Enter), false, true, InputMode::Normal), Action::None);
+    }
+
+    // --- Normal mode ---
+
+    #[test]
+    fn normal_quit_and_back() {
+        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char('q')), Action::Quit);
+        assert_eq!(n(KeyCode::Esc), Action::Back);
+    }
+
+    #[test]
+    fn normal_navigation() {
+        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char('j')), Action::MoveDown);
+        assert_eq!(n(KeyCode::Down), Action::MoveDown);
+        assert_eq!(n(KeyCode::Char('k')), Action::MoveUp);
+        assert_eq!(n(KeyCode::Up), Action::MoveUp);
+        assert_eq!(n(KeyCode::Enter), Action::Select);
+        assert_eq!(n(KeyCode::Char('g')), Action::JumpTop);
+        assert_eq!(n(KeyCode::Char('G')), Action::JumpBottom);
+    }
+
+    #[test]
+    fn normal_ctrl_keys() {
+        assert_eq!(map_key(ctrl('d'), false, false, InputMode::Normal), Action::PageDown);
+        assert_eq!(map_key(ctrl('u'), false, false, InputMode::Normal), Action::PageUp);
+    }
+
+    #[test]
+    fn normal_feed_switching() {
+        let n = |c: char| map_key(key(KeyCode::Char(c)), false, false, InputMode::Normal);
+        for (c, idx) in [('1', 0), ('2', 1), ('3', 2), ('4', 3), ('5', 4), ('6', 5)] {
+            assert_eq!(n(c), Action::SwitchFeed(idx));
+        }
+    }
+
+    #[test]
+    fn normal_actions() {
+        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char('o')), Action::OpenInBrowser);
+        assert_eq!(n(KeyCode::Char('p')), Action::OpenReader);
+        assert_eq!(n(KeyCode::Tab), Action::SwitchPane);
+        assert_eq!(n(KeyCode::BackTab), Action::SwitchPane);
+        assert_eq!(n(KeyCode::Left), Action::SwitchPane);
+        assert_eq!(n(KeyCode::Right), Action::SwitchPane);
+        assert_eq!(n(KeyCode::Char('r')), Action::Refresh);
+        assert_eq!(n(KeyCode::Char('/')), Action::EnterSearch);
+        assert_eq!(n(KeyCode::Char('?')), Action::ToggleHelp);
+    }
+
+    #[test]
+    fn normal_unmapped_returns_none() {
+        assert_eq!(map_key(key(KeyCode::Char('z')), false, false, InputMode::Normal), Action::None);
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -100,19 +100,39 @@ mod tests {
 
     #[test]
     fn search_input_always_returns_none() {
-        assert_eq!(map_key(key(KeyCode::Char('q')), false, false, InputMode::SearchInput), Action::None);
-        assert_eq!(map_key(key(KeyCode::Char('q')), true, true, InputMode::SearchInput), Action::None);
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('q')),
+                false,
+                false,
+                InputMode::SearchInput
+            ),
+            Action::None
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Char('q')), true, true, InputMode::SearchInput),
+            Action::None
+        );
     }
 
     #[test]
     fn help_visible_closes_on_any_key() {
-        assert_eq!(map_key(key(KeyCode::Char('q')), true, false, InputMode::Normal), Action::ToggleHelp);
-        assert_eq!(map_key(key(KeyCode::Enter), true, false, InputMode::Normal), Action::ToggleHelp);
+        assert_eq!(
+            map_key(key(KeyCode::Char('q')), true, false, InputMode::Normal),
+            Action::ToggleHelp
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Enter), true, false, InputMode::Normal),
+            Action::ToggleHelp
+        );
     }
 
     #[test]
     fn help_takes_priority_over_reader() {
-        assert_eq!(map_key(key(KeyCode::Char('j')), true, true, InputMode::Normal), Action::ToggleHelp);
+        assert_eq!(
+            map_key(key(KeyCode::Char('j')), true, true, InputMode::Normal),
+            Action::ToggleHelp
+        );
     }
 
     // --- Reader mode ---
@@ -133,14 +153,26 @@ mod tests {
 
     #[test]
     fn reader_ctrl_keys() {
-        assert_eq!(map_key(ctrl('d'), false, true, InputMode::Normal), Action::PageDown);
-        assert_eq!(map_key(ctrl('u'), false, true, InputMode::Normal), Action::PageUp);
+        assert_eq!(
+            map_key(ctrl('d'), false, true, InputMode::Normal),
+            Action::PageDown
+        );
+        assert_eq!(
+            map_key(ctrl('u'), false, true, InputMode::Normal),
+            Action::PageUp
+        );
     }
 
     #[test]
     fn reader_unmapped_returns_none() {
-        assert_eq!(map_key(key(KeyCode::Char('p')), false, true, InputMode::Normal), Action::None);
-        assert_eq!(map_key(key(KeyCode::Enter), false, true, InputMode::Normal), Action::None);
+        assert_eq!(
+            map_key(key(KeyCode::Char('p')), false, true, InputMode::Normal),
+            Action::None
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Enter), false, true, InputMode::Normal),
+            Action::None
+        );
     }
 
     // --- Normal mode ---
@@ -166,8 +198,14 @@ mod tests {
 
     #[test]
     fn normal_ctrl_keys() {
-        assert_eq!(map_key(ctrl('d'), false, false, InputMode::Normal), Action::PageDown);
-        assert_eq!(map_key(ctrl('u'), false, false, InputMode::Normal), Action::PageUp);
+        assert_eq!(
+            map_key(ctrl('d'), false, false, InputMode::Normal),
+            Action::PageDown
+        );
+        assert_eq!(
+            map_key(ctrl('u'), false, false, InputMode::Normal),
+            Action::PageUp
+        );
     }
 
     #[test]
@@ -194,6 +232,9 @@ mod tests {
 
     #[test]
     fn normal_unmapped_returns_none() {
-        assert_eq!(map_key(key(KeyCode::Char('z')), false, false, InputMode::Normal), Action::None);
+        assert_eq!(
+            map_key(key(KeyCode::Char('z')), false, false, InputMode::Normal),
+            Action::None
+        );
     }
 }

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -139,3 +139,288 @@ impl CommentTreeState {
         self.row_map.borrow_mut().clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(id: u64) -> Item {
+        Item {
+            id,
+            title: None,
+            url: None,
+            text: Some(format!("Comment {}", id)),
+            by: Some("user".into()),
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: Some("comment".into()),
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    /// Build a simple tree: root(1) -> child(2, depth 1) -> grandchild(3, depth 2), sibling(4, depth 0)
+    fn sample_tree() -> Vec<(Item, usize)> {
+        vec![
+            (make_item(1), 0),
+            (make_item(2), 1),
+            (make_item(3), 2),
+            (make_item(4), 0),
+        ]
+    }
+
+    #[test]
+    fn set_comments_populates() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        assert_eq!(state.comments.len(), 4);
+        assert_eq!(state.comments[0].depth, 0);
+        assert_eq!(state.comments[1].depth, 1);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn set_comments_resets_scroll() {
+        let mut state = CommentTreeState::new();
+        state.scroll.set(10);
+        state.selected = 5;
+        state.set_comments(sample_tree());
+        assert_eq!(state.scroll.get(), 0);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn insert_children_after_parent() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![(make_item(1), 0), (make_item(4), 0)]);
+        state.insert_children(1, vec![(make_item(2), 1), (make_item(3), 1)]);
+        assert_eq!(state.comments.len(), 4);
+        assert_eq!(state.comments[1].item.id, 2);
+        assert_eq!(state.comments[2].item.id, 3);
+        assert_eq!(state.comments[3].item.id, 4);
+    }
+
+    #[test]
+    fn insert_children_missing_parent_noop() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![(make_item(1), 0)]);
+        state.insert_children(999, vec![(make_item(2), 1)]);
+        assert_eq!(state.comments.len(), 1);
+    }
+
+    #[test]
+    fn visible_comments_no_collapse() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        assert_eq!(state.visible_comments().len(), 4);
+    }
+
+    #[test]
+    fn visible_comments_collapse_root_hides_children() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1); // collapse root comment
+        let visible = state.visible_comments();
+        let ids: Vec<u64> = visible.iter().map(|c| c.item.id).collect();
+        // Root 1 visible (but collapsed), children 2,3 hidden, sibling 4 visible
+        assert_eq!(ids, vec![1, 4]);
+    }
+
+    #[test]
+    fn visible_comments_collapse_mid_level() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(2); // collapse child at depth 1
+        let visible = state.visible_comments();
+        let ids: Vec<u64> = visible.iter().map(|c| c.item.id).collect();
+        // 1 visible, 2 visible (collapsed), 3 hidden (child of 2), 4 visible
+        assert_eq!(ids, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn visible_comments_empty() {
+        let state = CommentTreeState::new();
+        assert!(state.visible_comments().is_empty());
+    }
+
+    #[test]
+    fn select_next_increments() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.select_next();
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn select_next_clamps_at_end() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 3;
+        state.select_next();
+        assert_eq!(state.selected, 3);
+    }
+
+    #[test]
+    fn select_next_empty() {
+        let mut state = CommentTreeState::new();
+        state.select_next();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn select_prev_decrements() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 2;
+        state.select_prev();
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn select_prev_clamps_at_zero() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.select_prev();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn jump_top_resets() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 3;
+        state.scroll.set(5);
+        state.jump_top();
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.scroll.get(), 0);
+    }
+
+    #[test]
+    fn jump_bottom_selects_last() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.jump_bottom();
+        assert_eq!(state.selected, 3);
+    }
+
+    #[test]
+    fn page_down_moves_by_page() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.page_down(2);
+        assert_eq!(state.selected, 2);
+    }
+
+    #[test]
+    fn page_up_moves_by_page() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 3;
+        state.page_up(2);
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn select_next_clamps_at_visible_end_when_collapsed() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1); // visible: [1, 4]
+        state.select_next();
+        assert_eq!(state.selected, 1);
+        state.select_next();
+        assert_eq!(state.selected, 1); // clamped at visible len - 1
+    }
+
+    #[test]
+    fn jump_bottom_respects_collapse() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1); // visible: [1, 4]
+        state.jump_bottom();
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn jump_bottom_empty() {
+        let mut state = CommentTreeState::new();
+        state.jump_bottom();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn page_down_clamps_at_end() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 2;
+        state.page_down(5);
+        assert_eq!(state.selected, 3);
+    }
+
+    #[test]
+    fn page_down_empty() {
+        let mut state = CommentTreeState::new();
+        state.page_down(5);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn page_up_clamps_at_zero() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.selected = 1;
+        state.page_up(5);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn page_down_respects_collapse() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1); // visible: [1, 4]
+        state.page_down(5);
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn toggle_collapse_adds_to_set() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.toggle_collapse();
+        assert!(state.collapsed.contains(&1));
+    }
+
+    #[test]
+    fn toggle_collapse_removes_from_set() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1);
+        state.toggle_collapse();
+        assert!(!state.collapsed.contains(&1));
+    }
+
+    #[test]
+    fn toggle_collapse_empty_noop() {
+        let mut state = CommentTreeState::new();
+        state.toggle_collapse(); // should not panic
+        assert!(state.collapsed.is_empty());
+    }
+
+    #[test]
+    fn reset_clears_all() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        state.collapsed.insert(1);
+        state.selected = 2;
+        state.loading = true;
+        state.story = Some(make_item(99));
+        state.reset();
+        assert!(state.comments.is_empty());
+        assert_eq!(state.scroll.get(), 0);
+        assert_eq!(state.selected, 0);
+        assert!(state.collapsed.is_empty());
+        assert!(!state.loading);
+        assert!(state.story.is_none());
+    }
+}

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -78,3 +78,129 @@ impl ReaderState {
         self.lines.len().saturating_sub(1)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_lines(n: usize) -> Vec<Vec<StyledFragment>> {
+        (0..n)
+            .map(|i| {
+                vec![StyledFragment {
+                    text: format!("line {}", i),
+                    style: Style::default(),
+                }]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn new_loading_state() {
+        let r = ReaderState::new_loading("Title".into(), Some("example.com".into()), None);
+        assert_eq!(r.title, "Title");
+        assert_eq!(r.domain.as_deref(), Some("example.com"));
+        assert!(r.loading);
+        assert!(r.lines.is_empty());
+        assert_eq!(r.scroll, 0);
+        assert!(r.error.is_none());
+    }
+
+    #[test]
+    fn set_content_clears_loading() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.error = Some("old error".into());
+        r.scroll = 5;
+        r.set_content(make_lines(10));
+        assert_eq!(r.lines.len(), 10);
+        assert!(!r.loading);
+        assert!(r.error.is_none());
+        assert_eq!(r.scroll, 0);
+    }
+
+    #[test]
+    fn set_error_clears_loading() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_error("fail".into());
+        assert_eq!(r.error.as_deref(), Some("fail"));
+        assert!(!r.loading);
+    }
+
+    #[test]
+    fn scroll_down_increments() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(20));
+        r.scroll_down(5);
+        assert_eq!(r.scroll, 5);
+    }
+
+    #[test]
+    fn scroll_down_clamps_at_max() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(10));
+        r.scroll_down(100);
+        assert_eq!(r.scroll, 9); // max_scroll = 10 - 1
+    }
+
+    #[test]
+    fn scroll_down_empty_lines() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.scroll_down(5);
+        assert_eq!(r.scroll, 0);
+    }
+
+    #[test]
+    fn scroll_up_decrements() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(20));
+        r.scroll = 10;
+        r.scroll_up(3);
+        assert_eq!(r.scroll, 7);
+    }
+
+    #[test]
+    fn scroll_up_clamps_at_zero() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(20));
+        r.scroll = 2;
+        r.scroll_up(5);
+        assert_eq!(r.scroll, 0);
+    }
+
+    #[test]
+    fn jump_top_and_bottom() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(20));
+        r.jump_bottom();
+        assert_eq!(r.scroll, 19);
+        r.jump_top();
+        assert_eq!(r.scroll, 0);
+    }
+
+    #[test]
+    fn scroll_percent_at_top() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(100));
+        assert_eq!(r.scroll_percent(), 0);
+    }
+
+    #[test]
+    fn scroll_percent_at_bottom() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(100));
+        r.jump_bottom();
+        assert_eq!(r.scroll_percent(), 100);
+    }
+
+    #[test]
+    fn scroll_percent_empty_returns_100() {
+        let r = ReaderState::new_loading("T".into(), None, None);
+        assert_eq!(r.scroll_percent(), 100);
+    }
+
+    #[test]
+    fn scroll_percent_single_line() {
+        let mut r = ReaderState::new_loading("T".into(), None, None);
+        r.set_content(make_lines(1));
+        assert_eq!(r.scroll_percent(), 100); // max_scroll is 0
+    }
+}

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -70,3 +70,204 @@ impl StoryListState {
         self.loading = false;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(id: u64) -> Item {
+        Item {
+            id,
+            title: Some(format!("Story {}", id)),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    fn state_with_stories(n: usize) -> StoryListState {
+        let mut s = StoryListState::new();
+        for i in 0..n {
+            s.stories.push(make_item(i as u64));
+        }
+        s
+    }
+
+    #[test]
+    fn new_defaults() {
+        let s = StoryListState::new();
+        assert!(s.stories.is_empty());
+        assert!(s.all_ids.is_empty());
+        assert_eq!(s.selected, 0);
+        assert_eq!(s.offset, 0);
+        assert!(!s.loading);
+    }
+
+    #[test]
+    fn select_next_increments() {
+        let mut s = state_with_stories(5);
+        s.select_next();
+        assert_eq!(s.selected, 1);
+    }
+
+    #[test]
+    fn select_next_clamps_at_end() {
+        let mut s = state_with_stories(3);
+        s.selected = 2;
+        s.select_next();
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn select_next_empty_noop() {
+        let mut s = StoryListState::new();
+        s.select_next();
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn select_prev_decrements() {
+        let mut s = state_with_stories(5);
+        s.selected = 3;
+        s.select_prev();
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn select_prev_clamps_at_zero() {
+        let mut s = state_with_stories(5);
+        s.select_prev();
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn jump_top() {
+        let mut s = state_with_stories(10);
+        s.selected = 7;
+        s.jump_top();
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn jump_bottom() {
+        let mut s = state_with_stories(10);
+        s.jump_bottom();
+        assert_eq!(s.selected, 9);
+    }
+
+    #[test]
+    fn jump_bottom_empty() {
+        let mut s = StoryListState::new();
+        s.jump_bottom();
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn page_down() {
+        let mut s = state_with_stories(20);
+        s.page_down(5);
+        assert_eq!(s.selected, 5);
+    }
+
+    #[test]
+    fn page_down_clamps() {
+        let mut s = state_with_stories(10);
+        s.selected = 7;
+        s.page_down(5);
+        assert_eq!(s.selected, 9);
+    }
+
+    #[test]
+    fn page_down_empty() {
+        let mut s = StoryListState::new();
+        s.page_down(5);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn page_up() {
+        let mut s = state_with_stories(20);
+        s.selected = 10;
+        s.page_up(5);
+        assert_eq!(s.selected, 5);
+    }
+
+    #[test]
+    fn page_up_clamps_at_zero() {
+        let mut s = state_with_stories(10);
+        s.selected = 2;
+        s.page_up(5);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn page_up_empty() {
+        let mut s = StoryListState::new();
+        s.page_up(5);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn selected_story_returns_item() {
+        let s = state_with_stories(3);
+        assert_eq!(s.selected_story().unwrap().id, 0);
+    }
+
+    #[test]
+    fn selected_story_empty() {
+        let s = StoryListState::new();
+        assert!(s.selected_story().is_none());
+    }
+
+    #[test]
+    fn needs_more_below_threshold() {
+        let mut s = state_with_stories(10);
+        s.all_ids = (0..50).collect();
+        s.selected = 2;
+        assert!(!s.needs_more());
+    }
+
+    #[test]
+    fn needs_more_at_threshold() {
+        let mut s = state_with_stories(10);
+        s.all_ids = (0..50).collect();
+        s.selected = 8; // 80% of 10
+        assert!(s.needs_more());
+    }
+
+    #[test]
+    fn needs_more_all_loaded() {
+        let mut s = state_with_stories(10);
+        s.all_ids = (0..10).collect();
+        s.selected = 9;
+        assert!(!s.needs_more());
+    }
+
+    #[test]
+    fn needs_more_empty() {
+        let s = StoryListState::new();
+        assert!(!s.needs_more());
+    }
+
+    #[test]
+    fn reset_clears_all() {
+        let mut s = state_with_stories(5);
+        s.all_ids = vec![1, 2, 3];
+        s.selected = 3;
+        s.offset = 10;
+        s.loading = true;
+        s.reset();
+        assert!(s.stories.is_empty());
+        assert!(s.all_ids.is_empty());
+        assert_eq!(s.selected, 0);
+        assert_eq!(s.offset, 0);
+        assert!(!s.loading);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 118 unit tests across 6 modules using inline `#[cfg(test)]` blocks
- Covers: `api/types` (31), `api/client` (9), `state/story_state` (20), `state/comment_state` (27), `state/reader_state` (14), `keys` (12)
- Tests navigation bounds, empty-list guards, collapse visibility, scroll clamping, key mapping priority chain, URL encoding, badge detection, and more
- No new dependencies — uses Rust's built-in test harness

Closes #32

## Test plan
- [x] `cargo test` passes locally (118 tests, 0 failures)
- [x] CI passes (`cargo fmt`, `cargo clippy`, `cargo test`)