### PR TITLE
Bump version to 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump Cargo.toml version from 0.3.5 → 0.3.6 so that on merge to `main`, the release workflow cuts a new `v0.3.6` release with the spinner / layout changes from #55.

## Test plan
- [x] `cargo build --release` succeeds with new version
- [x] After merge: release workflow creates `v0.3.6` tag and GitHub release with prebuilt binaries for all four targets