### PR TITLE
Compute visible comment indices once per render frame

### DIFF
--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -62,11 +62,12 @@ impl CommentTreeState {
         }
     }
 
-    pub fn visible_comments(&self) -> Vec<&FlatComment> {
-        let mut result = Vec::new();
+    /// Walk the comment tree, skipping subtrees rooted at a collapsed comment.
+    /// Returns the indices (into `self.comments`) that should be shown.
+    pub fn visible_indices(&self) -> Vec<usize> {
+        let mut indices = Vec::with_capacity(self.comments.len());
         let mut skip_depth: Option<usize> = None;
-
-        for comment in &self.comments {
+        for (i, comment) in self.comments.iter().enumerate() {
             if let Some(sd) = skip_depth {
                 if comment.depth > sd {
                     continue;
@@ -74,15 +75,19 @@ impl CommentTreeState {
                     skip_depth = None;
                 }
             }
-
             if self.collapsed.contains(&comment.item.id) {
                 skip_depth = Some(comment.depth);
             }
-
-            result.push(comment);
+            indices.push(i);
         }
+        indices
+    }
 
-        result
+    pub fn visible_comments(&self) -> Vec<&FlatComment> {
+        self.visible_indices()
+            .into_iter()
+            .map(|i| &self.comments[i])
+            .collect()
     }
 
     pub fn select_next(&mut self) {

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -11,6 +11,7 @@ use ratatui::{
 
 pub struct CommentTree<'a> {
     pub state: &'a mut CommentTreeState,
+    pub visible: &'a [usize],
     pub focused: bool,
     pub tick: u64,
 }
@@ -74,7 +75,7 @@ impl<'a> Widget for CommentTree<'a> {
             return;
         }
 
-        let visible = self.state.visible_comments();
+        let visible = self.visible;
 
         if visible.is_empty() && !self.state.loading {
             let no_comments = Line::from(Span::styled("  No comments", theme::dim_style()));
@@ -178,18 +179,15 @@ impl<'a> Widget for CommentTree<'a> {
             return;
         }
 
-        // Pass 1: measure all comments into rows. After this, `measured` owns
-        // all the data it needs and `visible` can be dropped so we can mutate
-        // other fields on self.state (row_map, scroll).
+        // Pass 1: measure all comments into rows.
         let measured = measure_comments(
-            &visible,
+            visible,
             &self.state.collapsed,
             &self.state.comments,
             inner.width as usize,
             &self.state.pending_root_ids,
             spinner_frame,
         );
-        drop(visible);
 
         // Initialize row_map for mouse click handling
         self.state.row_map.clear();
@@ -295,7 +293,7 @@ impl<'a> Widget for CommentTree<'a> {
 
 /// Measure all visible comments into pre-computed line lists.
 fn measure_comments(
-    visible: &[&FlatComment],
+    visible_indices: &[usize],
     collapsed: &std::collections::HashSet<u64>,
     all_comments: &[FlatComment],
     width: usize,
@@ -304,7 +302,8 @@ fn measure_comments(
 ) -> Vec<MeasuredComment> {
     let mut result = Vec::new();
 
-    for (vi, comment) in visible.iter().enumerate() {
+    for (vi, &idx) in visible_indices.iter().enumerate() {
+        let comment = &all_comments[idx];
         let mut lines = Vec::new();
         let depth_color = theme::depth_color(comment.depth);
         let indent = "  ".repeat(comment.depth);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -49,10 +49,15 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         layout.stories,
     );
 
+    // Walk the comment tree once per frame and share the result between the
+    // comment tree widget and the status bar.
+    let visible_indices = app.comment_state.visible_indices();
+
     // Comment tree
     frame.render_widget(
         comment_tree::CommentTree {
             state: &mut app.comment_state,
+            visible: &visible_indices,
             focused: app.focus == crate::app::Pane::Comments,
             tick: app.tick_count,
         },
@@ -71,14 +76,13 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             )
         }
     } else {
-        let visible = app.comment_state.visible_comments();
         let total = app
             .comment_state
             .story
             .as_ref()
             .and_then(|s| s.descendants)
-            .unwrap_or(visible.len() as i64);
-        if visible.is_empty() {
+            .unwrap_or(visible_indices.len() as i64);
+        if visible_indices.is_empty() {
             "0/0".to_string()
         } else {
             format!("{}/{}", app.comment_state.selected + 1, total)


### PR DESCRIPTION
Fixes #41. Instead of calling `visible_comments()` separately from the comment tree widget and the status bar, `ui::render` walks the tree once (`visible_indices()`) and passes the `&[usize]` slice into the widget. Halves the per-frame tree walk cost for large threads.