### PR TITLE
Remove Cell/RefCell from CommentTreeState

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -705,10 +705,12 @@ impl App {
             self.focus = Pane::Comments;
 
             let screen_row = (row - inner.y) as usize;
-            let visual_index = {
-                let row_map = self.comment_state.row_map.borrow();
-                row_map.get(screen_row).copied().flatten()
-            };
+            let visual_index = self
+                .comment_state
+                .row_map
+                .get(screen_row)
+                .copied()
+                .flatten();
 
             if let Some(vi) = visual_index {
                 let visible_len = self.comment_state.visible_comments().len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
 
         // Draw
         terminal.draw(|frame| {
-            ui::render(&app, frame);
+            ui::render(&mut app, frame);
         })?;
 
         // Handle events

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -1,5 +1,4 @@
 use crate::api::types::Item;
-use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 
 pub struct FlatComment {
@@ -9,8 +8,8 @@ pub struct FlatComment {
 
 pub struct CommentTreeState {
     pub comments: Vec<FlatComment>,
-    /// Row-based scroll offset, updated by the renderer via interior mutability.
-    pub scroll: Cell<usize>,
+    /// Row-based scroll offset, updated by the renderer.
+    pub scroll: usize,
     pub selected: usize,
     pub collapsed: HashSet<u64>,
     pub loading: bool,
@@ -19,20 +18,20 @@ pub struct CommentTreeState {
     pub pending_root_ids: HashSet<u64>,
     /// Maps screen row (relative to inner area top) → visible comment index.
     /// Populated during render for mouse click handling.
-    pub row_map: RefCell<Vec<Option<usize>>>,
+    pub row_map: Vec<Option<usize>>,
 }
 
 impl CommentTreeState {
     pub fn new() -> Self {
         Self {
             comments: Vec::new(),
-            scroll: Cell::new(0),
+            scroll: 0,
             selected: 0,
             collapsed: HashSet::new(),
             loading: false,
             story: None,
             pending_root_ids: HashSet::new(),
-            row_map: RefCell::new(Vec::new()),
+            row_map: Vec::new(),
         }
     }
 
@@ -41,7 +40,7 @@ impl CommentTreeState {
             .into_iter()
             .map(|(item, depth)| FlatComment { item, depth })
             .collect();
-        self.scroll.set(0);
+        self.scroll = 0;
         self.selected = 0;
     }
 
@@ -99,7 +98,7 @@ impl CommentTreeState {
 
     pub fn jump_top(&mut self) {
         self.selected = 0;
-        self.scroll.set(0);
+        self.scroll = 0;
     }
 
     pub fn jump_bottom(&mut self) {
@@ -134,13 +133,13 @@ impl CommentTreeState {
 
     pub fn reset(&mut self) {
         self.comments.clear();
-        self.scroll.set(0);
+        self.scroll = 0;
         self.selected = 0;
         self.collapsed.clear();
         self.loading = false;
         self.story = None;
         self.pending_root_ids.clear();
-        self.row_map.borrow_mut().clear();
+        self.row_map.clear();
     }
 }
 
@@ -188,10 +187,10 @@ mod tests {
     #[test]
     fn set_comments_resets_scroll() {
         let mut state = CommentTreeState::new();
-        state.scroll.set(10);
+        state.scroll = 10;
         state.selected = 5;
         state.set_comments(sample_tree());
-        assert_eq!(state.scroll.get(), 0);
+        assert_eq!(state.scroll, 0);
         assert_eq!(state.selected, 0);
     }
 
@@ -295,10 +294,10 @@ mod tests {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
         state.selected = 3;
-        state.scroll.set(5);
+        state.scroll = 5;
         state.jump_top();
         assert_eq!(state.selected, 0);
-        assert_eq!(state.scroll.get(), 0);
+        assert_eq!(state.scroll, 0);
     }
 
     #[test]
@@ -422,7 +421,7 @@ mod tests {
         state.pending_root_ids.insert(1);
         state.reset();
         assert!(state.comments.is_empty());
-        assert_eq!(state.scroll.get(), 0);
+        assert_eq!(state.scroll, 0);
         assert_eq!(state.selected, 0);
         assert!(state.collapsed.is_empty());
         assert!(!state.loading);

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -10,14 +10,13 @@ use ratatui::{
 };
 
 pub struct CommentTree<'a> {
-    pub state: &'a CommentTreeState,
+    pub state: &'a mut CommentTreeState,
     pub focused: bool,
     pub tick: u64,
 }
 
 /// A pre-measured comment: all the lines it will produce and its visual index.
-struct MeasuredComment<'a> {
-    _comment: &'a FlatComment,
+struct MeasuredComment {
     visual_index: usize,
     lines: Vec<CommentLine>,
 }
@@ -176,19 +175,12 @@ impl<'a> Widget for CommentTree<'a> {
 
         let available_height = inner.height.saturating_sub(header_height) as usize;
         if available_height == 0 {
-            // Clear row_map when nothing to render
-            self.state.row_map.borrow_mut().clear();
             return;
         }
 
-        // Initialize row_map for mouse click handling
-        {
-            let mut row_map = self.state.row_map.borrow_mut();
-            row_map.clear();
-            row_map.resize(inner.height as usize, None);
-        }
-
-        // Pass 1: measure all comments into rows
+        // Pass 1: measure all comments into rows. After this, `measured` owns
+        // all the data it needs and `visible` can be dropped so we can mutate
+        // other fields on self.state (row_map, scroll).
         let measured = measure_comments(
             &visible,
             &self.state.collapsed,
@@ -197,6 +189,11 @@ impl<'a> Widget for CommentTree<'a> {
             &self.state.pending_root_ids,
             spinner_frame,
         );
+        drop(visible);
+
+        // Initialize row_map for mouse click handling
+        self.state.row_map.clear();
+        self.state.row_map.resize(inner.height as usize, None);
 
         // Find the row offset where the selected comment starts
         let mut selected_row_start: usize = 0;
@@ -213,7 +210,7 @@ impl<'a> Widget for CommentTree<'a> {
         }
 
         // Scroll so selected comment is visible — prefer selected at top
-        let current_scroll = self.state.scroll.get();
+        let current_scroll = self.state.scroll;
         let scroll_row = if selected_row_start < current_scroll
             || selected_row_end > current_scroll + available_height
         {
@@ -221,7 +218,7 @@ impl<'a> Widget for CommentTree<'a> {
         } else {
             current_scroll
         };
-        self.state.scroll.set(scroll_row);
+        self.state.scroll = scroll_row;
 
         // Pass 2: render from scroll_row
         let mut screen_y = header_height;
@@ -254,11 +251,8 @@ impl<'a> Widget for CommentTree<'a> {
                 }
 
                 // Record row → comment mapping for mouse clicks
-                {
-                    let mut row_map = self.state.row_map.borrow_mut();
-                    if (screen_y as usize) < row_map.len() {
-                        row_map[screen_y as usize] = Some(mc.visual_index);
-                    }
+                if (screen_y as usize) < self.state.row_map.len() {
+                    self.state.row_map[screen_y as usize] = Some(mc.visual_index);
                 }
 
                 match line {
@@ -300,14 +294,14 @@ impl<'a> Widget for CommentTree<'a> {
 }
 
 /// Measure all visible comments into pre-computed line lists.
-fn measure_comments<'a>(
-    visible: &[&'a FlatComment],
+fn measure_comments(
+    visible: &[&FlatComment],
     collapsed: &std::collections::HashSet<u64>,
     all_comments: &[FlatComment],
     width: usize,
     pending_root_ids: &std::collections::HashSet<u64>,
     spinner_frame: &str,
-) -> Vec<MeasuredComment<'a>> {
+) -> Vec<MeasuredComment> {
     let mut result = Vec::new();
 
     for (vi, comment) in visible.iter().enumerate() {
@@ -389,7 +383,6 @@ fn measure_comments<'a>(
         lines.push(CommentLine::Gap);
 
         result.push(MeasuredComment {
-            _comment: comment,
             visual_index: vi,
             lines,
         });

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,7 @@ use ratatui::{
     Frame,
 };
 
-pub fn render(app: &App, frame: &mut Frame) {
+pub fn render(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
 
     // Fill background
@@ -52,7 +52,7 @@ pub fn render(app: &App, frame: &mut Frame) {
     // Comment tree
     frame.render_widget(
         comment_tree::CommentTree {
-            state: &app.comment_state,
+            state: &mut app.comment_state,
             focused: app.focus == crate::app::Pane::Comments,
             tick: app.tick_count,
         },


### PR DESCRIPTION
Fixes #48. Comment tree state no longer needs interior mutability: `ui::render` takes `&mut App`, `CommentTree` holds `&mut CommentTreeState`, and `scroll`/`row_map` are plain `usize`/`Vec`. Cleaned up `MeasuredComment`'s unused lifetime parameter so we can drop `visible` before the state mutations.