### PR TITLE
Add prior-discussions overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Browse stories, read threaded comments, and open links — all from your termina
 - **Vim-style navigation** — `j`/`k`, `g`/`G`, `Ctrl+d`/`Ctrl+u`
 - **Search** — Algolia-powered full-text search across stories
 - **Reader mode** — Read article content directly in the terminal
+- **Prior discussions** — Press `h` to see past HN submissions of the same URL with their scores and dates
 - **Open in browser** — Press `o` to open the story URL
 - **Progressive loading** — Root comments appear instantly, children load in the background
 - **Lazy pagination** — Stories load automatically as you scroll
@@ -66,6 +67,7 @@ cargo build --release
 | `Enter` | Select story / toggle collapse |
 | `o` | Open URL in browser |
 | `p` | Open reader mode |
+| `h` | Show prior HN submissions of this URL |
 | `/` | Search stories |
 | `Tab` | Switch pane focus |
 | `1`-`6` | Switch feed (Top/New/Best/Ask/Show/Jobs) |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -136,6 +136,40 @@ impl HnClient {
         Ok((items, all_ids))
     }
 
+    /// Finds prior HN submissions of the same URL.
+    ///
+    /// Queries Algolia with a scheme-stripped form of the URL (which gets
+    /// tokenized against the indexed `url` field), then filters client-side
+    /// to exact URL matches after normalization (lowercased host, stripped
+    /// `www.` and trailing slash, scheme-insensitive). Returns up to 50
+    /// matches, most-recent first by Algolia default.
+    ///
+    /// Empty result is not an error — a novel URL legitimately has no prior
+    /// submissions.
+    pub async fn search_by_url(&self, url: &str) -> Result<Vec<Item>> {
+        let target = normalize_url(url);
+        if target.is_empty() {
+            return Ok(Vec::new());
+        }
+        let encoded = url_encode(&target);
+        let api = format!(
+            "{}?query={}&tags=story&hitsPerPage=50",
+            ALGOLIA_URL, encoded
+        );
+        let resp: SearchResponse = self.client.get(&api).send().await?.json().await?;
+        Ok(resp
+            .hits
+            .into_iter()
+            .map(Item::from)
+            .filter(|item| {
+                item.url
+                    .as_deref()
+                    .map(normalize_url)
+                    .is_some_and(|n| n == target)
+            })
+            .collect())
+    }
+
     /// Searches stories via the HN Algolia API.
     ///
     /// Returns `(stories, total_pages, total_hits)`. `page` is 0-indexed.
@@ -191,6 +225,29 @@ impl HnClient {
     }
 }
 
+/// Normalizes a URL for cross-submission comparison.
+///
+/// Lowercases the host, strips a leading `www.`, drops the scheme, strips
+/// a trailing slash, and drops the fragment. Preserves the query string
+/// because different query strings usually represent different resources.
+/// Returns the original input unchanged if it doesn't parse as a URL.
+fn normalize_url(u: &str) -> String {
+    let Ok(parsed) = url::Url::parse(u) else {
+        return u.to_string();
+    };
+    let Some(host) = parsed.host_str() else {
+        return u.to_string();
+    };
+    let host_lower = host.to_lowercase();
+    let host = host_lower.strip_prefix("www.").unwrap_or(&host_lower);
+    let path = parsed.path().trim_end_matches('/');
+    let query = parsed
+        .query()
+        .map(|q| format!("?{}", q))
+        .unwrap_or_default();
+    format!("{}{}{}", host, path, query)
+}
+
 /// Percent-encodes a query-string value. Preserves unreserved characters
 /// (`A-Z a-z 0-9 -_.~`), encodes space as `+`, and percent-encodes every
 /// other byte.
@@ -215,6 +272,77 @@ fn url_encode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- normalize_url ---
+
+    #[test]
+    fn normalize_url_strips_scheme() {
+        assert_eq!(
+            normalize_url("https://example.com/path"),
+            "example.com/path"
+        );
+        assert_eq!(normalize_url("http://example.com/path"), "example.com/path");
+    }
+
+    #[test]
+    fn normalize_url_strips_www() {
+        assert_eq!(
+            normalize_url("https://www.example.com/path"),
+            "example.com/path"
+        );
+    }
+
+    #[test]
+    fn normalize_url_strips_trailing_slash() {
+        assert_eq!(normalize_url("https://example.com/foo/"), "example.com/foo");
+        assert_eq!(normalize_url("https://example.com/"), "example.com");
+    }
+
+    #[test]
+    fn normalize_url_lowercases_host_preserves_path_case() {
+        assert_eq!(
+            normalize_url("https://EXAMPLE.com/Rust-1.0.html"),
+            "example.com/Rust-1.0.html"
+        );
+    }
+
+    #[test]
+    fn normalize_url_preserves_query() {
+        assert_eq!(
+            normalize_url("https://example.com/search?q=foo"),
+            "example.com/search?q=foo"
+        );
+    }
+
+    #[test]
+    fn normalize_url_drops_fragment() {
+        assert_eq!(
+            normalize_url("https://example.com/foo#section"),
+            "example.com/foo"
+        );
+    }
+
+    #[test]
+    fn normalize_url_invalid_returns_input() {
+        assert_eq!(normalize_url("not a url"), "not a url");
+    }
+
+    #[test]
+    fn normalize_url_http_and_https_collapse() {
+        assert_eq!(
+            normalize_url("http://example.com/foo"),
+            normalize_url("https://www.example.com/foo/")
+        );
+    }
+
+    #[test]
+    fn normalize_url_empty_host_returns_input() {
+        // file:// URLs have no host — treat as unnormalizable to avoid
+        // false-positive cross-submission matches.
+        assert_eq!(normalize_url("file:///tmp/foo"), "file:///tmp/foo");
+    }
+
+    // --- url_encode ---
 
     #[test]
     fn url_encode_space() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,10 +11,11 @@ use crate::api::types::{FeedKind, Item};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::keys::{Action, InputMode};
 use crate::state::comment_state::CommentTreeState;
