### PR TITLE
Bump version to 0.3.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` from `0.3.9` → `0.3.10`
- Triggers the `Release` workflow to build the four target binaries and publish `v0.3.10`

## What's in this release

- **Persistent read-state tracking** (#83, closes #82) — visited stories render dimmed; stories with new comments since your last visit get a `+N` badge. Persisted to `~/.local/share/hnt/read.json`.

## Test plan

- [ ] Merge → Release workflow kicks off
- [ ] All 4 target builds succeed (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`)
- [ ] `v0.3.10` appears under [Releases](https://github.com/thijsvos/hnt/releases) with 5 assets (4 binaries + checksums)