### PR TITLE
Cache plain-text rendering of comments and story text

### DIFF
--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -4,6 +4,31 @@ use std::collections::HashSet;
 pub struct FlatComment {
     pub item: Item,
     pub depth: usize,
+    /// Cached plain-text rendering of `item.text` at the given width.
+    /// Populated on first render; invalidated by a width change.
+    plain_text_cache: Option<(usize, String)>,
+}
+
+impl FlatComment {
+    pub fn new(item: Item, depth: usize) -> Self {
+        Self {
+            item,
+            depth,
+            plain_text_cache: None,
+        }
+    }
+
+    /// Returns the plain-text rendering of `item.text` at `width`, reusing
+    /// the last-rendered result if the width matches.
+    pub fn plain_text(&mut self, width: usize) -> Option<&str> {
+        let text = self.item.text.as_deref()?;
+        let needs_refresh = !matches!(&self.plain_text_cache, Some((w, _)) if *w == width);
+        if needs_refresh {
+            let rendered = html2text::from_read(text.as_bytes(), width.max(20)).unwrap_or_default();
+            self.plain_text_cache = Some((width, rendered));
+        }
+        self.plain_text_cache.as_ref().map(|(_, s)| s.as_str())
+    }
 }
 
 pub struct CommentTreeState {
@@ -19,6 +44,9 @@ pub struct CommentTreeState {
     /// Maps screen row (relative to inner area top) → visible comment index.
     /// Populated during render for mouse click handling.
     pub row_map: Vec<Option<usize>>,
+    /// Cached plain-text rendering of the current story's text (id, width, text).
+    /// Invalidated automatically when story id or width changes.
+    story_text_cache: Option<(u64, usize, String)>,
 }
 
 impl CommentTreeState {
@@ -32,13 +60,29 @@ impl CommentTreeState {
             story: None,
             pending_root_ids: HashSet::new(),
             row_map: Vec::new(),
+            story_text_cache: None,
         }
+    }
+
+    /// Return the plain-text rendering of the current story's text at `width`,
+    /// reusing the last-rendered result if the story and width match.
+    pub fn story_plain_text(&mut self, width: usize) -> Option<&str> {
+        let story = self.story.as_ref()?;
+        let text = story.text.as_deref()?;
+        let id = story.id;
+        let needs_refresh =
+            !matches!(&self.story_text_cache, Some((cid, w, _)) if *cid == id && *w == width);
+        if needs_refresh {
+            let rendered = html2text::from_read(text.as_bytes(), width.max(20)).unwrap_or_default();
+            self.story_text_cache = Some((id, width, rendered));
+        }
+        self.story_text_cache.as_ref().map(|(_, _, s)| s.as_str())
     }
 
     pub fn set_comments(&mut self, items: Vec<(Item, usize)>) {
         self.comments = items
             .into_iter()
-            .map(|(item, depth)| FlatComment { item, depth })
+            .map(|(item, depth)| FlatComment::new(item, depth))
             .collect();
         self.scroll = 0;
         self.selected = 0;
@@ -55,7 +99,7 @@ impl CommentTreeState {
         if let Some(pos) = insert_pos {
             let new_comments: Vec<FlatComment> = children
                 .into_iter()
-                .map(|(item, depth)| FlatComment { item, depth })
+                .map(|(item, depth)| FlatComment::new(item, depth))
                 .collect();
             // Splice them in after the parent
             self.comments.splice(pos..pos, new_comments);

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -86,9 +86,14 @@ impl<'a> Widget for CommentTree<'a> {
         // Render story meta header (fixed, not scrolled)
         let mut header_height: u16 = 0;
 
+        let story_plain = self
+            .state
+            .story_plain_text(inner.width as usize)
+            .map(str::to_owned);
+
         if let Some(story) = &self.state.story {
-            if let Some(text) = &story.text {
-                let plain = html_to_plain(text, inner.width as usize);
+            if let Some(_text) = &story.text {
+                let plain = story_plain.clone().unwrap_or_default();
                 let meta = format!(
                     "  {} pts | {} | {} comments",
                     story.score.unwrap_or(0),
@@ -183,7 +188,7 @@ impl<'a> Widget for CommentTree<'a> {
         let measured = measure_comments(
             visible,
             &self.state.collapsed,
-            &self.state.comments,
+            &mut self.state.comments,
             inner.width as usize,
             &self.state.pending_root_ids,
             spinner_frame,
@@ -295,7 +300,7 @@ impl<'a> Widget for CommentTree<'a> {
 fn measure_comments(
     visible_indices: &[usize],
     collapsed: &std::collections::HashSet<u64>,
-    all_comments: &[FlatComment],
+    all_comments: &mut [FlatComment],
     width: usize,
     pending_root_ids: &std::collections::HashSet<u64>,
     spinner_frame: &str,
@@ -303,15 +308,26 @@ fn measure_comments(
     let mut result = Vec::new();
 
     for (vi, &idx) in visible_indices.iter().enumerate() {
-        let comment = &all_comments[idx];
         let mut lines = Vec::new();
-        let depth_color = theme::depth_color(comment.depth);
-        let indent = "  ".repeat(comment.depth);
+        let depth = all_comments[idx].depth;
+        let indent = "  ".repeat(depth);
         let bar = "│ ";
+        let text_width = width.saturating_sub(indent.len() + bar.len() + 2);
+        let is_collapsed = collapsed.contains(&all_comments[idx].item.id);
+
+        // Populate/refresh the plain-text cache for this comment under a
+        // short-lived mutable borrow, then read everything else immutably.
+        let plain_text = if is_collapsed {
+            None
+        } else {
+            all_comments[idx].plain_text(text_width).map(str::to_owned)
+        };
+
+        let comment = &all_comments[idx];
+        let depth_color = theme::depth_color(comment.depth);
 
         let author = comment.item.by.as_deref().unwrap_or("[deleted]");
         let time_ago = comment.item.time.map(format_time_ago).unwrap_or_default();
-        let is_collapsed = collapsed.contains(&comment.item.id);
         let collapse_indicator = if is_collapsed { " [+]" } else { "" };
 
         let child_count = if is_collapsed {
@@ -356,24 +372,19 @@ fn measure_comments(
         lines.push(CommentLine::Header(header_spans));
 
         // Comment text lines
-        if !is_collapsed {
-            if let Some(text) = &comment.item.text {
-                let text_width = width.saturating_sub(indent.len() + bar.len() + 2);
-                let plain = html_to_plain(text, text_width);
-
-                for line in plain.lines().take(20) {
-                    let text_spans = vec![
-                        (
-                            format!("{}{}", indent, bar),
-                            ratatui::style::Style::default().fg(depth_color),
-                        ),
-                        (
-                            line.to_string(),
-                            ratatui::style::Style::default().fg(theme::TEXT),
-                        ),
-                    ];
-                    lines.push(CommentLine::Text(text_spans));
-                }
+        if let Some(plain) = &plain_text {
+            for line in plain.lines().take(20) {
+                let text_spans = vec![
+                    (
+                        format!("{}{}", indent, bar),
+                        ratatui::style::Style::default().fg(depth_color),
+                    ),
+                    (
+                        line.to_string(),
+                        ratatui::style::Style::default().fg(theme::TEXT),
+                    ),
+                ];
+                lines.push(CommentLine::Text(text_spans));
             }
         }
 
@@ -406,9 +417,4 @@ fn count_hidden_children(all: &[FlatComment], parent: &FlatComment) -> usize {
         }
         None => 0,
     }
-}
-
-fn html_to_plain(html: &str, width: usize) -> String {
-    let width = width.max(20);
-    html2text::from_read(html.as_bytes(), width).unwrap_or_default()
 }


### PR DESCRIPTION
Fixes #40. Stops re-parsing HTML with html2text every 250ms frame. `FlatComment` gets a `(width, String)` cache updated on-demand; `CommentTreeState` gets a `(story_id, width, String)` cache for the story header. Caches invalidate automatically when the width (or story id) changes.