### PR TITLE
Bump version to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Release cut. Material since v0.3.8:

- **Prior-discussions overlay** (#78) — Algolia-powered surface of past HN submissions of the same URL, bound to `h`. New pane-title badge, help-overlay entry, and status-bar hint.
- **Docstring polish** (#79) — follow-up to bring the new feature up to the post-#76 rustdoc bar.
- **Security patch + CI/CD hygiene** (#80) — `rustls-webpki` 0.103.10 → 0.103.13 (RUSTSEC-2026-0098/0099/0104), `html2text` 0.16 → 0.17, `lru` 0.16 → 0.17, gate Dependabot auto-merge on patch/minor only, fix stale action-gh-release comment.

On merge, `.github/workflows/release.yml` will tag `v0.3.9` and publish multi-platform binaries.