+use crate::state::prior_state::PriorDiscussionsState;
 use crate::state::reader_state::{ReaderState, StyledFragment};
 use crate::state::search_state::SearchState;
 use crate::state::story_state::StoryListState;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 
 const MIN_PAGE_SIZE: usize = 30;
@@ -73,6 +74,13 @@ pub enum AppMessage {
     ArticleError(String),
     /// Generic error to surface in the status bar.
     Error(String),
+    /// Algolia returned prior HN submissions of the selected story's URL.
+    /// `story_id` is the story that triggered the query — used to drop
+    /// results whose story has since been deselected.
+    PriorDiscussionsLoaded {
+        story_id: u64,
+        submissions: Vec<Item>,
+    },
 }
 
 /// Central application state — owned by the main loop.
@@ -95,6 +103,17 @@ pub struct App {
     pub terminal_height: u16,
     pub terminal_width: u16,
     pub tick_count: u64,
+
+    /// Prior-discussions overlay state. `Some` while the overlay is open;
+    /// `None` otherwise. Contents are populated from `prior_results` when
+    /// the user presses `h`.
+    pub prior_state: Option<PriorDiscussionsState>,
+    /// Prior-submissions query results, keyed by the story ID that was
+    /// queried. Keeps each result around for the rest of the session so
+    /// reopening the `h` overlay doesn't trigger a refetch.
+    pub prior_results: HashMap<u64, Vec<Item>>,
+    /// Story IDs whose URL queries are in flight. Prevents duplicate spawns.
+    prior_in_flight: HashSet<u64>,
 
     last_comment_click: Option<(std::time::Instant, usize)>,
 
@@ -122,6 +141,9 @@ impl App {
             terminal_height,
             terminal_width,
             tick_count: 0,
+            prior_state: None,
+            prior_results: HashMap::new(),
+            prior_in_flight: HashSet::new(),
             last_comment_click: None,
             client: HnClient::new(),
             msg_tx,
@@ -237,6 +259,21 @@ impl App {
                     self.story_state.loading = false;
                     self.comment_state.loading = false;
                 }
+                AppMessage::PriorDiscussionsLoaded {
+                    story_id,
+                    submissions,
+                } => {
+                    self.prior_in_flight.remove(&story_id);
+                    // If the user has already opened the overlay for this
+                    // same story, backfill its contents now that we have data.
+                    if let Some(ref mut ps) = self.prior_state {
+                        if ps.story_id == story_id && ps.submissions.is_empty() {
+                            ps.submissions = submissions.clone();
+                            ps.selected = 0;
+                        }
+                    }
+                    self.prior_results.insert(story_id, submissions);
+                }
             }
         }
     }
@@ -304,6 +341,60 @@ impl App {
                     return;
                 }
                 _ => return, // Consume all other keys
