### PR TITLE
Replace unmaintained `readability` crate with `readability-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -709,7 +709,7 @@ dependencies = [
  "html2text",
  "open",
  "ratatui",
- "readability",
+ "readability-rs",
  "reqwest",
  "serde",
  "serde_json",
@@ -1914,15 +1914,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "readability"
-version = "0.3.0"
+name = "readability-rs"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56596e20a6d3cf715182d9b6829220621e6e985cec04d00410cee29821b4220"
+checksum = "5a17841ca2fc1c3e2aed7c44b29121ab099176923c0ac55d9906edea8ab025bc"
 dependencies = [
  "html5ever 0.26.0",
  "lazy_static",
+ "log",
  "markup5ever_rcdom",
  "regex",
+ "thiserror 2.0.18",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ open = "5"
 chrono = "0.4"
 futures = "0.3"
 html2text = "0.16"
-readability = { version = "0.3.0", default-features = false }
+readability-rs = { version = "0.5.0", default-features = false }
 url = "2.5.8"

--- a/src/app.rs
+++ b/src/app.rs
@@ -992,9 +992,13 @@ fn extract_article_content(
     // Try readability extraction first, fall back to full HTML if it produces no content
     let tagged_lines = {
         let mut cursor = std::io::Cursor::new(html_bytes);
-        let readability_lines = match readability::extractor::extract(&mut cursor, &parsed_url) {
-            Ok(product) if !product.text.trim().is_empty() => {
-                html2text::from_read_rich(product.content.as_bytes(), width).unwrap_or_default()
+        let readability_lines = match readability::extract(
+            &mut cursor,
+            &parsed_url,
+            readability::ExtractOptions::default(),
+        ) {
+            Ok(readable) if !readable.text.trim().is_empty() => {
+                html2text::from_read_rich(readable.content.as_bytes(), width).unwrap_or_default()
             }
             _ => Vec::new(),
         };


### PR DESCRIPTION
## Summary

- Replace the unmaintained `readability` crate (kumabook/readability, no updates in ~2 years) with `readability-rs` v0.5.0 (quambene/readability-rs), an actively maintained fork
- Update the `extract()` call in `src/app.rs` to match the new API which requires an `ExtractOptions` parameter
- Eliminates duplicate `html5ever`/`markup5ever` dependency trees since `readability-rs` uses current versions

## Changes

- **Cargo.toml**: Swap `readability = "0.3.0"` for `readability-rs = "0.5.0"`
- **src/app.rs**: Update `readability::extractor::extract(&mut cursor, &parsed_url)` to `readability::extract(&mut cursor, &parsed_url, ExtractOptions::default())` and rename `product` to `readable` to match the new `Readable` return type

## Test plan

- [x] `cargo check` compiles cleanly
- [x] All 118 unit tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [ ] Manual smoke test: open an article in reader mode and verify content extraction still works

Closes #35