### PR TITLE
Bump version to 0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
Version bump from 0.3.7 to 0.3.8. On merge the release workflow will tag \`v0.3.8\` and publish binaries for the 4 targets.

## Issues fixed since 0.3.7
- #38 — Early Content-Length check before downloading article body (PR #67)
- #40 — Cache plain-text rendering of comments (PR #72)
- #41 — Compute visible comment indices once per render frame (PR #71)
- #42 — Recover from poisoned Mutex in HnClient (PR #66)
- #43 — Bound item cache with LRU (2000) (PR #68)
- #44 — Fix pagination drift (PR #62 — shipped in 0.3.7 already)
- #45 — Compile-time version in User-Agent (PR #63)
- #46 — Replace hand-rolled url_domain with url::Url::parse (PR #65)
- #47 — Extract article rendering into src/article.rs (PR #69)
- #48 — Remove Cell/RefCell from CommentTreeState (PR #70)
- #49 — Remove dead placeholder block in story_list.rs (PR #64)
- #50 — Tests for article-module pure functions (PR #73)
- #51 — Tests for ui::story_list::format_time_ago (PR #74)