+            }
+        }
+
+        // When the prior-discussions overlay is open, route a reduced action
+        // set and consume everything else.
+        if self.prior_state.is_some() {
+            match action {
+                Action::Back => {
+                    self.prior_state = None;
+                    return;
+                }
+                Action::MoveDown => {
+                    if let Some(ref mut p) = self.prior_state {
+                        p.select_next();
+                    }
+                    return;
+                }
+                Action::MoveUp => {
+                    if let Some(ref mut p) = self.prior_state {
+                        p.select_prev();
+                    }
+                    return;
+                }
+                Action::JumpTop => {
+                    if let Some(ref mut p) = self.prior_state {
+                        p.jump_top();
+                    }
+                    return;
+                }
+                Action::JumpBottom => {
+                    if let Some(ref mut p) = self.prior_state {
+                        p.jump_bottom();
+                    }
+                    return;
+                }
+                Action::Select => {
+                    self.open_selected_prior_discussion();
+                    return;
+                }
+                Action::OpenInBrowser => {
+                    if let Some(ref p) = self.prior_state {
+                        if let Some(item) = p.selected_submission() {
+                            if let Some(ref url) = item.url {
+                                if let Ok(parsed) = url::Url::parse(url) {
+                                    if parsed.scheme() == "http" || parsed.scheme() == "https" {
+                                        let _ = open::that(parsed.as_str());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return;
+                }
+                _ => return,
             }
         }
 
@@ -398,8 +489,100 @@ impl App {
                 Pane::Comments => self.comment_state.page_up(SCROLL_PAGE),
             },
             Action::ToggleHelp => self.show_help = !self.show_help,
+            Action::TogglePriorDiscussions => self.toggle_prior_discussions(),
             Action::None => {}
         }
+    }
+
+    /// Opens the prior-discussions overlay for the story whose comments are
+    /// currently loaded, using cached results from [`App::prior_results`].
+    /// No-op if no comments-loaded story has a URL-based query result. Opens
+    /// an empty-state overlay if a query returned zero prior submissions.
+    fn toggle_prior_discussions(&mut self) {
+        if self.prior_state.is_some() {
+            self.prior_state = None;
+            return;
+        }
+        let Some(story) = self.comment_state.story.as_ref() else {
+            return;
+        };
+        let story_id = story.id;
+        if let Some(submissions) = self.prior_results.get(&story_id) {
+            self.prior_state = Some(PriorDiscussionsState::new(story_id, submissions.clone()));
+        } else if let Some(url) = story.url.clone() {
+            // No result yet — fire the query (if not already in flight) and
+            // open an empty overlay; it will populate on the next
+            // process_messages tick via the overlay's view of prior_results.
+            self.spawn_prior_discussions(story_id, &url);
+            self.prior_state = Some(PriorDiscussionsState::new(story_id, Vec::new()));
+        }
+    }
+
+    /// Loads the selected prior submission's comments as if the user had
+    /// selected it from the story pane. Closes the prior-discussions overlay.
+    fn open_selected_prior_discussion(&mut self) {
+        let Some(item) = self
+            .prior_state
+            .as_ref()
+            .and_then(|p| p.selected_submission().cloned())
+        else {
+            return;
+        };
+        self.prior_state = None;
+        self.focus = Pane::Comments;
+        self.comment_state.loading = true;
+
+        let client = self.client.clone();
+        let tx = self.msg_tx.clone();
+        let story = item.clone();
+        let kids = item.kids.clone().unwrap_or_default();
+        let needs_full_fetch = item.kids.is_none();
+
+        tokio::spawn(async move {
+            let kids = if needs_full_fetch && story.id > 0 {
+                match client.fetch_item(story.id).await {
+                    Ok(Some(full_item)) => full_item.kids.unwrap_or_default(),
+                    _ => kids,
+                }
+            } else {
+                kids
+            };
+            let root_items = client.fetch_items(&kids).await;
+            let root_comments: Vec<(Item, usize)> = root_items
+                .into_iter()
+                .flatten()
+                .filter(|item| !item.is_dead_or_deleted())
+                .map(|item| (item, 0))
+                .collect();
+            let pending_roots: HashSet<u64> = root_comments
+                .iter()
+                .filter(|(r, _)| r.kids.as_ref().is_some_and(|k| !k.is_empty()))
+                .map(|(r, _)| r.id)
+                .collect();
+            let _ = tx.send(AppMessage::CommentsLoaded {
+                story: Box::new(story.clone()),
+                comments: root_comments.clone(),
+                pending_roots,
+            });
+            for (root, _) in &root_comments {
+                let child_ids = root.kids.clone().unwrap_or_default();
+                if child_ids.is_empty() {
+                    continue;
+                }
+                let parent_id = root.id;
+                let mut children = Vec::new();
+                client
+                    .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
+                    .await;
+                if !children.is_empty() {
+                    let _ = tx.send(AppMessage::CommentsAppended {
+                        parent_id,
+                        children,
+                    });
+                }
+            }
+            let _ = tx.send(AppMessage::CommentsDone);
+        });
     }
 
     /// Transitions into search-input mode, showing an empty search prompt.
@@ -535,6 +718,31 @@ impl App {
         }
     }
 
+    /// Kicks off a background Algolia query for prior HN submissions of the
+    /// given URL. No-ops if the story's URL has already been queried or a
+    /// query is already in flight. Failures silently no-op — prior-discussions
+    /// is optional UX, not critical-path.
+    fn spawn_prior_discussions(&mut self, story_id: u64, url: &str) {
+        if self.prior_results.contains_key(&story_id) || self.prior_in_flight.contains(&story_id) {
+            return;
+        }
+        self.prior_in_flight.insert(story_id);
+
+        let client = self.client.clone();
+        let tx = self.msg_tx.clone();
+        let url = url.to_string();
+        tokio::spawn(async move {
+            let submissions = match client.search_by_url(&url).await {
+                Ok(items) => items.into_iter().filter(|i| i.id != story_id).collect(),
+                Err(_) => Vec::new(),
+            };
+            let _ = tx.send(AppMessage::PriorDiscussionsLoaded {
+                story_id,
+                submissions,
+            });
+        });
+    }
+
     /// Kicks off a two-phase comment fetch for the currently selected story:
     /// (1) loads and displays root-level comments immediately, then
     /// (2) walks each root's subtree depth-first and appends children via
@@ -544,6 +752,12 @@ impl App {
         if let Some(story) = self.story_state.selected_story().cloned() {
             self.comment_state.loading = true;
             self.focus = Pane::Comments;
+
+            // Fire a background prior-submissions query for this story's URL
+            // so the `h` overlay has data ready when the user asks for it.
+            if let Some(url) = story.url.as_deref() {
+                self.spawn_prior_discussions(story.id, url);
+            }
 
             let client = self.client.clone();
             let tx = self.msg_tx.clone();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -35,6 +35,7 @@ pub enum Action {
     PageDown,
     PageUp,
     ToggleHelp,
+    TogglePriorDiscussions,
     EnterSearch,
     Back,
     None,
@@ -46,12 +47,14 @@ pub enum Action {
 /// Priority order: search-input mode suppresses normal keys (returns
 /// [`Action::None`] so `main.rs` can handle raw characters); a visible
 /// help overlay consumes any key as [`Action::ToggleHelp`]; a visible
-/// reader overlay uses its own reduced keymap; otherwise the standard
-/// navigation keymap applies.
+/// reader overlay uses its own reduced keymap; a visible
+/// prior-discussions overlay uses a reduced keymap of its own; otherwise
+/// the standard navigation keymap applies.
 pub fn map_key(
     key: KeyEvent,
     help_visible: bool,
     reader_visible: bool,
+    prior_visible: bool,
     input_mode: InputMode,
 ) -> Action {
     // When in search input mode, main.rs handles raw keys — return None here
@@ -79,6 +82,22 @@ pub fn map_key(
         };
     }
 
+    // Prior-discussions overlay has its own limited key set. Note: `h` here
+    // does NOT close the overlay — use Esc/q. This leaves `h` free to be the
+    // global toggle in normal mode (below) without ambiguity.
+    if prior_visible {
+        return match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Action::MoveDown,
+            KeyCode::Char('k') | KeyCode::Up => Action::MoveUp,
+            KeyCode::Char('g') => Action::JumpTop,
+            KeyCode::Char('G') => Action::JumpBottom,
+            KeyCode::Enter => Action::Select,
+            KeyCode::Char('o') => Action::OpenInBrowser,
+            KeyCode::Esc | KeyCode::Char('q') => Action::Back,
+            _ => Action::None,
+        };
+    }
+
     match key.code {
         KeyCode::Char('q') => Action::Quit,
         KeyCode::Esc => Action::Back,
@@ -87,6 +106,7 @@ pub fn map_key(
         KeyCode::Enter => Action::Select,
         KeyCode::Char('o') => Action::OpenInBrowser,
         KeyCode::Char('p') => Action::OpenReader,
+        KeyCode::Char('h') => Action::TogglePriorDiscussions,
         KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => Action::SwitchPane,
         KeyCode::Char('1') => Action::SwitchFeed(0),
         KeyCode::Char('2') => Action::SwitchFeed(1),
@@ -126,12 +146,19 @@ mod tests {
                 key(KeyCode::Char('q')),
                 false,
                 false,
+                false,
                 InputMode::SearchInput
             ),
             Action::None
         );
         assert_eq!(
-            map_key(key(KeyCode::Char('q')), true, true, InputMode::SearchInput),
+            map_key(
+                key(KeyCode::Char('q')),
+                true,
+                true,
+                false,
+                InputMode::SearchInput
+            ),
             Action::None
         );
     }
@@ -139,11 +166,17 @@ mod tests {
     #[test]
     fn help_visible_closes_on_any_key() {
         assert_eq!(
-            map_key(key(KeyCode::Char('q')), true, false, InputMode::Normal),
+            map_key(
+                key(KeyCode::Char('q')),
+                true,
+                false,
+                false,
+                InputMode::Normal
+            ),
             Action::ToggleHelp
         );
         assert_eq!(
-            map_key(key(KeyCode::Enter), true, false, InputMode::Normal),
+            map_key(key(KeyCode::Enter), true, false, false, InputMode::Normal),
             Action::ToggleHelp
         );
     }
@@ -151,7 +184,13 @@ mod tests {
     #[test]
     fn help_takes_priority_over_reader() {
         assert_eq!(
-            map_key(key(KeyCode::Char('j')), true, true, InputMode::Normal),
+            map_key(
+                key(KeyCode::Char('j')),
+                true,
+                true,
+                false,
+                InputMode::Normal
+            ),
             Action::ToggleHelp
         );
     }
@@ -160,7 +199,7 @@ mod tests {
 
     #[test]
     fn reader_navigation() {
-        let r = |code| map_key(key(code), false, true, InputMode::Normal);
+        let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
         assert_eq!(r(KeyCode::Char('j')), Action::MoveDown);
         assert_eq!(r(KeyCode::Down), Action::MoveDown);
         assert_eq!(r(KeyCode::Char('k')), Action::MoveUp);
@@ -175,11 +214,11 @@ mod tests {
     #[test]
     fn reader_ctrl_keys() {
         assert_eq!(
-            map_key(ctrl('d'), false, true, InputMode::Normal),
+            map_key(ctrl('d'), false, true, false, InputMode::Normal),
             Action::PageDown
         );
         assert_eq!(
-            map_key(ctrl('u'), false, true, InputMode::Normal),
+            map_key(ctrl('u'), false, true, false, InputMode::Normal),
             Action::PageUp
         );
     }
@@ -187,11 +226,17 @@ mod tests {
     #[test]
     fn reader_unmapped_returns_none() {
         assert_eq!(
-            map_key(key(KeyCode::Char('p')), false, true, InputMode::Normal),
+            map_key(
+                key(KeyCode::Char('p')),
+                false,
+                true,
+                false,
+                InputMode::Normal
+            ),
             Action::None
         );
         assert_eq!(
-            map_key(key(KeyCode::Enter), false, true, InputMode::Normal),
+            map_key(key(KeyCode::Enter), false, true, false, InputMode::Normal),
             Action::None
         );
     }
@@ -200,14 +245,14 @@ mod tests {
 
     #[test]
     fn normal_quit_and_back() {
-        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(n(KeyCode::Char('q')), Action::Quit);
         assert_eq!(n(KeyCode::Esc), Action::Back);
     }
 
     #[test]
     fn normal_navigation() {
-        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(n(KeyCode::Char('j')), Action::MoveDown);
         assert_eq!(n(KeyCode::Down), Action::MoveDown);
         assert_eq!(n(KeyCode::Char('k')), Action::MoveUp);
@@ -220,18 +265,26 @@ mod tests {
     #[test]
     fn normal_ctrl_keys() {
         assert_eq!(
-            map_key(ctrl('d'), false, false, InputMode::Normal),
+            map_key(ctrl('d'), false, false, false, InputMode::Normal),
             Action::PageDown
         );
         assert_eq!(
-            map_key(ctrl('u'), false, false, InputMode::Normal),
+            map_key(ctrl('u'), false, false, false, InputMode::Normal),
             Action::PageUp
         );
     }
 
     #[test]
     fn normal_feed_switching() {
-        let n = |c: char| map_key(key(KeyCode::Char(c)), false, false, InputMode::Normal);
+        let n = |c: char| {
+            map_key(
+                key(KeyCode::Char(c)),
+                false,
+                false,
+                false,
+                InputMode::Normal,
+            )
+        };
         for (c, idx) in [('1', 0), ('2', 1), ('3', 2), ('4', 3), ('5', 4), ('6', 5)] {
             assert_eq!(n(c), Action::SwitchFeed(idx));
         }
@@ -239,9 +292,10 @@ mod tests {
 
     #[test]
     fn normal_actions() {
-        let n = |code| map_key(key(code), false, false, InputMode::Normal);
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(n(KeyCode::Char('o')), Action::OpenInBrowser);
         assert_eq!(n(KeyCode::Char('p')), Action::OpenReader);
+        assert_eq!(n(KeyCode::Char('h')), Action::TogglePriorDiscussions);
         assert_eq!(n(KeyCode::Tab), Action::SwitchPane);
         assert_eq!(n(KeyCode::BackTab), Action::SwitchPane);
         assert_eq!(n(KeyCode::Left), Action::SwitchPane);
@@ -254,8 +308,72 @@ mod tests {
     #[test]
     fn normal_unmapped_returns_none() {
         assert_eq!(
-            map_key(key(KeyCode::Char('z')), false, false, InputMode::Normal),
+            map_key(
+                key(KeyCode::Char('z')),
+                false,
+                false,
+                false,
+                InputMode::Normal
+            ),
             Action::None
+        );
+    }
+
+    // --- Prior-discussions overlay ---
+
+    #[test]
+    fn prior_overlay_keymap() {
+        let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
+        assert_eq!(p(KeyCode::Char('j')), Action::MoveDown);
+        assert_eq!(p(KeyCode::Down), Action::MoveDown);
+        assert_eq!(p(KeyCode::Char('k')), Action::MoveUp);
+        assert_eq!(p(KeyCode::Up), Action::MoveUp);
+        assert_eq!(p(KeyCode::Char('g')), Action::JumpTop);
+        assert_eq!(p(KeyCode::Char('G')), Action::JumpBottom);
+        assert_eq!(p(KeyCode::Enter), Action::Select);
+        assert_eq!(p(KeyCode::Char('o')), Action::OpenInBrowser);
+        assert_eq!(p(KeyCode::Esc), Action::Back);
+        assert_eq!(p(KeyCode::Char('q')), Action::Back);
+    }
+
+    #[test]
+    fn prior_overlay_consumes_unmapped_keys() {
+        // Keys that would otherwise dispatch in normal mode — the overlay
+        // should swallow them so e.g. `/` doesn't enter search underneath.
+        let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
+        assert_eq!(p(KeyCode::Char('/')), Action::None);
+        assert_eq!(p(KeyCode::Char('1')), Action::None);
+        assert_eq!(p(KeyCode::Char('p')), Action::None);
+        assert_eq!(p(KeyCode::Char('h')), Action::None);
+    }
+
+    #[test]
+    fn reader_takes_priority_over_prior() {
+        // If both overlays are somehow flagged simultaneously, reader wins
+        // because it's strictly modal (article-reading beats context-lookup).
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('o')),
+                false,
+                true,
+                true,
+                InputMode::Normal
+            ),
+            Action::OpenInBrowser
+        );
+    }
+
+    #[test]
+    fn help_takes_priority_over_prior() {
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('j')),
+                true,
+                false,
+                true,
+                InputMode::Normal
+            ),
+            Action::ToggleHelp
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
                         key,
                         app.show_help,
                         app.reader_state.is_some(),
+                        app.prior_state.is_some(),
                         app.input_mode,
                     );
                     app.dispatch(action);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -4,9 +4,12 @@
 //! methods: [`story_state::StoryListState`] for the left pane,
 //! [`comment_state::CommentTreeState`] for the comment tree (with collapse
 //! and plain-text caching), [`reader_state::ReaderState`] for the article
-//! overlay, and [`search_state::SearchState`] for the Algolia search flow.
+//! overlay, [`search_state::SearchState`] for the Algolia search flow,
+//! and [`prior_state::PriorDiscussionsState`] for the prior-submissions
+//! overlay.
 
 pub mod comment_state;
+pub mod prior_state;
 pub mod reader_state;
 pub mod search_state;
 pub mod story_state;

--- a/src/state/prior_state.rs
+++ b/src/state/prior_state.rs
@@ -1,0 +1,131 @@
+//! Prior-discussions overlay state.
+//!
+//! When a story with a URL is selected, the app fires an Algolia query
+//! for other HN submissions of the same URL (see
+//! [`crate::api::client::HnClient::search_by_url`]). Results are stashed
+//! here and displayed via the prior-discussions overlay when the user
+//! presses `h`.
+
+use crate::api::types::Item;
+
+/// State backing the prior-discussions overlay.
+///
+/// `story_id` identifies the story whose URL was queried — the UI checks
+/// this against the currently selected story to avoid stale data. `submissions`
+/// is the list of prior HN submissions of the same URL, sorted by Algolia's
+/// default (most recent first). `selected` is the list cursor.
+pub struct PriorDiscussionsState {
+    pub story_id: u64,
+    pub submissions: Vec<Item>,
+    pub selected: usize,
+}
+
+impl PriorDiscussionsState {
+    /// Starts a fresh overlay positioned at the first entry.
+    pub fn new(story_id: u64, submissions: Vec<Item>) -> Self {
+        Self {
+            story_id,
+            submissions,
+            selected: 0,
+        }
+    }
+
+    /// Moves selection down one row, clamping at the last entry.
+    pub fn select_next(&mut self) {
+        if !self.submissions.is_empty() {
+            self.selected = (self.selected + 1).min(self.submissions.len() - 1);
+        }
+    }
+
+    /// Moves selection up one row, clamping at zero.
+    pub fn select_prev(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Jumps selection to the first entry.
+    pub fn jump_top(&mut self) {
+        self.selected = 0;
+    }
+
+    /// Jumps selection to the last entry.
+    pub fn jump_bottom(&mut self) {
+        if !self.submissions.is_empty() {
+            self.selected = self.submissions.len() - 1;
+        }
+    }
+
+    /// Returns the currently-selected submission, if any.
+    pub fn selected_submission(&self) -> Option<&Item> {
+        self.submissions.get(self.selected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: u64) -> Item {
+        Item {
+            id,
+            title: Some(format!("Story {}", id)),
+            url: Some(format!("https://example.com/{}", id)),
+            text: None,
+            by: Some("user".into()),
+            score: Some(100),
+            time: Some(1000),
+            kids: None,
+            descendants: Some(10),
+            item_type: Some("story".into()),
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    #[test]
+    fn new_defaults_selected_to_zero() {
+        let s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        assert_eq!(s.selected, 0);
+        assert_eq!(s.story_id, 1);
+        assert_eq!(s.submissions.len(), 2);
+    }
+
+    #[test]
+    fn select_next_clamps_at_end() {
+        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        s.select_next();
+        s.select_next();
+        s.select_next();
+        assert_eq!(s.selected, 1);
+    }
+
+    #[test]
+    fn select_prev_clamps_at_zero() {
+        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        s.select_prev();
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn empty_submissions_nav_is_noop() {
+        let mut s = PriorDiscussionsState::new(1, Vec::new());
+        s.select_next();
+        s.jump_bottom();
+        assert_eq!(s.selected, 0);
+        assert!(s.selected_submission().is_none());
+    }
+
+    #[test]
+    fn jump_bottom_selects_last() {
+        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2), item(3)]);
+        s.jump_bottom();
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn selected_submission_returns_current() {
+        let mut s = PriorDiscussionsState::new(1, vec![item(10), item(20)]);
+        assert_eq!(s.selected_submission().unwrap().id, 10);
+        s.select_next();
+        assert_eq!(s.selected_submission().unwrap().id, 20);
+    }
+}

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -20,11 +20,16 @@ use ratatui::{
 /// Stateless widget that renders the right pane. Takes a mutable reference
 /// to [`CommentTreeState`] because rendering populates the `row_map` and
 /// may advance `scroll` to keep the selected comment visible.
+///
+/// `prior_count` is an optional informational badge shown in the title when
+/// non-zero — the number of prior HN submissions of the loaded story's URL
+/// that the `h` overlay will surface.
 pub struct CommentTree<'a> {
     pub state: &'a mut CommentTreeState,
     pub visible: &'a [usize],
     pub focused: bool,
     pub tick: u64,
+    pub prior_count: usize,
 }
 
 /// A pre-measured comment: all the lines it will produce and its visual index.
@@ -50,7 +55,7 @@ impl<'a> Widget for CommentTree<'a> {
             theme::dim_style()
         };
 
-        let title = if let Some(story) = &self.state.story {
+        let title_text = if let Some(story) = &self.state.story {
             if let Some(badge) = story.badge() {
                 format!(" [{}] {} ", badge.label(), story.display_title())
             } else {
@@ -60,10 +65,18 @@ impl<'a> Widget for CommentTree<'a> {
             " Comments ".to_string()
         };
 
+        let mut title_spans = vec![Span::styled(title_text, theme::title_style())];
+        if self.prior_count > 0 {
+            title_spans.push(Span::styled(
+                format!("· {} prior (h) ", self.prior_count),
+                theme::dim_style(),
+            ));
+        }
+
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(border_style)
-            .title(Span::styled(title, theme::title_style()))
+            .title(Line::from(title_spans))
             .style(theme::base_style());
 
         let inner = block.inner(area);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod article_reader;
 pub mod comment_tree;
 pub mod header;
 pub mod layout;
+pub mod prior_overlay;
 pub mod spinner;
 pub mod status_bar;
 pub mod story_list;
@@ -61,12 +62,20 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     let visible_indices = app.comment_state.visible_indices();
 
     // Comment tree
+    let prior_count = app
+        .comment_state
+        .story
+        .as_ref()
+        .and_then(|s| app.prior_results.get(&s.id))
+        .map(|v| v.len())
+        .unwrap_or(0);
     frame.render_widget(
         comment_tree::CommentTree {
             state: &mut app.comment_state,
             visible: &visible_indices,
             focused: app.focus == crate::app::Pane::Comments,
             tick: app.tick_count,
+            prior_count,
         },
         layout.comments,
     );
@@ -125,11 +134,20 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     if let Some(ref reader_state) = app.reader_state {
         article_reader::render_article_overlay(frame, area, reader_state);
     }
+
+    // Prior-discussions overlay (takes precedence over comment pane focus but
+    // sits below the article reader — a user who has the reader open is busy
+    // with the article).
+    if app.reader_state.is_none() {
+        if let Some(ref prior_state) = app.prior_state {
+            prior_overlay::render_prior_overlay(frame, area, prior_state);
+        }
+    }
 }
 
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let width = 50u16.min(area.width.saturating_sub(4));
-    let height = 21u16.min(area.height.saturating_sub(4));
+    let height = 22u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let popup_area = Rect::new(x, y, width, height);
@@ -154,6 +172,10 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  p            ", theme::accent_style()),
             Span::styled("Read article inline", theme::base_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  h            ", theme::accent_style()),
+            Span::styled("Show prior HN submissions of this URL", theme::base_style()),
         ]),
         Line::from(vec![
             Span::styled("  Tab          ", theme::accent_style()),

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -1,0 +1,166 @@
+//! Prior-discussions overlay rendering.
+//!
+//! [`render_prior_overlay`] draws a full-screen list of prior HN
+//! submissions of the currently-selected story's URL. Follows the same
+//! visual pattern as [`crate::ui::article_reader`] for consistency.
+
+use crate::api::types::Item;
+use crate::state::prior_state::PriorDiscussionsState;
+use crate::ui::theme;
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+/// Draws the prior-discussions overlay for `state` into `area` with a
+/// small margin. No-op if the available space is too small.
+pub fn render_prior_overlay(frame: &mut Frame, area: Rect, state: &PriorDiscussionsState) {
+    let margin = 2u16;
+    let x = margin.min(area.width / 2);
+    let y = 1u16.min(area.height / 2);
+    let width = area.width.saturating_sub(x * 2);
+    let height = area.height.saturating_sub(y * 2);
+
+    if width < 20 || height < 5 {
+        return;
+    }
+
+    let overlay_area = Rect::new(x, y, width, height);
+    frame.render_widget(Clear, overlay_area);
+
+    let title = format!(
+        " Prior Discussions ({}) ",
+        match state.submissions.len() {
+            1 => "1 prior submission".to_string(),
+            n => format!("{} prior submissions", n),
+        }
+    );
+
+    let footer = Line::from(Span::styled(
+        " j/k:navigate  Enter:load comments  o:browser  Esc:close ",
+        theme::dim_style(),
+    ))
+    .centered();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent_style())
+        .title(Span::styled(title, theme::title_style()))
+        .title_bottom(footer)
+        .style(theme::base_style());
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if state.submissions.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "No prior HN submissions found for this URL.",
+            theme::dim_style(),
+        )))
+        .alignment(ratatui::layout::Alignment::Center);
+        let y_offset = inner.height / 2;
+        if y_offset > 0 && inner.height > 0 {
+            let centered = Rect::new(inner.x, inner.y + y_offset, inner.width, 1);
+            frame.render_widget(empty, centered);
+        }
+        return;
+    }
+
+    // Each submission takes two rows (header + byline) + a blank gap, so
+    // we can render up to `inner.height / 3` comfortably.
+    let rows_per_item = 3u16;
+    let visible_count = (inner.height / rows_per_item) as usize;
+    if visible_count == 0 {
+        return;
+    }
+
+    // Scroll so the selected row is always in view.
+    let scroll = if state.selected >= visible_count {
+        state.selected - visible_count + 1
+    } else {
+        0
+    };
+
+    let mut lines: Vec<Line> = Vec::with_capacity(visible_count * 3);
+    for (i, item) in state
+        .submissions
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(visible_count)
+    {
+        let is_selected = i == state.selected;
+        lines.extend(format_submission(item, is_selected, inner.width as usize));
+        lines.push(Line::from(""));
+    }
+
+    let list = Paragraph::new(lines);
+    frame.render_widget(list, inner);
+}
+
+/// Formats one submission as two styled lines (main + byline).
+fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static>; 2] {
+    let points = item.score.unwrap_or(0);
+    let comments = item.descendants.unwrap_or(0);
+    let date = item
+        .time
+        .and_then(|t| chrono::DateTime::<chrono::Utc>::from_timestamp(t, 0))
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "?".into());
+    let title = item.display_title();
+    let author = item.by.as_deref().unwrap_or("[deleted]");
+
+    let cursor = if selected { "> " } else { "  " };
+    let title_style = if selected {
+        theme::title_style().bg(theme::SURFACE)
+    } else {
+        ratatui::style::Style::default().fg(theme::TEXT)
+    };
+    let meta_style = if selected {
+        theme::accent_style().bg(theme::SURFACE)
+    } else {
+        theme::accent_style()
+    };
+    let dim_style = if selected {
+        theme::dim_style().bg(theme::SURFACE)
+    } else {
+        theme::dim_style()
+    };
+    let row_bg = if selected {
+        theme::selected_style()
+    } else {
+        theme::base_style()
+    };
+
+    // First line: `>  847 pts  2023-04-02  Title here`
+    let prefix = format!("{}{:>4} pts  {}  ", cursor, points, date);
+    let title_truncated = truncate_to(title, width.saturating_sub(prefix.chars().count() + 2));
+
+    let line1 = Line::from(vec![
+        Span::styled(format!("{}{:>4} pts  ", cursor, points), meta_style),
+        Span::styled(format!("{}  ", date), dim_style),
+        Span::styled(title_truncated, title_style),
+    ])
+    .style(row_bg);
+
+    // Second line: `       ({N} comments) by {author}`
+    let byline = format!(
+        "     ({} comment{}) by {}",
+        comments,
+        if comments == 1 { "" } else { "s" },
+        author
+    );
+    let line2 = Line::from(Span::styled(byline, dim_style)).style(row_bg);
+
+    [line1, line2]
+}
+
+fn truncate_to(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max.saturating_sub(3)).collect();
+    format!("{}...", truncated)
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -67,7 +67,7 @@ impl Widget for StatusBar {
                 ));
             } else {
                 spans.push(Span::styled(
-                    "j/k:nav enter:comments o:browser p:read /:new search esc:back ?:help ",
+                    "j/k:nav enter:comments o:browser p:read h:prior /:new search esc:back ?:help ",
                     theme::status_style(),
                 ));
             }
@@ -88,7 +88,7 @@ impl Widget for StatusBar {
                 ));
             } else {
                 spans.push(Span::styled(
-                    "j/k:nav tab:switch enter:open 1-6:feed /:search o:browser p:read r:refresh ?:help q:quit ",
+                    "j/k:nav tab:switch enter:open 1-6:feed /:search o:browser p:read h:prior r:refresh ?:help q:quit ",
                     theme::status_style(),
                 ));
             }


### PR DESCRIPTION
Closes #77.

## Summary

- Opening a story with a URL auto-fires an Algolia query for other HN submissions of the same URL.
- Comment-pane title gains a `· N prior (h)` indicator when results exist.
- `h` opens a full-screen overlay listing prior submissions with score, date, title, comment count, author.
- Overlay keymap: `j/k/g/G` navigate, `Enter` loads selected thread's comments, `o` opens browser, `Esc/q` closes.
- Status bar hint and `?` help overlay both advertise the `h` key.
- Zero new dependencies; reuses reqwest, serde, url, and the existing overlay pattern.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo doc --no-deps` (no warnings)
- [x] `cargo test` (167/167 pass; +19 new — 9 for `normalize_url`, 6 for `PriorDiscussionsState` nav, 4 for key priority chain)
- [ ] Manual: open a known-duplicated story (e.g. a bun release, rust-lang blog post) — verify `· N prior (h)` appears and `h` shows prior submissions.
- [ ] Manual: open an Ask HN text-only post — verify no indicator and no overlay on `h`.
- [ ] Manual: open a story from `new` with a novel URL — verify `h` shows "No prior HN submissions found."
- [ ] Manual: with reader overlay open, `h` is consumed (reader has precedence).
- [ ] Manual: `?` help overlay includes the `h` entry between `p` and `Tab`.