### PR TITLE
Fix pagination drift by reusing cached story IDs

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -76,7 +76,30 @@ impl HnClient {
         ids.iter().map(|id| result_map.get(id).cloned()).collect()
     }
 
-    /// Fetch stories for a feed: get IDs, then batch fetch first `count` items.
+    /// Fetch a page of items from a pre-fetched ID list. Used for pagination
+    /// so callers can reuse the initial ID list instead of re-fetching it —
+    /// avoiding drift when new stories have been posted since the last fetch.
+    pub async fn fetch_items_page(
+        &self,
+        ids: &[u64],
+        offset: usize,
+        count: usize,
+    ) -> Result<Vec<Item>> {
+        if offset >= ids.len() {
+            return Ok(Vec::new());
+        }
+        let end = (offset + count).min(ids.len());
+        let page_ids = &ids[offset..end];
+
+        Ok(self
+            .fetch_items(page_ids)
+            .await
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
+    /// Fetch stories for a feed: get IDs, then batch fetch a page of items.
     pub async fn fetch_stories(
         &self,
         feed: FeedKind,
@@ -84,16 +107,7 @@ impl HnClient {
         count: usize,
     ) -> Result<(Vec<Item>, Vec<u64>)> {
         let all_ids = self.fetch_story_ids(feed).await?;
-        let end = (offset + count).min(all_ids.len());
-        let page_ids = &all_ids[offset..end];
-
-        let items: Vec<Item> = self
-            .fetch_items(page_ids)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
-
+        let items = self.fetch_items_page(&all_ids, offset, count).await?;
         Ok((items, all_ids))
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,9 @@ pub enum Pane {
 pub enum AppMessage {
     StoriesLoaded {
         stories: Vec<Item>,
-        all_ids: Vec<u64>,
+        // Only populated on initial load; subsequent paginated loads reuse
+        // the cached ID list to avoid drift when the feed changes mid-session.
+        all_ids: Option<Vec<u64>>,
         append: bool,
     },
     CommentsLoaded {
@@ -130,7 +132,9 @@ impl App {
                     } else {
                         self.story_state.stories = stories;
                     }
-                    self.story_state.all_ids = all_ids;
+                    if let Some(ids) = all_ids {
+                        self.story_state.all_ids = ids;
+                    }
                     self.story_state.loading = false;
                     self.error = None;
                     // Auto-load comments for the first story on initial load
@@ -437,29 +441,50 @@ impl App {
 
     fn spawn_load_stories(&self, append: bool) {
         let client = self.client.clone();
-        let feed = self.current_feed;
-        let offset = if append {
-            self.story_state.stories.len()
-        } else {
-            0
-        };
         let tx = self.msg_tx.clone();
         let page_size = self.page_size();
 
-        tokio::spawn(async move {
-            match client.fetch_stories(feed, offset, page_size).await {
-                Ok((stories, all_ids)) => {
-                    let _ = tx.send(AppMessage::StoriesLoaded {
-                        stories,
-                        all_ids,
-                        append,
-                    });
+        if append {
+            // Reuse the ID list from the initial load so offsets stay stable
+            // even if new stories have been posted to the feed since.
+            let cached_ids = self.story_state.all_ids.clone();
+            let offset = self.story_state.stories.len();
+            tokio::spawn(async move {
+                match client
+                    .fetch_items_page(&cached_ids, offset, page_size)
+                    .await
+                {
+                    Ok(stories) => {
+                        let _ = tx.send(AppMessage::StoriesLoaded {
+                            stories,
+                            all_ids: None,
+                            append: true,
+                        });
+                    }
+                    Err(e) => {
+                        let _ =
+                            tx.send(AppMessage::Error(format!("Failed to load stories: {}", e)));
+                    }
                 }
-                Err(e) => {
-                    let _ = tx.send(AppMessage::Error(format!("Failed to load stories: {}", e)));
+            });
+        } else {
+            let feed = self.current_feed;
+            tokio::spawn(async move {
+                match client.fetch_stories(feed, 0, page_size).await {
+                    Ok((stories, all_ids)) => {
+                        let _ = tx.send(AppMessage::StoriesLoaded {
+                            stories,
+                            all_ids: Some(all_ids),
+                            append: false,
+                        });
+                    }
+                    Err(e) => {
+                        let _ =
+                            tx.send(AppMessage::Error(format!("Failed to load stories: {}", e)));
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     fn load_selected_comments(&mut self) {


### PR DESCRIPTION
Fixes #44.

## Summary
- Every paginated append was calling `fetch_story_ids` fresh and then slicing by `self.story_state.stories.len()`. When new stories had been posted to the feed between pages, the ID list had shifted but the offset hadn't — producing duplicates or gaps.
- Cache `all_ids` from the **initial** load; subsequent appends reuse it instead of re-fetching.
- Added `HnClient::fetch_items_page(ids, offset, count)` which pages from a pre-fetched ID list; `fetch_stories` now delegates to it.
- `AppMessage::StoriesLoaded.all_ids` is now `Option<Vec<u64>>` — `Some` on initial load, `None` on append.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (119 passed)
- [ ] Manually: scroll past the first page and confirm no duplicate or missing stories.