### PR TITLE
Persist read-state across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Browse stories, read threaded comments, and open links — all from your termina
 - **Search** — Algolia-powered full-text search across stories
 - **Reader mode** — Read article content directly in the terminal
 - **Prior discussions** — Press `h` to see past HN submissions of the same URL with their scores and dates
+- **Read-state tracking** — Visited stories render dimmed; stories with new comments since your last visit get a `+N` badge. Persisted to `$XDG_DATA_HOME/hnt/read.json`
 - **Open in browser** — Press `o` to open the story URL
 - **Progressive loading** — Root comments appear instantly, children load in the background
 - **Lazy pagination** — Stories load automatically as you scroll

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::keys::{Action, InputMode};
 use crate::state::comment_state::CommentTreeState;
 use crate::state::prior_state::PriorDiscussionsState;
+use crate::state::read_store::ReadStore;
 use crate::state::reader_state::{ReaderState, StyledFragment};
 use crate::state::search_state::SearchState;
 use crate::state::story_state::StoryListState;
@@ -115,6 +116,13 @@ pub struct App {
     /// Story IDs whose URL queries are in flight. Prevents duplicate spawns.
     prior_in_flight: HashSet<u64>,
 
+    /// Persisted read-state — records which stories have been opened and
+    /// how many comments each had at the time. Rendered by
+    /// [`crate::ui::story_list::StoryList`] to dim visited stories and
+    /// surface `+N` new-comments badges. Loaded from disk at startup and
+    /// flushed via [`App::persist`] on shutdown.
+    pub read_store: ReadStore,
+
     last_comment_click: Option<(std::time::Instant, usize)>,
 
     client: HnClient,
@@ -144,6 +152,7 @@ impl App {
             prior_state: None,
             prior_results: HashMap::new(),
             prior_in_flight: HashSet::new(),
+            read_store: ReadStore::load(),
             last_comment_click: None,
             client: HnClient::new(),
             msg_tx,
@@ -162,6 +171,13 @@ impl App {
     pub fn set_terminal_size(&mut self, w: u16, h: u16) {
         self.terminal_width = w;
         self.terminal_height = h;
+    }
+
+    /// Flushes any in-memory persistent state (read-store) to disk. Call
+    /// once at shutdown after the main loop exits. Silently swallows I/O
+    /// errors — read-state is non-critical.
+    pub fn persist(&mut self) {
+        self.read_store.save();
     }
 
     /// Spawns a background fetch for the first page of the current feed.
@@ -528,6 +544,7 @@ impl App {
         else {
             return;
         };
+        self.read_store.mark(item.id, item.descendants.unwrap_or(0));
         self.prior_state = None;
         self.focus = Pane::Comments;
         self.comment_state.loading = true;
@@ -750,6 +767,8 @@ impl App {
     /// For search results (kids missing), fetches the full item first.
     fn load_selected_comments(&mut self) {
         if let Some(story) = self.story_state.selected_story().cloned() {
+            self.read_store
+                .mark(story.id, story.descendants.unwrap_or(0));
             self.comment_state.loading = true;
             self.focus = Pane::Comments;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<()> {
         }
     }
 
+    app.persist();
     tui::restore()?;
     Ok(())
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,11 +5,12 @@
 //! [`comment_state::CommentTreeState`] for the comment tree (with collapse
 //! and plain-text caching), [`reader_state::ReaderState`] for the article
 //! overlay, [`search_state::SearchState`] for the Algolia search flow,
-//! and [`prior_state::PriorDiscussionsState`] for the prior-submissions
-//! overlay.
+//! [`prior_state::PriorDiscussionsState`] for the prior-submissions
+//! overlay, and [`read_store::ReadStore`] for persisted read-state tracking.
 
 pub mod comment_state;
 pub mod prior_state;
+pub mod read_store;
 pub mod reader_state;
 pub mod search_state;
 pub mod story_state;

--- a/src/state/read_store.rs
+++ b/src/state/read_store.rs
@@ -1,0 +1,345 @@
+//! Persistent read-state store.
+//!
+//! Tracks which stories the user has opened and how many comments each had
+//! at that moment. [`crate::ui::story_list::StoryList`] uses this to dim
+//! visited stories and badge stories with new comments since last visit.
+//!
+//! Backed by a JSON file at `$XDG_DATA_HOME/hnt/read.json` (or
+//! `$HOME/.local/share/hnt/read.json` as a fallback). Failures to resolve
+//! the path or read the file leave the store in-memory only — the feature
+//! still works within the session but is not persisted across restarts.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Soft cap on stored entries. Oldest (lowest `last_seen_at`) entries are
+/// evicted on overflow so the file stays bounded.
+const MAX_ENTRIES: usize = 5000;
+
+/// On-disk schema version. Bumped only on incompatible format changes.
+const SCHEMA_VERSION: u32 = 1;
+
+/// One visited story's persisted state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadEntry {
+    /// Wall-clock timestamp (Unix seconds) of the most recent visit.
+    pub last_seen_at: i64,
+    /// Total comment count (`descendants`) at the time of the visit. A
+    /// later render can subtract this from the current count to surface a
+    /// `+N` "new comments" badge.
+    pub last_comment_count: i64,
+}
+
+/// In-memory read-state store with JSON-file persistence.
+///
+/// Constructed via [`ReadStore::load`] at startup. Mark a story as visited
+/// with [`ReadStore::mark`] and flush with [`ReadStore::save`]. Reads
+/// ([`ReadStore::is_read`], [`ReadStore::new_comments_since`]) are cheap.
+pub struct ReadStore {
+    entries: HashMap<u64, ReadEntry>,
+    path: Option<PathBuf>,
+    dirty: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DiskStore {
+    version: u32,
+    #[serde(default)]
+    entries: HashMap<String, ReadEntry>,
+}
+
+impl ReadStore {
+    /// In-memory-only store with no persistence path. Used when the
+    /// default XDG path can't be resolved.
+    pub fn empty() -> Self {
+        Self {
+            entries: HashMap::new(),
+            path: None,
+            dirty: false,
+        }
+    }
+
+    /// Loads from `$XDG_DATA_HOME/hnt/read.json` (or the
+    /// `$HOME/.local/share/hnt/read.json` fallback). Returns an empty
+    /// in-memory store if the path can't be resolved or the file is
+    /// missing/corrupt.
+    pub fn load() -> Self {
+        match default_path() {
+            Some(path) => Self::load_from(path),
+            None => Self::empty(),
+        }
+    }
+
+    /// Loads or creates a store at `path`. A missing or corrupt file
+    /// produces an empty store with `path` still set as the save target —
+    /// the next [`ReadStore::save`] will replace it.
+    pub fn load_from(path: PathBuf) -> Self {
+        let entries = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<DiskStore>(&raw).ok())
+            .map(|disk| {
+                disk.entries
+                    .into_iter()
+                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (id, v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            entries,
+            path: Some(path),
+            dirty: false,
+        }
+    }
+
+    /// Writes the store to its configured path if dirty. No-op for
+    /// in-memory-only stores and for clean stores. Uses an atomic
+    /// `tmp → rename` to avoid leaving half-written files on crash.
+    /// Failures (permissions, missing parent, disk full) are silently
+    /// swallowed — read-state is non-critical.
+    pub fn save(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        let disk = DiskStore {
+            version: SCHEMA_VERSION,
+            entries: self
+                .entries
+                .iter()
+                .map(|(&id, entry)| (id.to_string(), *entry))
+                .collect(),
+        };
+        let Ok(json) = serde_json::to_string(&disk) else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let tmp = path.with_extension("json.tmp");
+        if std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
+            self.dirty = false;
+        }
+    }
+
+    /// Records or refreshes the entry for `id` with the current wall-clock
+    /// timestamp and comment count. Evicts oldest entries if the store
+    /// would overflow [`MAX_ENTRIES`].
+    pub fn mark(&mut self, id: u64, current_comment_count: i64) {
+        self.mark_at(id, current_comment_count, chrono::Utc::now().timestamp());
+    }
+
+    /// Variant of [`ReadStore::mark`] that uses an explicit timestamp —
+    /// used by tests to keep behavior deterministic.
+    pub fn mark_at(&mut self, id: u64, current_comment_count: i64, now: i64) {
+        self.entries.insert(
+            id,
+            ReadEntry {
+                last_seen_at: now,
+                last_comment_count: current_comment_count,
+            },
+        );
+        if self.entries.len() > MAX_ENTRIES {
+            self.evict_oldest();
+        }
+        self.dirty = true;
+    }
+
+    /// Returns whether `id` has ever been visited.
+    pub fn is_read(&self, id: u64) -> bool {
+        self.entries.contains_key(&id)
+    }
+
+    /// Persisted entry for `id`, if any.
+    #[cfg(test)]
+    pub fn entry(&self, id: u64) -> Option<&ReadEntry> {
+        self.entries.get(&id)
+    }
+
+    /// New comments since the last visit, if any. Returns `Some(n)` when
+    /// `n > 0`; `None` when the story was never visited or has no new
+    /// comments. A shrinking count (rare — deletions) is clamped to `None`.
+    pub fn new_comments_since(&self, id: u64, current_count: i64) -> Option<i64> {
+        let entry = self.entries.get(&id)?;
+        let delta = current_count - entry.last_comment_count;
+        if delta > 0 {
+            Some(delta)
+        } else {
+            None
+        }
+    }
+
+    /// Drops entries with the lowest `last_seen_at` until the store is
+    /// back within [`MAX_ENTRIES`].
+    fn evict_oldest(&mut self) {
+        let mut ages: Vec<(i64, u64)> = self
+            .entries
+            .iter()
+            .map(|(&id, e)| (e.last_seen_at, id))
+            .collect();
+        ages.sort_unstable();
+        let excess = self.entries.len().saturating_sub(MAX_ENTRIES);
+        for (_, id) in ages.into_iter().take(excess) {
+            self.entries.remove(&id);
+        }
+    }
+
+    /// Number of persisted entries. Exposed for tests and diagnostics.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Resolves the default persistence path: `$XDG_DATA_HOME/hnt/read.json`,
+/// falling back to `$HOME/.local/share/hnt/read.json`. Returns `None` if
+/// neither variable is set (rare — containers with no `HOME`).
+fn default_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("hnt").join("read.json"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(
+        PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("hnt")
+            .join("read.json"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "hnt_read_store_test_{}_{}.json",
+            name,
+            std::process::id()
+        ))
+    }
+
+    fn fresh_store(name: &str) -> ReadStore {
+        let p = tmp_path(name);
+        let _ = std::fs::remove_file(&p);
+        ReadStore::load_from(p)
+    }
+
+    #[test]
+    fn empty_store_has_no_entries() {
+        let s = ReadStore::empty();
+        assert!(!s.is_read(42));
+        assert!(s.new_comments_since(42, 10).is_none());
+    }
+
+    #[test]
+    fn mark_then_is_read() {
+        let mut s = fresh_store("mark_then_is_read");
+        s.mark_at(42, 10, 1_700_000_000);
+        assert!(s.is_read(42));
+        assert!(!s.is_read(99));
+    }
+
+    #[test]
+    fn new_comments_since_returns_positive_delta() {
+        let mut s = fresh_store("new_comments_delta");
+        s.mark_at(42, 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(42, 15), Some(5));
+    }
+
+    #[test]
+    fn new_comments_since_returns_none_when_unchanged() {
+        let mut s = fresh_store("new_comments_unchanged");
+        s.mark_at(42, 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(42, 10), None);
+    }
+
+    #[test]
+    fn new_comments_since_returns_none_when_shrunk() {
+        let mut s = fresh_store("new_comments_shrunk");
+        s.mark_at(42, 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(42, 5), None);
+    }
+
+    #[test]
+    fn new_comments_since_none_for_unknown_id() {
+        let s = ReadStore::empty();
+        assert_eq!(s.new_comments_since(99, 10), None);
+    }
+
+    #[test]
+    fn mark_updates_existing_entry_in_place() {
+        let mut s = fresh_store("mark_updates");
+        s.mark_at(42, 10, 1_700_000_000);
+        s.mark_at(42, 25, 1_700_000_100);
+        let e = s.entry(42).unwrap();
+        assert_eq!(e.last_seen_at, 1_700_000_100);
+        assert_eq!(e.last_comment_count, 25);
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn save_and_reload_roundtrip() {
+        let p = tmp_path("roundtrip");
+        let _ = std::fs::remove_file(&p);
+        {
+            let mut s = ReadStore::load_from(p.clone());
+            s.mark_at(1, 10, 1_700_000_000);
+            s.mark_at(2, 20, 1_700_000_100);
+            s.save();
+        }
+        let s2 = ReadStore::load_from(p.clone());
+        assert!(s2.is_read(1));
+        assert!(s2.is_read(2));
+        assert_eq!(s2.entry(1).unwrap().last_comment_count, 10);
+        assert_eq!(s2.entry(2).unwrap().last_comment_count, 20);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn save_is_noop_when_not_dirty() {
+        let p = tmp_path("save_noop");
+        let _ = std::fs::remove_file(&p);
+        let mut s = ReadStore::load_from(p.clone());
+        s.save();
+        assert!(!p.exists());
+    }
+
+    #[test]
+    fn corrupt_file_loads_as_empty() {
+        let p = tmp_path("corrupt");
+        std::fs::write(&p, "{not valid json").unwrap();
+        let s = ReadStore::load_from(p.clone());
+        assert_eq!(s.len(), 0);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn in_memory_only_store_silently_drops_save() {
+        let mut s = ReadStore::empty();
+        s.mark_at(1, 10, 1000);
+        s.save();
+        assert!(s.is_read(1));
+    }
+
+    #[test]
+    fn eviction_bounds_size_at_max_and_removes_oldest() {
+        let mut s = ReadStore::empty();
+        for i in 0..(MAX_ENTRIES as u64 + 5) {
+            s.mark_at(i, 0, i as i64);
+        }
+        assert_eq!(s.len(), MAX_ENTRIES);
+        for oldest in 0..5u64 {
+            assert!(!s.is_read(oldest), "oldest id {oldest} should be evicted");
+        }
+        assert!(s.is_read(MAX_ENTRIES as u64 + 4));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -58,6 +58,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             focused: app.focus == crate::app::Pane::Stories,
             loading: app.story_state.loading,
             search_query: if search_active { search_query } else { None },
+            read_store: &app.read_store,
         },
         layout.stories,
     );
@@ -154,7 +155,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 /// Bounded to at most 50×22 cells; auto-shrinks on small terminals.
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let width = 50u16.min(area.width.saturating_sub(4));
-    let height = 22u16.min(area.height.saturating_sub(4));
+    let height = 24u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let popup_area = Rect::new(x, y, width, height);
@@ -223,6 +224,11 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
             Span::styled("  ?            ", theme::accent_style()),
             Span::styled("Toggle this help", theme::base_style()),
         ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Visited stories are dimmed; +N marks new comments",
+            theme::dim_style(),
+        )),
         Line::from(""),
         Line::from(Span::styled("  Press any key to close", theme::dim_style())),
     ];

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -6,6 +6,7 @@
 //! timestamps.
 
 use crate::api::types::Item;
+use crate::state::read_store::ReadStore;
 use crate::ui::theme;
 use ratatui::{
     buffer::Buffer,
@@ -23,6 +24,9 @@ pub struct StoryList<'a> {
     pub focused: bool,
     pub loading: bool,
     pub search_query: Option<&'a str>,
+    /// Persisted read-state: stories present here render dimmed, and those
+    /// whose comment count has grown since the last visit get a `+N` badge.
+    pub read_store: &'a ReadStore,
 }
 
 impl<'a> Widget for StoryList<'a> {
@@ -90,6 +94,10 @@ impl<'a> Widget for StoryList<'a> {
         {
             let y = inner.top() + (i - scroll) as u16;
             let is_selected = i == self.selected;
+            let is_read = self.read_store.is_read(story.id);
+            let new_comments = self
+                .read_store
+                .new_comments_since(story.id, story.descendants.unwrap_or(0));
 
             let title = story.display_title();
             let badge = story.badge();
@@ -97,12 +105,14 @@ impl<'a> Widget for StoryList<'a> {
                 .domain()
                 .map(|d| format!(" ({})", d))
                 .unwrap_or_default();
+            let new_badge_text = new_comments.map(|n| format!(" +{}", n));
 
             let num = format!("{:>3}. ", i + 1);
             let badge_text = badge.map(|b| format!("[{}] ", b.label()));
             let badge_width = badge_text.as_ref().map_or(0, |t| t.len());
-            let max_title_width =
-                (inner.width as usize).saturating_sub(num.len() + badge_width + domain.len() + 2);
+            let new_badge_width = new_badge_text.as_ref().map_or(0, |t| t.len());
+            let max_title_width = (inner.width as usize)
+                .saturating_sub(num.len() + badge_width + new_badge_width + domain.len() + 2);
             let truncated_title: String = if title.chars().count() > max_title_width {
                 let truncated: String = title
                     .chars()
@@ -113,15 +123,31 @@ impl<'a> Widget for StoryList<'a> {
                 title.to_string()
             };
 
-            let style = if is_selected {
+            let row_bg = if is_selected {
+                theme::SURFACE
+            } else {
+                theme::BG
+            };
+            let row_style = if is_selected {
                 theme::selected_style()
             } else {
                 theme::base_style()
             };
+            // Visited stories use the dim foreground so they recede visually,
+            // while still keeping the selection highlight (bold + surface bg)
+            // so the cursor row remains obvious.
+            let title_style = match (is_selected, is_read) {
+                (true, true) => theme::dim_style()
+                    .bg(theme::SURFACE)
+                    .add_modifier(ratatui::style::Modifier::BOLD),
+                (true, false) => theme::selected_style(),
+                (false, true) => theme::dim_style(),
+                (false, false) => theme::base_style(),
+            };
 
             // Fill line background
             for x in inner.left()..inner.right() {
-                buf[(x, y)].set_style(style);
+                buf[(x, y)].set_style(row_style);
             }
 
             let mut spans = vec![Span::styled(
@@ -135,15 +161,11 @@ impl<'a> Widget for StoryList<'a> {
             if let Some((text, b)) = badge_text.zip(badge) {
                 spans.push(Span::styled(text, theme::badge_style(b)));
             }
-            spans.push(Span::styled(truncated_title, style));
-            spans.push(Span::styled(
-                domain,
-                theme::dim_style().bg(if is_selected {
-                    theme::SURFACE
-                } else {
-                    theme::BG
-                }),
-            ));
+            spans.push(Span::styled(truncated_title, title_style));
+            if let Some(text) = new_badge_text {
+                spans.push(Span::styled(text, theme::accent_style().bg(row_bg)));
+            }
+            spans.push(Span::styled(domain, theme::dim_style().bg(row_bg)));
 
             let line = Line::from(spans);
             buf.set_line(inner.left(), y, &line, inner.width);


### PR DESCRIPTION
Closes #82.

## Summary

- Adds a persistent read-state store so `hnt` can remember which stories you've opened across sessions.
- Visited stories render **dimmed** in the story list.
- Stories whose comment count has grown since your last visit get a **`+N`** badge in HN-orange between title and domain.
- State is persisted to `\$XDG_DATA_HOME/hnt/read.json` (fallback `~/.local/share/hnt/read.json`), loaded at startup, flushed at shutdown.
- Zero new dependencies — reuses `serde`/`serde_json`/`chrono`.

## Design

- **`src/state/read_store.rs`** (new, ~280 LOC):
  - `ReadEntry { last_seen_at, last_comment_count }`
  - `ReadStore` with `load`/`save`/`mark`/`is_read`/`new_comments_since`
  - 5000-entry cap with oldest-wins eviction on overflow
  - Atomic write (`tmp → rename`) so an ill-timed crash never leaves a half-written file
  - All I/O errors silently fall back to in-memory — read-state is non-critical UX, shouldn't ever block the app
- **`src/app.rs`**: new \`read_store\` field loaded via \`ReadStore::load()\` in \`App::new\`; marks the story in \`load_selected_comments\` and \`open_selected_prior_discussion\`; adds \`App::persist()\` called from \`main.rs\` at shutdown.
- **`src/ui/story_list.rs`**: \`StoryList\` gains \`read_store: &ReadStore\` param. Visited stories use dim foreground; stories with new comments get a \`+N\` span.
- **Docs**: README Features list + help overlay (\`?\`) both mention the feature.

## Verification

- \`cargo fmt --all --check\` ✓
- \`cargo clippy --all-targets --all-features -- -D warnings\` ✓
- \`cargo test\` — **179 passed** (167 prior + 12 new)
- \`cargo build --release\` ✓

## Test plan

- [x] \`cargo run\` → open a story (Enter) → quit (\`q\`)
- [x] \`cat ~/.local/share/hnt/read.json\` → contains the visited ID
- [x] \`cargo run\` again → the story renders dimmed
- [x] Open the same story a couple of hours later when HN has new comments → \`+N\` badge appears between title and domain
- [x] Delete \`read.json\` → app starts cleanly with nothing dimmed
- [x] Corrupt \`read.json\` (\`echo garbage > …\`) → app starts cleanly without crashing
- [x] Open \`h\` (prior discussions), select an entry → that submission is also marked on exit

## Out of scope (follow-ups)

- Manual "mark as unread" toggle
- "Show unread only" filter
- Favorites / bookmarks