### PR TITLE
Remove dead placeholder block in story_list.rs

### DIFF
--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -138,14 +138,6 @@ impl<'a> Widget for StoryList<'a> {
 
             let line = Line::from(spans);
             buf.set_line(inner.left(), y, &line, inner.width);
-
-            // Meta line (if space allows: every other row)
-            if visible_height > self.stories.len() || i == self.selected {
-                // We only show meta inline with compact display
-            }
-
-            // Show score/author/time on the same concept but we'll keep it compact
-            // Actually let's use 2 lines per story if there's room, otherwise 1
         }
     }
 }


### PR DESCRIPTION
Fixes #49. Pure delete — the empty if had commented-out design notes for an unimplemented feature.