### PR TITLE
Validate URL scheme before fetching article

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -556,6 +556,12 @@ impl App {
             return;
         }
 
+        // Reject non-http(s) schemes (file://, javascript:, data:, etc.) before fetching.
+        match url::Url::parse(url.as_deref().unwrap_or("")) {
+            Ok(parsed) if matches!(parsed.scheme(), "http" | "https") => {}
+            _ => return,
+        }
+
         self.reader_state = Some(ReaderState::new_loading(title, domain, url.clone()));
 
         let tx = self.msg_tx.clone();


### PR DESCRIPTION
Fixes #39.

## Summary
- `open_article_reader` now rejects any URL whose scheme isn't `http` or `https` before touching reqwest, mirroring the existing guard in `open_in_browser`.
- Blocks `file://`, `javascript:`, `data:`, etc. from being fetched via a crafted HN story URL.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (119 passed)
- [ ] Manually: normal http/https story loads in the reader as before.