### PR TITLE
Polish prior-discussions docstrings

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -140,7 +140,7 @@ impl HnClient {
     ///
     /// Queries Algolia with a scheme-stripped form of the URL (which gets
     /// tokenized against the indexed `url` field), then filters client-side
-    /// to exact URL matches after normalization (lowercased host, stripped
+    /// to exact URL matches using [`normalize_url`] (lowercased host, stripped
     /// `www.` and trailing slash, scheme-insensitive). Returns up to 50
     /// matches, most-recent first by Algolia default.
     ///

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,9 +74,9 @@ pub enum AppMessage {
     ArticleError(String),
     /// Generic error to surface in the status bar.
     Error(String),
-    /// Algolia returned prior HN submissions of the selected story's URL.
-    /// `story_id` is the story that triggered the query — used to drop
-    /// results whose story has since been deselected.
+    /// Carries prior HN submissions of the selected story's URL returned
+    /// by Algolia. `story_id` identifies the originating query so stale
+    /// results (user has since deselected the story) can be dropped.
     PriorDiscussionsLoaded {
         story_id: u64,
         submissions: Vec<Item>,
@@ -105,12 +105,12 @@ pub struct App {
     pub tick_count: u64,
 
     /// Prior-discussions overlay state. `Some` while the overlay is open;
-    /// `None` otherwise. Contents are populated from `prior_results` when
-    /// the user presses `h`.
+    /// `None` otherwise. Contents are populated from [`App::prior_results`]
+    /// when the user presses `h`.
     pub prior_state: Option<PriorDiscussionsState>,
     /// Prior-submissions query results, keyed by the story ID that was
     /// queried. Keeps each result around for the rest of the session so
-    /// reopening the `h` overlay doesn't trigger a refetch.
+    /// reopening the [`PriorDiscussionsState`] overlay doesn't trigger a refetch.
     pub prior_results: HashMap<u64, Vec<Item>>,
     /// Story IDs whose URL queries are in flight. Prevents duplicate spawns.
     prior_in_flight: HashSet<u64>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -48,7 +48,7 @@ pub enum Action {
 /// [`Action::None`] so `main.rs` can handle raw characters); a visible
 /// help overlay consumes any key as [`Action::ToggleHelp`]; a visible
 /// reader overlay uses its own reduced keymap; a visible
-/// prior-discussions overlay uses a reduced keymap of its own; otherwise
+/// prior-discussions overlay likewise uses a reduced keymap; otherwise
 /// the standard navigation keymap applies.
 pub fn map_key(
     key: KeyEvent,

--- a/src/state/prior_state.rs
+++ b/src/state/prior_state.rs
@@ -10,13 +10,18 @@ use crate::api::types::Item;
 
 /// State backing the prior-discussions overlay.
 ///
-/// `story_id` identifies the story whose URL was queried — the UI checks
-/// this against the currently selected story to avoid stale data. `submissions`
-/// is the list of prior HN submissions of the same URL, sorted by Algolia's
-/// default (most recent first). `selected` is the list cursor.
+/// Populated from [`crate::api::client::HnClient::search_by_url`] results
+/// and displayed by [`crate::ui::prior_overlay::render_prior_overlay`].
+/// [`PriorDiscussionsState::new`] constructs a fresh instance positioned
+/// at the first entry; the `select_*` / `jump_*` methods drive the cursor.
 pub struct PriorDiscussionsState {
+    /// Story whose URL was queried. Checked against the currently selected
+    /// story so stale results from a prior selection are dropped.
     pub story_id: u64,
+    /// Prior HN submissions of `story_id`'s URL, in Algolia default order
+    /// (most recent first). May be empty when the URL has no prior submissions.
     pub submissions: Vec<Item>,
+    /// Cursor into `submissions`. Clamps at `submissions.len() - 1`.
     pub selected: usize,
 }
 
@@ -30,7 +35,8 @@ impl PriorDiscussionsState {
         }
     }
 
-    /// Moves selection down one row, clamping at the last entry.
+    /// Advances selection by one, saturating at the last entry. No-op when
+    /// `submissions` is empty.
     pub fn select_next(&mut self) {
         if !self.submissions.is_empty() {
             self.selected = (self.selected + 1).min(self.submissions.len() - 1);
@@ -47,7 +53,7 @@ impl PriorDiscussionsState {
         self.selected = 0;
     }
 
-    /// Jumps selection to the last entry.
+    /// Jumps selection to the last entry. No-op when `submissions` is empty.
     pub fn jump_bottom(&mut self) {
         if !self.submissions.is_empty() {
             self.selected = self.submissions.len() - 1;

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -23,7 +23,7 @@ use ratatui::{
 ///
 /// `prior_count` is an optional informational badge shown in the title when
 /// non-zero — the number of prior HN submissions of the loaded story's URL
-/// that the `h` overlay will surface.
+/// that the [`crate::ui::prior_overlay`] overlay (bound to `h`) will surface.
 pub struct CommentTree<'a> {
     pub state: &'a mut CommentTreeState,
     pub visible: &'a [usize],

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -24,6 +24,11 @@ use ratatui::{
     Frame,
 };
 
+/// Composes one ratatui frame from [`App`] state: header, story list,
+/// comment tree (with optional `· N prior (h)` badge), status bar, and
+/// the help, article-reader, and prior-discussions overlays when active.
+/// The article reader takes precedence over the prior-discussions overlay
+/// when both are somehow open.
 pub fn render(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
 
@@ -145,6 +150,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     }
 }
 
+/// Draws the centered modal help overlay listing every keybinding.
+/// Bounded to at most 50×22 cells; auto-shrinks on small terminals.
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let width = 50u16.min(area.width.saturating_sub(4));
     let height = 22u16.min(area.height.saturating_sub(4));

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -14,8 +14,9 @@ use ratatui::{
     Frame,
 };
 
-/// Draws the prior-discussions overlay for `state` into `area` with a
-/// small margin. No-op if the available space is too small.
+/// Draws the prior-discussions overlay for `state` into `area`.
+///
+/// Leaves a small margin and no-ops if the available space is too small.
 pub fn render_prior_overlay(frame: &mut Frame, area: Rect, state: &PriorDiscussionsState) {
     let margin = 2u16;
     let x = margin.min(area.width / 2);
@@ -157,6 +158,9 @@ fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static
     [line1, line2]
 }
 
+/// Truncates `s` to at most `max` characters (operating on `char`s to stay
+/// UTF-8-safe), appending `...` when truncation occurs. Returns `s`
+/// unchanged when it already fits.
 fn truncate_to(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();


### PR DESCRIPTION
Follow-up to #78 — brings the prior-discussions merge up to the post-#76 rustdoc bar, identified by a fresh `/docstring-check` scoped to that commit.

## Summary

- Fills two gaps on touched pub functions: `ui::render` and `render_help_overlay` now have `///` docs (the former was a pre-existing gap surfaced by #78's overlay-dispatch change; the latter grew an `h` row and bumped its height cap).
- Restructures `PriorDiscussionsState`'s struct doc to match the `CommentTreeState` / `SearchState` pattern — per-field `///`s on the three pub fields instead of inline prose.
- Records the empty-`submissions` no-op contract on `select_next` / `jump_bottom` that `empty_submissions_nav_is_noop` already tests.
- Adds missing `///` on `truncate_to` for parity with sibling `format_submission`.
- Normalizes `AppMessage::PriorDiscussionsLoaded` opener to third-person indicative.
- Tightens `App::prior_state` / `prior_results` / `search_by_url` / `CommentTree` prose with backticked intra-doc links to companion items, matching the link style `toggle_prior_discussions` already uses.
- Drops a redundant "own keymap / keymap of its own" echo from the `map_key` doc.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo doc --no-deps` (zero warnings — new intra-doc links resolve)
- [x] `cargo test` (167/167)
- No behavior changes; docs-only.