### PR TITLE
Add rustdoc coverage across modules and public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [dependencies]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,3 +1,10 @@
+//! HTTP client for the Hacker News Firebase API and Algolia search.
+//!
+//! [`HnClient`] is cheaply [`Clone`]able (shared `reqwest::Client` plus
+//! `Arc<Mutex<LruCache>>`) so async tasks can each take their own handle.
+//! Item fetches are cached up to `CACHE_CAPACITY` entries and fan out
+//! with `CONCURRENT_REQUESTS` in flight.
+
 use super::types::{FeedKind, Item, SearchResponse};
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
@@ -11,6 +18,11 @@ const ALGOLIA_URL: &str = "https://hn.algolia.com/api/v1/search";
 const CONCURRENT_REQUESTS: usize = 20;
 const CACHE_CAPACITY: usize = 2000;
 
+/// Shared HTTP client for the Hacker News API.
+///
+/// Cheaply [`Clone`]able — both fields are `Arc`-backed — so each spawned
+/// task can take its own handle. Item fetches hit the internal LRU cache
+/// before the network.
 #[derive(Clone)]
 pub struct HnClient {
     client: reqwest::Client,
@@ -18,6 +30,8 @@ pub struct HnClient {
 }
 
 impl HnClient {
+    /// Builds a fresh client with an empty LRU cache of up to
+    /// `CACHE_CAPACITY` items.
     pub fn new() -> Self {
         let capacity = NonZeroUsize::new(CACHE_CAPACITY).expect("cache capacity > 0");
         Self {
@@ -26,18 +40,20 @@ impl HnClient {
         }
     }
 
+    /// Drops every cached item. Called on feed switch and refresh to avoid
+    /// serving stale data.
     pub fn clear_cache(&self) {
         self.cache.lock().unwrap_or_else(|e| e.into_inner()).clear();
     }
 
-    /// Fetch the list of story IDs for a given feed.
+    /// Fetches the list of story IDs for a given feed.
     pub async fn fetch_story_ids(&self, feed: FeedKind) -> Result<Vec<u64>> {
         let url = format!("{}/{}.json", BASE_URL, feed.endpoint());
         let ids: Vec<u64> = self.client.get(&url).send().await?.json().await?;
         Ok(ids)
     }
 
-    /// Fetch a single item by ID (uses cache).
+    /// Fetches a single item by ID, consulting the LRU cache first.
     pub async fn fetch_item(&self, id: u64) -> Result<Option<Item>> {
         // Check cache first
         {
@@ -59,7 +75,10 @@ impl HnClient {
         Ok(item)
     }
 
-    /// Fetch multiple items concurrently (up to CONCURRENT_REQUESTS at a time).
+    /// Fetches multiple items concurrently (up to `CONCURRENT_REQUESTS`
+    /// in flight) and returns them in the order of `ids` — `result[i]`
+    /// corresponds to `ids[i]`, and is `None` when the item was missing
+    /// or its fetch failed.
     pub async fn fetch_items(&self, ids: &[u64]) -> Vec<Option<Item>> {
         let results: Vec<Option<Item>> = stream::iter(ids.iter().copied())
             .map(|id| {
@@ -80,7 +99,7 @@ impl HnClient {
         ids.iter().map(|id| result_map.get(id).cloned()).collect()
     }
 
-    /// Fetch a page of items from a pre-fetched ID list. Used for pagination
+    /// Fetches a page of items from a pre-fetched ID list. Used for pagination
     /// so callers can reuse the initial ID list instead of re-fetching it —
     /// avoiding drift when new stories have been posted since the last fetch.
     pub async fn fetch_items_page(
@@ -103,7 +122,9 @@ impl HnClient {
             .collect())
     }
 
-    /// Fetch stories for a feed: get IDs, then batch fetch a page of items.
+    /// Fetches a page of a feed. Returns `(items, all_ids)` where `all_ids`
+    /// is the complete ID list from the feed endpoint — callers should stash
+    /// it for stable subsequent pagination.
     pub async fn fetch_stories(
         &self,
         feed: FeedKind,
@@ -115,7 +136,11 @@ impl HnClient {
         Ok((items, all_ids))
     }
 
-    /// Search stories via the HN Algolia API.
+    /// Searches stories via the HN Algolia API.
+    ///
+    /// Returns `(stories, total_pages, total_hits)`. `page` is 0-indexed.
+    /// Story [`Item::kids`] is always `None` in results — fetch the full
+    /// item if comment IDs are needed.
     pub async fn search_stories(
         &self,
         query: &str,
@@ -132,7 +157,10 @@ impl HnClient {
         Ok((stories, resp.nb_pages, resp.nb_hits))
     }
 
-    /// Recursively fetch children of a comment, depth-first.
+    /// Walks a comment subtree depth-first, appending `(Item, depth)` into
+    /// `result` for every live descendant up to `max_depth`. Dead/deleted
+    /// comments are skipped. Returns a boxed future so the recursion can
+    /// cross `async` boundaries.
     pub fn fetch_children_recursive<'a>(
         &'a self,
         ids: &'a [u64],
@@ -163,7 +191,9 @@ impl HnClient {
     }
 }
 
-/// Minimal percent-encoding for query parameters.
+/// Percent-encodes a query-string value. Preserves unreserved characters
+/// (`A-Z a-z 0-9 -_.~`), encodes space as `+`, and percent-encodes every
+/// other byte.
 fn url_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,2 +1,10 @@
+//! Hacker News API layer.
+//!
+//! [`client::HnClient`] wraps the Firebase Hacker News API and the Algolia
+//! search endpoint with an LRU item cache and bounded concurrency.
+//! [`types`] defines the wire-level [`types::Item`] / [`types::FeedKind`] /
+//! [`types::SearchHit`] structures and the [`types::StoryBadge`] prefix
+//! classifier used by the UI.
+
 pub mod client;
 pub mod types;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,6 +1,20 @@
+//! Wire types for the Hacker News Firebase API and Algolia search.
+//!
+//! [`Item`] is the unified story/comment/job record used throughout the
+//! app; [`FeedKind`] enumerates the six listing endpoints; [`StoryBadge`]
+//! classifies stories by their title prefix (`Ask HN:`, `Show HN:`, etc.)
+//! or item type. [`SearchHit`]/[`SearchResponse`] decode the Algolia
+//! response and convert into [`Item`] via [`From`].
+
 use serde::Deserialize;
 use std::fmt;
 
+/// A Hacker News item: story, comment, job, or poll.
+///
+/// Most fields are optional because the Firebase API omits unset keys and
+/// deleted items arrive as skeletons. `kids` holds direct-child IDs (comment
+/// replies, or a story's top-level comments); `descendants` is only set on
+/// stories and counts the total transitive comment count.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Item {
     pub id: u64,
@@ -29,14 +43,21 @@ pub struct Item {
 }
 
 impl Item {
+    /// Whether this item was removed by moderators or its author — either
+    /// flag suppresses rendering.
     pub fn is_dead_or_deleted(&self) -> bool {
         self.dead.unwrap_or(false) || self.deleted.unwrap_or(false)
     }
 
+    /// Host component of `url` (with a leading `www.` stripped), or `None`
+    /// for HN-native posts and non-http(s) schemes.
     pub fn domain(&self) -> Option<String> {
         self.url.as_ref().and_then(|u| url_domain(u))
     }
 
+    /// Classifies this item by `item_type` (Job/Poll) or by title prefix
+    /// (`Ask HN:`, `Show HN:`, `Tell HN:`, `Launch HN:`). Returns `None`
+    /// for plain stories. `item_type` takes priority over title prefix.
     pub fn badge(&self) -> Option<StoryBadge> {
         if self.item_type.as_deref() == Some("job") {
             return Some(StoryBadge::Job);
@@ -60,7 +81,7 @@ impl Item {
         None
     }
 
-    /// Title with badge prefix stripped (e.g. "Ask HN: Foo" → "Foo")
+    /// Title with badge prefix stripped (e.g. `"Ask HN: Foo"` → `"Foo"`).
     pub fn display_title(&self) -> &str {
         let title = self.title.as_deref().unwrap_or("[no title]");
         if let Some(rest) = title.strip_prefix("Ask HN:") {
@@ -79,6 +100,8 @@ impl Item {
     }
 }
 
+/// A classification label shown next to a story title. See [`Item::badge`]
+/// for how values are derived.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StoryBadge {
     Ask,
@@ -90,6 +113,7 @@ pub enum StoryBadge {
 }
 
 impl StoryBadge {
+    /// Human-readable label (e.g. `"Ask HN"`, `"Show HN"`) used in the UI.
     pub fn label(self) -> &'static str {
         match self {
             StoryBadge::Ask => "Ask HN",
@@ -104,6 +128,8 @@ impl StoryBadge {
 
 // --- Algolia Search types ---
 
+/// One result entry returned by the Algolia HN search endpoint. Shape
+/// differs from the Firebase [`Item`]; convert via [`From`].
 #[derive(Debug, Deserialize)]
 pub struct SearchHit {
     #[serde(rename = "objectID")]
@@ -117,6 +143,7 @@ pub struct SearchHit {
     pub story_text: Option<String>,
 }
 
+/// Top-level envelope of an Algolia search response.
 #[derive(Debug, Deserialize)]
 pub struct SearchResponse {
     pub hits: Vec<SearchHit>,
@@ -154,6 +181,8 @@ fn url_domain(raw: &str) -> Option<String> {
     Some(host.strip_prefix("www.").unwrap_or(host).to_string())
 }
 
+/// The six Hacker News feeds the app can display; mirrors the Firebase
+/// endpoints exposed via [`FeedKind::endpoint`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeedKind {
     Top,
@@ -165,6 +194,8 @@ pub enum FeedKind {
 }
 
 impl FeedKind {
+    /// Every [`FeedKind`] in display order — indexed by the 1–6 number keys
+    /// and iterated to build the header tab bar.
     pub const ALL: [FeedKind; 6] = [
         FeedKind::Top,
         FeedKind::New,
@@ -174,6 +205,7 @@ impl FeedKind {
         FeedKind::Jobs,
     ];
 
+    /// Firebase path segment (e.g. `"topstories"`) for this feed.
     pub fn endpoint(&self) -> &'static str {
         match self {
             FeedKind::Top => "topstories",

--- a/src/app.rs
+++ b/src/app.rs
@@ -61,9 +61,7 @@ pub enum AppMessage {
     /// spinners.
     CommentsDone,
     /// Article reader content extracted and ready to render.
-    ArticleLoaded {
-        lines: Vec<Vec<StyledFragment>>,
-    },
+    ArticleLoaded { lines: Vec<Vec<StyledFragment>> },
     /// Algolia search returned a page of results.
     SearchResultsLoaded {
         stories: Vec<Item>,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,11 @@
+//! Central application state and event dispatch.
+//!
+//! [`App`] owns every pane's state, the HN client, and an MPSC channel
+//! used by spawned tokio tasks to deliver results back to the main loop
+//! via [`AppMessage`]. [`App::dispatch`] translates [`Action`]s from the
+//! keybinding layer into state mutations and task spawns;
+//! [`App::process_messages`] drains pending async results each frame.
+
 use crate::api::client::HnClient;
 use crate::api::types::{FeedKind, Item};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
@@ -13,6 +21,7 @@ const MIN_PAGE_SIZE: usize = 30;
 const SCROLL_PAGE: usize = 10;
 const MAX_COMMENT_DEPTH: usize = 10;
 
+/// Which content pane currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
     Stories,
@@ -20,14 +29,24 @@ pub enum Pane {
 }
 
 /// Messages sent from async tasks back to the main loop.
+///
+/// Variants correspond to the lifecycle of each async operation: a one-shot
+/// load (`StoriesLoaded`, `SearchResultsLoaded`, `ArticleLoaded`), a
+/// multi-step progressive load (`CommentsLoaded` → zero or more
+/// `CommentsAppended` → `CommentsDone`), or a terminal error (`Error`,
+/// `ArticleError`).
 pub enum AppMessage {
+    /// Initial or paginated batch of stories finished loading.
     StoriesLoaded {
         stories: Vec<Item>,
-        // Only populated on initial load; subsequent paginated loads reuse
-        // the cached ID list to avoid drift when the feed changes mid-session.
+        /// Only populated on initial load; subsequent paginated loads
+        /// reuse the cached ID list to avoid drift when the feed changes
+        /// mid-session.
         all_ids: Option<Vec<u64>>,
         append: bool,
     },
+    /// Root-level comments for a story are available; deeper descendants
+    /// still pending.
     CommentsLoaded {
         story: Box<Item>,
         comments: Vec<(Item, usize)>,
@@ -38,20 +57,32 @@ pub enum AppMessage {
         parent_id: u64,
         children: Vec<(Item, usize)>,
     },
+    /// All outstanding comment fetches finished; clear any "loading"
+    /// spinners.
     CommentsDone,
+    /// Article reader content extracted and ready to render.
     ArticleLoaded {
         lines: Vec<Vec<StyledFragment>>,
     },
+    /// Algolia search returned a page of results.
     SearchResultsLoaded {
         stories: Vec<Item>,
         total_pages: usize,
         total_hits: usize,
         append: bool,
     },
+    /// Article fetch/extract failed; surface in the reader overlay.
     ArticleError(String),
+    /// Generic error to surface in the status bar.
     Error(String),
 }
 
+/// Central application state — owned by the main loop.
+///
+/// Aggregates every pane's state, the shared [`HnClient`], and an MPSC
+/// channel that async tasks use to send [`AppMessage`]s back. All input
+/// flows through [`App::dispatch`]; all async results flow through
+/// [`App::process_messages`].
 pub struct App {
     pub running: bool,
     pub current_feed: FeedKind,
@@ -75,6 +106,8 @@ pub struct App {
 }
 
 impl App {
+    /// Constructs an [`App`] sized to the given terminal dimensions, with
+    /// a fresh HN client, empty state, and a brand-new message channel.
     pub fn new(terminal_width: u16, terminal_height: u16) -> Self {
         let (msg_tx, msg_rx) = mpsc::unbounded_channel();
         Self {
@@ -105,17 +138,21 @@ impl App {
         visible.max(MIN_PAGE_SIZE)
     }
 
+    /// Updates cached terminal dimensions after a resize event.
     pub fn set_terminal_size(&mut self, w: u16, h: u16) {
         self.terminal_width = w;
         self.terminal_height = h;
     }
 
-    /// Initial load on startup.
+    /// Spawns a background fetch for the first page of the current feed.
+    ///
+    /// Intended to be called once at startup; calling it concurrently will
+    /// race two `StoriesLoaded` messages into the channel.
     pub fn load_initial_feed(&self) {
         self.spawn_load_stories(false);
     }
 
-    /// Process any pending async messages (non-blocking).
+    /// Processes any pending async messages (non-blocking).
     pub fn process_messages(&mut self) {
         while let Ok(msg) = self.msg_rx.try_recv() {
             match msg {
@@ -206,7 +243,12 @@ impl App {
         }
     }
 
-    /// Dispatch an action from keybindings.
+    /// Applies an [`Action`] from the keybinding layer.
+    ///
+    /// Routing is context-sensitive: when the article reader is open, a
+    /// restricted set of actions drives the reader and others are consumed.
+    /// Otherwise the action mutates the focused pane's state or spawns an
+    /// async task (feed switch, refresh, comment load, search).
     pub fn dispatch(&mut self, action: Action) {
         // When reader is open, route actions to reader
         if self.reader_state.is_some() {
@@ -362,12 +404,15 @@ impl App {
         }
     }
 
+    /// Transitions into search-input mode, showing an empty search prompt.
     pub fn enter_search_mode(&mut self) {
         self.input_mode = InputMode::SearchInput;
         self.search_state = Some(SearchState::new());
         self.focus = Pane::Stories;
     }
 
+    /// Commits the typed `input` as the active search query and spawns an
+    /// Algolia fetch for page 0. An empty input cancels search instead.
     pub fn submit_search(&mut self) {
         let query = if let Some(ref ss) = self.search_state {
             ss.input.trim().to_string()
@@ -391,6 +436,7 @@ impl App {
         self.spawn_search(&query, 0, false);
     }
 
+    /// Exits search mode, clears the cache, and reloads the current feed.
     pub fn cancel_search(&mut self) {
         self.search_state = None;
         self.input_mode = InputMode::Normal;
@@ -400,18 +446,22 @@ impl App {
         self.spawn_load_stories(false);
     }
 
+    /// Appends a typed character to the in-progress search input.
     pub fn search_input_char(&mut self, c: char) {
         if let Some(ref mut ss) = self.search_state {
             ss.input.push(c);
         }
     }
 
+    /// Removes the last character from the in-progress search input.
     pub fn search_input_backspace(&mut self) {
         if let Some(ref mut ss) = self.search_state {
             ss.input.pop();
         }
     }
 
+    /// Kicks off an async Algolia search. `append = true` extends the
+    /// current result list (lazy pagination); `append = false` replaces it.
     fn spawn_search(&mut self, query: &str, page: usize, append: bool) {
         self.story_state.loading = true;
         let client = self.client.clone();
@@ -436,6 +486,9 @@ impl App {
         });
     }
 
+    /// Kicks off an async feed-page load. When `append` is true, reuses
+    /// the cached ID list to compute a stable offset (so newly posted
+    /// stories don't shift the page); otherwise fetches a fresh ID list.
     fn spawn_load_stories(&self, append: bool) {
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
@@ -484,6 +537,11 @@ impl App {
         }
     }
 
+    /// Kicks off a two-phase comment fetch for the currently selected story:
+    /// (1) loads and displays root-level comments immediately, then
+    /// (2) walks each root's subtree depth-first and appends children via
+    ///     [`AppMessage::CommentsAppended`] as they arrive.
+    /// For search results (kids missing), fetches the full item first.
     fn load_selected_comments(&mut self) {
         if let Some(story) = self.story_state.selected_story().cloned() {
             self.comment_state.loading = true;
@@ -551,6 +609,11 @@ impl App {
         }
     }
 
+    /// Opens the reader overlay for the story in the focused pane.
+    ///
+    /// For text-only posts (Ask HN, etc.) renders the inline `text`
+    /// locally. For URL stories, validates the http(s) scheme and then
+    /// spawns a fetch + readability extraction task.
     fn open_article_reader(&mut self) {
         let story = match self.focus {
             Pane::Stories => self.story_state.selected_story().cloned(),
@@ -602,6 +665,9 @@ impl App {
         });
     }
 
+    /// Opens the focused story's URL in the system browser. Falls back to
+    /// the HN item page for text-only stories. Only http(s) URLs are
+    /// opened.
     fn open_in_browser(&self) {
         let url = match self.focus {
             Pane::Stories => self
@@ -633,6 +699,9 @@ impl App {
         }
     }
 
+    /// If the selection has crossed the lazy-load threshold, kicks off
+    /// the next page. Uses Algolia page-based pagination in search mode
+    /// and offset-based pagination over cached IDs otherwise.
     fn check_lazy_load(&mut self) {
         if self.story_state.loading {
             return;
@@ -653,7 +722,13 @@ impl App {
         }
     }
 
-    /// Handle a mouse left-click at the given terminal position.
+    /// Handles a mouse left-click at the given terminal cell.
+    ///
+    /// Maps the cell to a pane via `build_layout`: in the stories pane,
+    /// selects the clicked story (triggering lazy load + comment fetch);
+    /// in the comments pane, selects the clicked comment, treating a second
+    /// click on the same row within 400ms as a double-click to toggle
+    /// collapse. No-op when the reader overlay is open.
     pub fn handle_click(&mut self, column: u16, row: u16) {
         // When reader is open, consume clicks
         if self.reader_state.is_some() {
@@ -732,7 +807,9 @@ impl App {
         }
     }
 
-    /// Handle mouse scroll in the pane under the cursor.
+    /// Handles a mouse wheel event in the pane under the cursor. When the
+    /// reader overlay is open, scrolls the reader (3 lines per tick);
+    /// otherwise moves the selected item in the hit pane.
     pub fn handle_scroll(&mut self, _column: u16, _row: u16, down: bool) {
         // When reader is open, scroll reader
         if self.reader_state.is_some() {

--- a/src/article.rs
+++ b/src/article.rs
@@ -1,3 +1,10 @@
+//! Article fetching and rendering for the inline reader overlay.
+//!
+//! [`fetch_and_extract_article`] downloads a URL, runs readability
+//! extraction, and returns styled lines ready for rendering. For GitHub
+//! and GitLab repo roots it short-circuits to the raw README. HN-native
+//! text posts (Ask HN, etc.) go through [`html_to_styled_lines`] directly.
+
 use crate::state::reader_state::StyledFragment;
 use crate::ui::theme;
 use html2text::render::RichAnnotation;
@@ -5,8 +12,8 @@ use ratatui::style::{Modifier, Style};
 
 const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024; // 5MB
 
-/// For GitHub/GitLab repo pages, try to fetch the raw README instead of the
-/// JS-heavy HTML shell (the README content is loaded dynamically by JS).
+/// For GitHub/GitLab repo pages, tries to fetch the raw README instead of
+/// the JS-heavy HTML shell (the README content is loaded dynamically by JS).
 async fn try_fetch_readme(client: &reqwest::Client, url: &str) -> Option<(String, bool)> {
     let parsed = url::Url::parse(url).ok()?;
     let host = parsed.host_str()?;
@@ -76,7 +83,11 @@ async fn try_fetch_readme(client: &reqwest::Client, url: &str) -> Option<(String
     None
 }
 
-/// Convert markdown text to styled lines with basic formatting.
+/// Converts markdown text to styled lines with basic formatting.
+///
+/// Handles h1/h2/h3 headings, bullet lists, blockquotes, fenced code
+/// markers, and 4-space/tab indented code blocks. Long lines are
+/// word-wrapped at `width`.
 fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>> {
     let mut lines: Vec<Vec<StyledFragment>> = Vec::new();
 
@@ -181,7 +192,8 @@ fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>
     lines
 }
 
-/// Fetch article HTML, run readability extraction, convert to styled lines.
+/// Fetches article HTML, runs readability extraction, converts to styled
+/// lines.
 pub async fn fetch_and_extract_article(
     url: &str,
     width: usize,
@@ -266,7 +278,8 @@ pub async fn fetch_and_extract_article(
         .map_err(|e| format!("Processing error: {}", e))?
 }
 
-/// Run readability extraction + html2text rich rendering (blocking/CPU-bound).
+/// Runs readability extraction + html2text rich rendering
+/// (blocking/CPU-bound).
 fn extract_article_content(
     html_bytes: &[u8],
     url_str: &str,
@@ -326,7 +339,7 @@ fn extract_article_content(
     Ok(lines)
 }
 
-/// Convert html2text RichAnnotation set to a ratatui Style.
+/// Converts an html2text `RichAnnotation` set to a ratatui [`Style`].
 fn annotations_to_style(annotations: &[RichAnnotation]) -> Style {
     let mut style = Style::default().fg(theme::TEXT);
 
@@ -357,7 +370,7 @@ fn annotations_to_style(annotations: &[RichAnnotation]) -> Style {
     style
 }
 
-/// Convert raw HTML bytes to styled lines using html2text rich rendering.
+/// Converts raw HTML bytes to styled lines using html2text rich rendering.
 pub fn html_to_styled_lines(html: &[u8], width: usize) -> Vec<Vec<StyledFragment>> {
     let tagged_lines = html2text::from_read_rich(html, width).unwrap_or_default();
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,19 @@
+//! Terminal event plumbing.
+//!
+//! [`EventHandler`] spawns a background tokio task that multiplexes
+//! crossterm input events and a fixed-rate tick timer onto a single
+//! MPSC channel. The main loop `.await`s [`EventHandler::next`] for a
+//! unified [`Event`] stream.
+
 use anyhow::Result;
 use crossterm::event::{Event as CrosstermEvent, EventStream, KeyEvent, MouseEvent};
 use futures::StreamExt;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+/// Unified event stream delivered by [`EventHandler`]: terminal input
+/// forwarded from crossterm, plus periodic [`Event::Tick`]s for animation
+/// (e.g. the loading spinner).
 #[derive(Debug)]
 pub enum Event {
     Key(KeyEvent),
@@ -12,12 +22,18 @@ pub enum Event {
     Tick,
 }
 
+/// Background event pump. Constructed with a tick rate; exposes
+/// [`EventHandler::next`] to `.await` the next [`Event`].
 pub struct EventHandler {
     rx: mpsc::UnboundedReceiver<Event>,
     _tx: mpsc::UnboundedSender<Event>,
 }
 
 impl EventHandler {
+    /// Spawns the background input/tick task and returns a handle.
+    ///
+    /// The task runs until the channel is dropped or the crossterm stream
+    /// errors/ends. Ticks fire every `tick_rate`.
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let _tx = tx.clone();
@@ -52,6 +68,8 @@ impl EventHandler {
         Self { rx, _tx }
     }
 
+    /// Awaits the next [`Event`]. Returns an error if the channel closes,
+    /// which means the background task has terminated.
     pub async fn next(&mut self) -> Result<Event> {
         self.rx
             .recv()

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,11 +1,24 @@
+//! Keybinding → [`Action`] translation.
+//!
+//! [`map_key`] is a pure, context-aware dispatch: search-input mode
+//! suppresses normal keys, the help overlay eats any keypress, and
+//! the reader overlay has its own reduced map. The [`InputMode`] enum
+//! distinguishes character-capturing search input from normal navigation.
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+/// Whether the keyboard is in normal-navigation mode or accumulating
+/// characters for the search-query input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     Normal,
     SearchInput,
 }
 
+/// A keybinding-independent operation the app may perform.
+///
+/// Produced by [`map_key`] from raw [`KeyEvent`]s, consumed by
+/// [`crate::app::App::dispatch`]. `Action::None` means "unmapped — ignore."
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     Quit,
@@ -27,6 +40,14 @@ pub enum Action {
     None,
 }
 
+/// Translates a [`KeyEvent`] into an [`Action`] for the current UI
+/// context.
+///
+/// Priority order: search-input mode suppresses normal keys (returns
+/// [`Action::None`] so `main.rs` can handle raw characters); a visible
+/// help overlay consumes any key as [`Action::ToggleHelp`]; a visible
+/// reader overlay uses its own reduced keymap; otherwise the standard
+/// navigation keymap applies.
 pub fn map_key(
     key: KeyEvent,
     help_visible: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+//! `hnt` — a terminal Hacker News reader built on ratatui + tokio.
+//!
+//! Two-pane layout (stories/comments) with an overlay article reader,
+//! Algolia-backed search, and progressive comment-tree fetching.
+
 mod api;
 mod app;
 mod article;

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -1,6 +1,18 @@
+//! Comment-tree state: a flattened list with depth, collapse tracking,
+//! and an incremental-insertion API for progressive loads.
+//!
+//! Comments are stored as a pre-order flat [`Vec`] of [`FlatComment`]
+//! (item + depth); [`CommentTreeState::visible_indices`] applies collapse
+//! rules by skipping subtrees. [`CommentTreeState::insert_children`]
+//! splices a root's children in-place as async fetches complete.
+
 use crate::api::types::Item;
 use std::collections::HashSet;
 
+/// One comment in the flattened, depth-tagged comment tree.
+///
+/// `depth == 0` is a root-level comment; children have strictly greater
+/// depth and are stored contiguously after their parent in pre-order.
 pub struct FlatComment {
     pub item: Item,
     pub depth: usize,
@@ -10,6 +22,7 @@ pub struct FlatComment {
 }
 
 impl FlatComment {
+    /// Wraps an [`Item`] at the given tree depth with an empty text cache.
     pub fn new(item: Item, depth: usize) -> Self {
         Self {
             item,
@@ -19,7 +32,8 @@ impl FlatComment {
     }
 
     /// Returns the plain-text rendering of `item.text` at `width`, reusing
-    /// the last-rendered result if the width matches.
+    /// the last-rendered result if the width matches. The cache is keyed
+    /// only on width because each `FlatComment` wraps a single `Item`.
     pub fn plain_text(&mut self, width: usize) -> Option<&str> {
         let text = self.item.text.as_deref()?;
         let needs_refresh = !matches!(&self.plain_text_cache, Some((w, _)) if *w == width);
@@ -31,11 +45,20 @@ impl FlatComment {
     }
 }
 
+/// State for the comments pane: flattened tree, collapse set, selection,
+/// and render-populated scroll/row-map.
+///
+/// [`CommentTreeState::set_comments`] replaces the tree;
+/// [`CommentTreeState::insert_children`] splices in subtrees as progressive
+/// loads complete.
 pub struct CommentTreeState {
     pub comments: Vec<FlatComment>,
     /// Row-based scroll offset, updated by the renderer.
     pub scroll: usize,
+    /// Index into `visible_comments()`, not into `comments`.
     pub selected: usize,
+    /// Collapsed-subtree comment IDs; their descendants are hidden from
+    /// `visible_comments()`.
     pub collapsed: HashSet<u64>,
     pub loading: bool,
     pub story: Option<Item>,
@@ -50,6 +73,7 @@ pub struct CommentTreeState {
 }
 
 impl CommentTreeState {
+    /// Constructs an empty state with no loaded story and no pending fetches.
     pub fn new() -> Self {
         Self {
             comments: Vec::new(),
@@ -64,8 +88,9 @@ impl CommentTreeState {
         }
     }
 
-    /// Return the plain-text rendering of the current story's text at `width`,
-    /// reusing the last-rendered result if the story and width match.
+    /// Returns the plain-text rendering of the current story's text at
+    /// `width`, reusing the last-rendered result if the story and width
+    /// match.
     pub fn story_plain_text(&mut self, width: usize) -> Option<&str> {
         let story = self.story.as_ref()?;
         let text = story.text.as_deref()?;
@@ -79,6 +104,8 @@ impl CommentTreeState {
         self.story_text_cache.as_ref().map(|(_, _, s)| s.as_str())
     }
 
+    /// Replaces the flat list and resets selection/scroll to the top.
+    /// Each tuple is `(item, depth)` in pre-order.
     pub fn set_comments(&mut self, items: Vec<(Item, usize)>) {
         self.comments = items
             .into_iter()
@@ -127,6 +154,8 @@ impl CommentTreeState {
         indices
     }
 
+    /// Resolves [`visible_indices`](Self::visible_indices) into borrowed
+    /// comment references.
     pub fn visible_comments(&self) -> Vec<&FlatComment> {
         self.visible_indices()
             .into_iter()
@@ -168,6 +197,8 @@ impl CommentTreeState {
         self.selected = self.selected.saturating_sub(page_size);
     }
 
+    /// Flips the collapse state of the currently selected comment.
+    /// Collapsing hides the subtree on the next `visible_indices` call.
     pub fn toggle_collapse(&mut self) {
         let visible = self.visible_comments();
         if let Some(comment) = visible.get(self.selected) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,11 @@
+//! Application state containers, separated by UI concern.
+//!
+//! Each submodule owns a single pane's state and its navigation/mutation
+//! methods: [`story_state::StoryListState`] for the left pane,
+//! [`comment_state::CommentTreeState`] for the comment tree (with collapse
+//! and plain-text caching), [`reader_state::ReaderState`] for the article
+//! overlay, and [`search_state::SearchState`] for the Algolia search flow.
+
 pub mod comment_state;
 pub mod reader_state;
 pub mod search_state;

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -1,10 +1,21 @@
+//! Article-reader overlay state.
+//!
+//! [`ReaderState`] tracks the pre-rendered [`StyledFragment`] lines,
+//! scroll position, and loading/error status for an article fetched via
+//! `crate::article`. [`StyledFragment`] is the shared line-fragment type
+//! used by both article extraction and HTML comment rendering.
+
 use ratatui::style::Style;
 
+/// A run of text sharing one ratatui [`Style`]. Multiple fragments compose
+/// one rendered line (see `Vec<Vec<StyledFragment>>`).
 pub struct StyledFragment {
     pub text: String,
     pub style: Style,
 }
 
+/// Article-reader overlay state: title/domain chrome, pre-rendered styled
+/// lines, scroll position, and loading/error status.
 pub struct ReaderState {
     pub title: String,
     pub domain: Option<String>,
@@ -16,6 +27,9 @@ pub struct ReaderState {
 }
 
 impl ReaderState {
+    /// Starts in the loading state; the overlay renders a placeholder until
+    /// [`set_content`](Self::set_content) or [`set_error`](Self::set_error)
+    /// is called.
     pub fn new_loading(title: String, domain: Option<String>, url: Option<String>) -> Self {
         Self {
             title,
@@ -28,6 +42,8 @@ impl ReaderState {
         }
     }
 
+    /// Installs loaded content, clears the loading flag and any prior
+    /// error, and resets scroll to the top.
     pub fn set_content(&mut self, lines: Vec<Vec<StyledFragment>>) {
         self.lines = lines;
         self.loading = false;
@@ -35,6 +51,7 @@ impl ReaderState {
         self.scroll = 0;
     }
 
+    /// Transitions from loading to error state with the given message.
     pub fn set_error(&mut self, msg: String) {
         self.error = Some(msg);
         self.loading = false;
@@ -65,6 +82,8 @@ impl ReaderState {
         self.scroll = self.max_scroll();
     }
 
+    /// Position as a percentage of `max_scroll`, clamped 0..=100. Returns
+    /// 100 when the content is empty or fits on one line.
     pub fn scroll_percent(&self) -> u16 {
         let max = self.max_scroll();
         if max == 0 {

--- a/src/state/search_state.rs
+++ b/src/state/search_state.rs
@@ -1,3 +1,14 @@
+//! Algolia-search UI state.
+//!
+//! Separates the in-progress typed `input` from the submitted `query`
+//! so pagination (`current_page` / `total_pages`) anchors to the
+//! submitted value, not whatever the user is currently typing.
+
+/// State for an active Algolia search.
+///
+/// `input` is the in-progress typed text; `query` is the submitted
+/// (committed) query — the two differ while the user is editing, which is
+/// why pagination anchors to `query`.
 pub struct SearchState {
     pub query: String,
     pub input: String,
@@ -7,6 +18,7 @@ pub struct SearchState {
 }
 
 impl SearchState {
+    /// Starts with empty input/query and zeroed pagination.
     pub fn new() -> Self {
         Self {
             query: String::new(),

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -1,5 +1,17 @@
+//! State for the left-hand story list pane.
+//!
+//! Holds the loaded [`Item`]s, the full ID list from the initial feed
+//! fetch (used to compute stable pagination offsets), selection index,
+//! and the loading flag. [`StoryListState::needs_more`] drives lazy
+//! pagination when the cursor approaches the end.
+
 use crate::api::types::Item;
 
+/// State for the story-list pane.
+///
+/// `stories` is the currently loaded window; `all_ids` is the full ID list
+/// from the initial feed fetch, used as a stable index for pagination so
+/// appended pages don't drift when new stories are posted mid-session.
 pub struct StoryListState {
     pub stories: Vec<Item>,
     pub all_ids: Vec<u64>,
@@ -53,6 +65,8 @@ impl StoryListState {
         self.stories.get(self.selected)
     }
 
+    /// Whether the selected story is within 80% of the loaded window and
+    /// more IDs remain to be fetched — signals lazy-pagination time.
     pub fn needs_more(&self) -> bool {
         // Load more when within 80% of loaded stories
         if self.stories.is_empty() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,9 @@
+//! Terminal lifecycle: enter/leave alternate screen, raw mode, mouse capture.
+//!
+//! [`init`] and [`restore`] bracket the app's runtime; [`install_panic_hook`]
+//! ensures the terminal is restored even on panic so the user's shell
+//! isn't left in raw mode.
+
 use anyhow::Result;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
@@ -7,8 +13,11 @@ use crossterm::{
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io::{self, Stdout};
 
+/// Concrete ratatui terminal type used by the app.
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
+/// Enters raw mode, switches to the alternate screen, and enables mouse
+/// capture; returns a ready-to-draw [`Tui`].
 pub fn init() -> Result<Tui> {
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
@@ -17,13 +26,15 @@ pub fn init() -> Result<Tui> {
     Ok(terminal)
 }
 
+/// Undoes [`init`]: disables raw mode, leaves the alternate screen, and
+/// disables mouse capture. Safe to call from a panic hook.
 pub fn restore() -> Result<()> {
     disable_raw_mode()?;
     execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
     Ok(())
 }
 
-/// Install a panic hook that restores the terminal before panicking.
+/// Installs a panic hook that restores the terminal before panicking.
 pub fn install_panic_hook() {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -1,3 +1,9 @@
+//! Full-screen article-reader overlay rendering.
+//!
+//! [`render_article_overlay`] dispatches to loading, error, or content
+//! renderers based on [`ReaderState`]. Content is drawn as wrapped
+//! styled lines with a title, domain, and keybinding footer.
+
 use crate::state::reader_state::ReaderState;
 use crate::ui::theme;
 use ratatui::{
@@ -7,6 +13,9 @@ use ratatui::{
     Frame,
 };
 
+/// Draws the full-screen reader overlay for `reader`'s current state
+/// (loading, error, or content) into `area` with a small margin. No-op if
+/// the available space is too small.
 pub fn render_article_overlay(frame: &mut Frame, area: Rect, reader: &ReaderState) {
     // Fullscreen overlay with 2-cell margin on each side
     let margin = 2u16;

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -1,3 +1,11 @@
+//! Comment tree widget — renders the right-hand pane.
+//!
+//! Two-pass rendering: `measure_comments` produces per-comment line lists
+//! (header + wrapped text + gap), then the widget scrolls to keep the
+//! selected comment in view and draws from the computed offset. Also
+//! populates `CommentTreeState::row_map` so mouse clicks can map rows
+//! back to comment indices.
+
 use crate::state::comment_state::{CommentTreeState, FlatComment};
 use crate::ui::spinner;
 use crate::ui::story_list::format_time_ago;
@@ -9,6 +17,9 @@ use ratatui::{
     widgets::{Block, Borders, Widget},
 };
 
+/// Stateless widget that renders the right pane. Takes a mutable reference
+/// to [`CommentTreeState`] because rendering populates the `row_map` and
+/// may advance `scroll` to keep the selected comment visible.
 pub struct CommentTree<'a> {
     pub state: &'a mut CommentTreeState,
     pub visible: &'a [usize],
@@ -22,6 +33,9 @@ struct MeasuredComment {
     lines: Vec<CommentLine>,
 }
 
+/// One rendered line in the measure pass. `Header` is the author/time
+/// line, `Text` is a single wrapped body line, `Gap` is a blank row
+/// between comments.
 enum CommentLine {
     Header(Vec<(String, ratatui::style::Style)>),
     Text(Vec<(String, ratatui::style::Style)>),
@@ -296,7 +310,10 @@ impl<'a> Widget for CommentTree<'a> {
     }
 }
 
-/// Measure all visible comments into pre-computed line lists.
+/// Pre-renders each visible comment to a [`MeasuredComment`] (header line,
+/// wrapped body lines capped at 20, trailing gap). Collapsed comments omit
+/// body lines and render a `[+] (N hidden)` suffix. Root comments still
+/// fetching children get a spinner glyph.
 fn measure_comments(
     visible_indices: &[usize],
     collapsed: &std::collections::HashSet<u64>,
@@ -401,6 +418,8 @@ fn measure_comments(
     result
 }
 
+/// Counts descendants of `parent` in the flat list — the contiguous run
+/// of comments with strictly greater depth that follow it.
 fn count_hidden_children(all: &[FlatComment], parent: &FlatComment) -> usize {
     let parent_idx = all.iter().position(|c| c.item.id == parent.item.id);
     match parent_idx {

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,3 +1,5 @@
+//! Top header bar: app brand, feed tabs, and search-mode indicator.
+
 use crate::api::types::FeedKind;
 use crate::ui::theme;
 use ratatui::{
@@ -7,6 +9,8 @@ use ratatui::{
     widgets::Widget,
 };
 
+/// Top header: brand, feed tabs (highlighting `current_feed` unless a
+/// search is active), and a "Search" chip when `search_active`.
 pub struct Header {
     pub current_feed: FeedKind,
     pub search_active: bool,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,5 +1,15 @@
+//! Top-level terminal layout: header, two content panes, status bar.
+//!
+//! Produces an [`AppLayout`] with fixed 1-row header and status rows
+//! and a 35/65 horizontal split for stories/comments. Shared by
+//! `ui::render` and by click/scroll hit-testing in `app.rs`.
+
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
+/// Rects for the four top-level regions of the screen, in draw order
+/// top-to-bottom: [`header`](Self::header),
+/// [`stories`](Self::stories) / [`comments`](Self::comments) side-by-side,
+/// [`status`](Self::status).
 pub struct AppLayout {
     pub header: Rect,
     pub stories: Rect,
@@ -7,6 +17,8 @@ pub struct AppLayout {
     pub status: Rect,
 }
 
+/// Splits `area` into header/body/status (1/flex/1 rows), then splits the
+/// body 35/65 into stories/comments.
 pub fn build_layout(area: Rect) -> AppLayout {
     let outer = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,10 @@
+//! Terminal UI widgets and top-level frame renderer.
+//!
+//! [`render`] composes one ratatui frame from [`App`] state: header tab bar,
+//! story list, comment tree, status bar, plus the help and article-reader
+//! overlays when active. Submodules expose individual widgets and the
+//! shared [`theme`] palette.
+
 pub mod article_reader;
 pub mod comment_tree;
 pub mod header;

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -1,3 +1,8 @@
+//! Loading-spinner frame generator.
+//!
+//! [`frame`] maps a monotonic tick count to one of six braille glyphs,
+//! reusing a single `indicatif::ProgressStyle` via [`OnceLock`].
+
 use indicatif::ProgressStyle;
 use std::sync::OnceLock;
 
@@ -8,6 +13,8 @@ fn style() -> &'static ProgressStyle {
     STYLE.get_or_init(|| ProgressStyle::default_spinner().tick_strings(FRAMES))
 }
 
+/// Picks the braille spinner glyph for this tick. Safe to call every
+/// frame — the [`ProgressStyle`] is built once via [`OnceLock`].
 pub fn frame(tick: u64) -> &'static str {
     style().get_tick_str(tick)
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,3 +1,8 @@
+//! Bottom status bar: mode indicator, keybinding hint, position counter.
+//!
+//! Renders three visual modes — search-input prompt, search-results
+//! banner, and normal — plus a right-aligned `N/total [Pane]` counter.
+
 use crate::api::types::FeedKind;
 use crate::keys::InputMode;
 use crate::ui::theme;
@@ -8,6 +13,9 @@ use ratatui::{
     widgets::Widget,
 };
 
+/// Bottom status bar. Display mode depends on `input_mode` and
+/// `search_query`: a `/` prompt during input, a search-results banner
+/// while search results are shown, or the normal feed/hint line.
 pub struct StatusBar {
     pub feed: FeedKind,
     pub position: String,

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -1,3 +1,10 @@
+//! Story-list widget for the left pane.
+//!
+//! [`StoryList`] renders numbered story rows with badge, title, and
+//! domain, scrolling to keep the selected row in view. Also exposes
+//! [`format_time_ago`], used by the comment-tree widget for author
+//! timestamps.
+
 use crate::api::types::Item;
 use crate::ui::theme;
 use ratatui::{
@@ -7,6 +14,8 @@ use ratatui::{
     widgets::{Block, Borders, Widget},
 };
 
+/// Stateless widget that renders the left pane. Composed from borrowed
+/// app state; rebuilt each frame.
 pub struct StoryList<'a> {
     pub stories: &'a [Item],
     pub selected: usize,
@@ -142,6 +151,8 @@ impl<'a> Widget for StoryList<'a> {
     }
 }
 
+/// Renders a Unix timestamp as `"Ns"`/`"Nm"`/`"Nh"`/`"Nd"` relative to
+/// the current wall-clock time.
 pub fn format_time_ago(timestamp: i64) -> String {
     format_time_ago_since(timestamp, chrono::Utc::now().timestamp())
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,12 @@
+//! Catppuccin Mocha-inspired color palette and ratatui [`Style`] helpers.
+//!
+//! Exposes named [`Color`] constants for base, accent, and semantic
+//! (status/metadata/badge) uses, plus `*_style()` constructors that pair
+//! foreground + background for a widget context. [`depth_color`] cycles
+//! through [`DEPTH_COLORS`] for comment indentation.
+
 use ratatui::style::{Color, Modifier, Style};
 
-// Catppuccin Mocha-inspired dark theme with HN orange accent
 pub const BG: Color = Color::Rgb(30, 30, 46);
 pub const SURFACE: Color = Color::Rgb(49, 50, 68);
 #[allow(dead_code)]
@@ -17,13 +23,15 @@ pub const MAUVE: Color = Color::Rgb(203, 166, 247);
 pub const TEAL: Color = Color::Rgb(148, 226, 213);
 pub const PEACH: Color = Color::Rgb(250, 179, 135);
 
-/// Colors for comment depth levels (cycles through these)
+/// Colors for comment depth levels (cycles through these).
 pub const DEPTH_COLORS: [Color; 6] = [HN_ORANGE, BLUE, GREEN, MAUVE, TEAL, PEACH];
 
+/// Default foreground on the base background — body text.
 pub fn base_style() -> Style {
     Style::default().fg(TEXT).bg(BG)
 }
 
+/// Highlighted row: base fg on surface bg, bold.
 pub fn selected_style() -> Style {
     Style::default()
         .fg(TEXT)
@@ -31,30 +39,37 @@ pub fn selected_style() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
+/// HN-orange bold for widget titles.
 pub fn title_style() -> Style {
     Style::default().fg(HN_ORANGE).add_modifier(Modifier::BOLD)
 }
 
+/// Default header-bar style: body fg on surface bg.
 pub fn header_style() -> Style {
     Style::default().fg(TEXT).bg(SURFACE)
 }
 
+/// Default status-bar style: muted fg on surface bg.
 pub fn status_style() -> Style {
     Style::default().fg(SUBTEXT).bg(SURFACE)
 }
 
+/// HN-orange foreground — brand accents.
 pub fn accent_style() -> Style {
     Style::default().fg(HN_ORANGE)
 }
 
+/// Dimmed foreground — hints and secondary text.
 pub fn dim_style() -> Style {
     Style::default().fg(DIM)
 }
 
+/// Secondary foreground — author/score metadata.
 pub fn meta_style() -> Style {
     Style::default().fg(SUBTEXT)
 }
 
+/// Selected feed-tab: bg swapped with HN-orange, bold.
 pub fn active_tab_style() -> Style {
     Style::default()
         .fg(BG)
@@ -62,14 +77,19 @@ pub fn active_tab_style() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
+/// Unselected feed-tab: muted fg on surface bg.
 pub fn inactive_tab_style() -> Style {
     Style::default().fg(SUBTEXT).bg(SURFACE)
 }
 
+/// Wraps `depth` modulo 6 into [`DEPTH_COLORS`]; used to color comment
+/// indentation bars so nested replies are visually distinct.
 pub fn depth_color(depth: usize) -> Color {
     DEPTH_COLORS[depth % DEPTH_COLORS.len()]
 }
 
+/// Bold badge color on the surface background — one color per
+/// [`StoryBadge`](crate::api::types::StoryBadge) variant.
 pub fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
     use crate::api::types::StoryBadge;
     let color = match badge {


### PR DESCRIPTION
## Summary

- Adds module-level `//!` docs to all 23 source files and `///` docs to cross-module `pub` types, constructors, and primary methods (~55 items).
- Fixes drift/clarity gaps in existing docs: `fetch_items` order-preservation, `fetch_stories`/`search_stories` return tuples, `dispatch` reader-first routing, `AppMessage` variant parity, `CommentTreeState` field semantics.
- Normalizes imperative-mood summaries to third-person indicative per RFC 1574.
- Also includes the pre-existing v0.3.8 version bump commit (`d54eb3c`).

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo doc --no-deps` — no warnings, no broken intra-doc links
- [x] `cargo test` — 148/148 pass
- [ ] Skim rendered docs locally with `cargo doc --open` before merging