### PR TITLE
Bump version to 0.3.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Version bump to 0.3.7; pushes to main will trigger the release workflow, which tags `v0.3.7` and publishes cross-platform binaries.

## Notable changes since 0.3.6
- #60 — Validate URL scheme before fetching article (security; rejects non-http(s) schemes in the article reader)
- #59 — Add dependabot auto-merge workflow
- #58/#57/#52 — Dependency updates (minor/patch group, rust slim image, action-gh-release)

## Test plan
- [x] `cargo check` / `clippy` / `test` pass locally.
- [ ] CI green on this PR.
- [ ] On merge, release workflow creates `v0.3.7` tag and release artifacts.