### PR TITLE
Add subcomment loading spinner and fix comment layout spacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +426,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -707,6 +725,7 @@ dependencies = [
  "crossterm",
  "futures",
  "html2text",
+ "indicatif",
  "open",
  "ratatui",
  "readability-rs",
@@ -1000,6 +1019,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -2766,6 +2798,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ futures = "0.3"
 html2text = "0.16"
 readability-rs = { version = "0.5.0", default-features = false }
 url = "2.5.8"
+indicatif = "0.18.4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use crate::state::story_state::StoryListState;
 use crate::ui::theme;
 use html2text::render::RichAnnotation;
 use ratatui::style::{Modifier, Style};
+use std::collections::HashSet;
 use tokio::sync::mpsc;
 
 const MIN_PAGE_SIZE: usize = 30;
@@ -31,6 +32,7 @@ pub enum AppMessage {
     CommentsLoaded {
         story: Item,
         comments: Vec<(Item, usize)>,
+        pending_roots: HashSet<u64>,
     },
     /// Progressive update — append more child comments into the tree.
     CommentsAppended {
@@ -64,6 +66,7 @@ pub struct App {
     pub error: Option<String>,
     pub terminal_height: u16,
     pub terminal_width: u16,
+    pub tick_count: u64,
 
     last_comment_click: Option<(std::time::Instant, usize)>,
 
@@ -88,6 +91,7 @@ impl App {
             error: None,
             terminal_height,
             terminal_width,
+            tick_count: 0,
             last_comment_click: None,
             client: HnClient::new(),
             msg_tx,
@@ -160,9 +164,14 @@ impl App {
                         self.focus = Pane::Stories;
                     }
                 }
-                AppMessage::CommentsLoaded { story, comments } => {
+                AppMessage::CommentsLoaded {
+                    story,
+                    comments,
+                    pending_roots,
+                } => {
                     self.comment_state.story = Some(story);
                     self.comment_state.set_comments(comments);
+                    self.comment_state.pending_root_ids = pending_roots;
                     // Still loading children in background
                     self.error = None;
                 }
@@ -171,9 +180,11 @@ impl App {
                     children,
                 } => {
                     self.comment_state.insert_children(parent_id, children);
+                    self.comment_state.pending_root_ids.remove(&parent_id);
                 }
                 AppMessage::CommentsDone => {
                     self.comment_state.loading = false;
+                    self.comment_state.pending_root_ids.clear();
                 }
                 AppMessage::ArticleLoaded { lines } => {
                     if let Some(ref mut reader) = self.reader_state {
@@ -482,9 +493,16 @@ impl App {
                     .map(|item| (item, 0))
                     .collect();
 
+                let pending_roots: HashSet<u64> = root_comments
+                    .iter()
+                    .filter(|(r, _)| r.kids.as_ref().is_some_and(|k| !k.is_empty()))
+                    .map(|(r, _)| r.id)
+                    .collect();
+
                 let _ = tx.send(AppMessage::CommentsLoaded {
                     story: story_clone,
                     comments: root_comments.clone(),
+                    pending_roots,
                 });
 
                 // Step 2: For each root comment, fetch its children progressively

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ pub enum AppMessage {
         append: bool,
     },
     CommentsLoaded {
-        story: Item,
+        story: Box<Item>,
         comments: Vec<(Item, usize)>,
         pending_roots: HashSet<u64>,
     },
@@ -169,7 +169,7 @@ impl App {
                     comments,
                     pending_roots,
                 } => {
-                    self.comment_state.story = Some(story);
+                    self.comment_state.story = Some(*story);
                     self.comment_state.set_comments(comments);
                     self.comment_state.pending_root_ids = pending_roots;
                     // Still loading children in background
@@ -500,7 +500,7 @@ impl App {
                     .collect();
 
                 let _ = tx.send(AppMessage::CommentsLoaded {
-                    story: story_clone,
+                    story: Box::new(story_clone),
                     comments: root_comments.clone(),
                     pending_roots,
                 });

--- a/src/event.rs
+++ b/src/event.rs
@@ -34,24 +34,15 @@ impl EventHandler {
                         }
                     }
                     event = reader.next() => {
-                        match event {
-                            Some(Ok(CrosstermEvent::Key(key))) => {
-                                if tx.send(Event::Key(key)).is_err() {
-                                    break;
-                                }
-                            }
-                            Some(Ok(CrosstermEvent::Mouse(mouse))) => {
-                                if tx.send(Event::Mouse(mouse)).is_err() {
-                                    break;
-                                }
-                            }
-                            Some(Ok(CrosstermEvent::Resize(w, h))) => {
-                                if tx.send(Event::Resize(w, h)).is_err() {
-                                    break;
-                                }
-                            }
+                        let send_result = match event {
+                            Some(Ok(CrosstermEvent::Key(key))) => tx.send(Event::Key(key)),
+                            Some(Ok(CrosstermEvent::Mouse(mouse))) => tx.send(Event::Mouse(mouse)),
+                            Some(Ok(CrosstermEvent::Resize(w, h))) => tx.send(Event::Resize(w, h)),
                             Some(Err(_)) | None => break,
-                            _ => {}
+                            _ => continue,
+                        };
+                        if send_result.is_err() {
+                            break;
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
                 app.set_terminal_size(w, h);
             }
             Event::Tick => {
-                // Tick — just triggers redraw above
+                app.tick_count = app.tick_count.wrapping_add(1);
             }
         }
     }

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -15,6 +15,8 @@ pub struct CommentTreeState {
     pub collapsed: HashSet<u64>,
     pub loading: bool,
     pub story: Option<Item>,
+    /// Root-comment IDs whose subtrees are still being fetched.
+    pub pending_root_ids: HashSet<u64>,
     /// Maps screen row (relative to inner area top) → visible comment index.
     /// Populated during render for mouse click handling.
     pub row_map: RefCell<Vec<Option<usize>>>,
@@ -29,6 +31,7 @@ impl CommentTreeState {
             collapsed: HashSet::new(),
             loading: false,
             story: None,
+            pending_root_ids: HashSet::new(),
             row_map: RefCell::new(Vec::new()),
         }
     }
@@ -136,6 +139,7 @@ impl CommentTreeState {
         self.collapsed.clear();
         self.loading = false;
         self.story = None;
+        self.pending_root_ids.clear();
         self.row_map.borrow_mut().clear();
     }
 }
@@ -415,6 +419,7 @@ mod tests {
         state.selected = 2;
         state.loading = true;
         state.story = Some(make_item(99));
+        state.pending_root_ids.insert(1);
         state.reset();
         assert!(state.comments.is_empty());
         assert_eq!(state.scroll.get(), 0);
@@ -422,5 +427,26 @@ mod tests {
         assert!(state.collapsed.is_empty());
         assert!(!state.loading);
         assert!(state.story.is_none());
+        assert!(state.pending_root_ids.is_empty());
+    }
+
+    #[test]
+    fn pending_root_ids_lifecycle() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(sample_tree());
+        // Populate — simulating app.rs inserting after CommentsLoaded
+        state.pending_root_ids.insert(1);
+        state.pending_root_ids.insert(4);
+        assert_eq!(state.pending_root_ids.len(), 2);
+
+        // CommentsAppended for root 1 → children arrive, remove from pending
+        state.insert_children(1, vec![(make_item(10), 1)]);
+        state.pending_root_ids.remove(&1);
+        assert!(!state.pending_root_ids.contains(&1));
+        assert!(state.pending_root_ids.contains(&4));
+
+        // CommentsDone → clear remaining
+        state.pending_root_ids.clear();
+        assert!(state.pending_root_ids.is_empty());
     }
 }

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -1,4 +1,5 @@
 use crate::state::comment_state::{CommentTreeState, FlatComment};
+use crate::ui::spinner;
 use crate::ui::story_list::format_time_ago;
 use crate::ui::theme;
 use ratatui::{
@@ -11,6 +12,7 @@ use ratatui::{
 pub struct CommentTree<'a> {
     pub state: &'a CommentTreeState,
     pub focused: bool,
+    pub tick: u64,
 }
 
 /// A pre-measured comment: all the lines it will produce and its visual index.
@@ -53,8 +55,13 @@ impl<'a> Widget for CommentTree<'a> {
         let inner = block.inner(area);
         block.render(area, buf);
 
+        let spinner_frame = spinner::frame(self.tick);
+
         if self.state.loading && self.state.story.is_none() {
-            let loading = Line::from(Span::styled("  Loading comments...", theme::dim_style()));
+            let loading = Line::from(vec![
+                Span::styled(format!("  {} ", spinner_frame), theme::accent_style()),
+                Span::styled("Loading comments...", theme::dim_style()),
+            ]);
             buf.set_line(inner.left(), inner.top(), &loading, inner.width);
             return;
         }
@@ -157,7 +164,10 @@ impl<'a> Widget for CommentTree<'a> {
                 buf.set_line(
                     inner.left(),
                     inner.top() + header_height,
-                    &Line::from(Span::styled("  Loading comments...", theme::dim_style())),
+                    &Line::from(vec![
+                        Span::styled(format!("  {} ", spinner_frame), theme::accent_style()),
+                        Span::styled("Loading comments...", theme::dim_style()),
+                    ]),
                     inner.width,
                 );
             }
@@ -184,6 +194,8 @@ impl<'a> Widget for CommentTree<'a> {
             &self.state.collapsed,
             &self.state.comments,
             inner.width as usize,
+            &self.state.pending_root_ids,
+            spinner_frame,
         );
 
         // Find the row offset where the selected comment starts
@@ -232,8 +244,9 @@ impl<'a> Widget for CommentTree<'a> {
                     return;
                 }
 
-                // Fill background for selected comment
-                if is_selected {
+                // Fill background for selected comment (skip trailing gap so the
+                // highlight aligns with the left `│` bar)
+                if is_selected && !matches!(line, CommentLine::Gap) {
                     for x in inner.left()..inner.right() {
                         buf[(x, inner.top() + screen_y)]
                             .set_style(ratatui::style::Style::default().bg(bg));
@@ -276,10 +289,10 @@ impl<'a> Widget for CommentTree<'a> {
             buf.set_line(
                 inner.left(),
                 inner.top() + screen_y,
-                &Line::from(Span::styled(
-                    "  Loading more comments...",
-                    theme::dim_style(),
-                )),
+                &Line::from(vec![
+                    Span::styled(format!("  {} ", spinner_frame), theme::accent_style()),
+                    Span::styled("Loading more comments...", theme::dim_style()),
+                ]),
                 inner.width,
             );
         }
@@ -292,6 +305,8 @@ fn measure_comments<'a>(
     collapsed: &std::collections::HashSet<u64>,
     all_comments: &[FlatComment],
     width: usize,
+    pending_root_ids: &std::collections::HashSet<u64>,
+    spinner_frame: &str,
 ) -> Vec<MeasuredComment<'a>> {
     let mut result = Vec::new();
 
@@ -318,11 +333,17 @@ fn measure_comments<'a>(
         };
 
         // Header line
-        let header_spans = vec![
-            (
-                format!("{}{}", indent, bar),
-                ratatui::style::Style::default().fg(depth_color),
-            ),
+        let mut header_spans = vec![(
+            format!("{}{}", indent, bar),
+            ratatui::style::Style::default().fg(depth_color),
+        )];
+        if comment.depth == 0 && pending_root_ids.contains(&comment.item.id) {
+            header_spans.push((
+                format!("{} ", spinner_frame),
+                ratatui::style::Style::default().fg(theme::HN_ORANGE),
+            ));
+        }
+        header_spans.extend([
             (
                 format!("{} ", author),
                 ratatui::style::Style::default()
@@ -338,7 +359,7 @@ fn measure_comments<'a>(
                 ratatui::style::Style::default().fg(theme::YELLOW),
             ),
             (child_count, ratatui::style::Style::default().fg(theme::DIM)),
-        ];
+        ]);
         lines.push(CommentLine::Header(header_spans));
 
         // Comment text lines
@@ -363,10 +384,9 @@ fn measure_comments<'a>(
             }
         }
 
-        // Gap after top-level comments
-        if comment.depth == 0 {
-            lines.push(CommentLine::Gap);
-        }
+        // Blank gap after every comment — prevents the next comment's vertical
+        // bar from visually bleeding into this comment's last row.
+        lines.push(CommentLine::Gap);
 
         result.push(MeasuredComment {
             _comment: comment,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod article_reader;
 pub mod comment_tree;
 pub mod header;
 pub mod layout;
+pub mod spinner;
 pub mod status_bar;
 pub mod story_list;
 pub mod theme;
@@ -53,6 +54,7 @@ pub fn render(app: &App, frame: &mut Frame) {
         comment_tree::CommentTree {
             state: &app.comment_state,
             focused: app.focus == crate::app::Pane::Comments,
+            tick: app.tick_count,
         },
         layout.comments,
     );

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -1,0 +1,13 @@
+use indicatif::ProgressStyle;
+use std::sync::OnceLock;
+
+const FRAMES: &[&str] = &["⠾", "⠷", "⠯", "⠟", "⠻", "⠽"];
+
+fn style() -> &'static ProgressStyle {
+    static STYLE: OnceLock<ProgressStyle> = OnceLock::new();
+    STYLE.get_or_init(|| ProgressStyle::default_spinner().tick_strings(FRAMES))
+}
+
+pub fn frame(tick: u64) -> &'static str {
+    style().get_tick_str(tick)
+}


### PR DESCRIPTION
Closes #54

## Summary
- Animated braille spinner (`⠾ ⠷ ⠯ ⠟ ⠻ ⠽`, 5 dots visible with one rotating hole) next to every root comment whose subtree is still fetching, plus on the "Loading comments..." and "Loading more comments..." indicators. Frames come from `indicatif`'s `ProgressStyle::get_tick_str`, advanced by the existing 250 ms tick event.
- Track pending root subtrees in `CommentTreeState::pending_root_ids`: populated from `CommentsLoaded`, removed on `CommentsAppended`, cleared on `CommentsDone` (covers the case where every descendant was dead/deleted and `CommentsAppended` never fires).
- Insert a blank `Gap` row after every comment so the next comment's `│` bar has an empty row to render against instead of visually bleeding into the previous comment's last text row.
- Skip the selection-background fill on `Gap` rows so the grey highlight aligns with where the `│` bar actually ends.

## Test plan
- [x] `cargo build --release`
- [x] `cargo test` — 119 passed, including new `pending_root_ids_lifecycle`
- [x] Manual: select a story with deep threads; confirm spinner appears per-root while subtree loads and disappears when each root's `CommentsAppended` arrives
- [x] Manual: selected comment's grey highlight aligns with the `│` bar top and bottom
- [x] Manual: blank row separates consecutive subcomments at the same or different depths