### PR TITLE
Rust idiom cleanups: perf wins + exhaustive overlay dispatch

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -89,14 +89,16 @@ impl HnClient {
             .collect()
             .await;
 
-        // buffer_unordered doesn't preserve order, so re-order by input IDs
-        let result_map: HashMap<u64, Item> = results
+        // buffer_unordered doesn't preserve order, so re-order by input IDs.
+        // `remove` moves each Item out of the temporary map — `get().cloned()`
+        // would clone the entire Item unnecessarily since the map is discarded.
+        let mut result_map: HashMap<u64, Item> = results
             .into_iter()
             .flatten()
             .map(|item| (item.id, item))
             .collect();
 
-        ids.iter().map(|id| result_map.get(id).cloned()).collect()
+        ids.iter().map(|id| result_map.remove(id)).collect()
     }
 
     /// Fetches a page of items from a pre-fetched ID list. Used for pagination

--- a/src/app.rs
+++ b/src/app.rs
@@ -301,117 +301,82 @@ impl App {
     /// Otherwise the action mutates the focused pane's state or spawns an
     /// async task (feed switch, refresh, comment load, search).
     pub fn dispatch(&mut self, action: Action) {
-        // When reader is open, route actions to reader
+        // When reader is open, route actions to reader.
         if self.reader_state.is_some() {
-            match action {
-                Action::Back => {
-                    self.reader_state = None;
-                    return;
-                }
-                Action::MoveDown => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.scroll_down(1);
-                    }
-                    return;
-                }
-                Action::MoveUp => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.scroll_up(1);
-                    }
-                    return;
-                }
-                Action::PageDown => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.page_down(SCROLL_PAGE);
-                    }
-                    return;
-                }
-                Action::PageUp => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.page_up(SCROLL_PAGE);
-                    }
-                    return;
-                }
-                Action::JumpTop => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.jump_top();
-                    }
-                    return;
-                }
-                Action::JumpBottom => {
-                    if let Some(ref mut r) = self.reader_state {
-                        r.jump_bottom();
-                    }
-                    return;
-                }
-                Action::OpenInBrowser => {
-                    if let Some(ref reader) = self.reader_state {
-                        if let Some(ref url) = reader.url {
-                            if let Ok(parsed) = url::Url::parse(url) {
-                                if parsed.scheme() == "http" || parsed.scheme() == "https" {
-                                    let _ = open::that(parsed.as_str());
-                                }
-                            }
-                        }
-                    }
-                    return;
-                }
-                _ => return, // Consume all other keys
+            // Back mutates the Option itself, so handle it before borrowing
+            // the inner state.
+            if matches!(action, Action::Back) {
+                self.reader_state = None;
+                return;
             }
+            let Some(r) = self.reader_state.as_mut() else {
+                return;
+            };
+            match action {
+                Action::MoveDown => r.scroll_down(1),
+                Action::MoveUp => r.scroll_up(1),
+                Action::PageDown => r.page_down(SCROLL_PAGE),
+                Action::PageUp => r.page_up(SCROLL_PAGE),
+                Action::JumpTop => r.jump_top(),
+                Action::JumpBottom => r.jump_bottom(),
+                Action::OpenInBrowser => open_http_url(r.url.as_deref()),
+                // Exhaustive no-op list — when new Action variants are added
+                // they'll provoke a compile error here so the overlay's
+                // handling is a deliberate choice, not an accident.
+                Action::Quit
+                | Action::Select
+                | Action::OpenReader
+                | Action::SwitchPane
+                | Action::SwitchFeed(_)
+                | Action::Refresh
+                | Action::EnterSearch
+                | Action::ToggleHelp
+                | Action::TogglePriorDiscussions
+                | Action::None => {}
+                Action::Back => unreachable!("Back is handled above"),
+            }
+            return;
         }
 
         // When the prior-discussions overlay is open, route a reduced action
         // set and consume everything else.
         if self.prior_state.is_some() {
-            match action {
-                Action::Back => {
-                    self.prior_state = None;
-                    return;
-                }
-                Action::MoveDown => {
-                    if let Some(ref mut p) = self.prior_state {
-                        p.select_next();
-                    }
-                    return;
-                }
-                Action::MoveUp => {
-                    if let Some(ref mut p) = self.prior_state {
-                        p.select_prev();
-                    }
-                    return;
-                }
-                Action::JumpTop => {
-                    if let Some(ref mut p) = self.prior_state {
-                        p.jump_top();
-                    }
-                    return;
-                }
-                Action::JumpBottom => {
-                    if let Some(ref mut p) = self.prior_state {
-                        p.jump_bottom();
-                    }
-                    return;
-                }
-                Action::Select => {
-                    self.open_selected_prior_discussion();
-                    return;
-                }
-                Action::OpenInBrowser => {
-                    if let Some(ref p) = self.prior_state {
-                        if let Some(item) = p.selected_submission() {
-                            if let Some(ref url) = item.url {
-                                if let Ok(parsed) = url::Url::parse(url) {
-                                    if parsed.scheme() == "http" || parsed.scheme() == "https" {
-                                        let _ = open::that(parsed.as_str());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    return;
-                }
-                _ => return,
+            // Actions that mutate App itself (not just the overlay's inner
+            // state) go first so the subsequent borrow of `p` is clean.
+            if matches!(action, Action::Back) {
+                self.prior_state = None;
+                return;
             }
+            if matches!(action, Action::Select) {
+                self.open_selected_prior_discussion();
+                return;
+            }
+            let Some(p) = self.prior_state.as_mut() else {
+                return;
+            };
+            match action {
+                Action::MoveDown => p.select_next(),
+                Action::MoveUp => p.select_prev(),
+                Action::JumpTop => p.jump_top(),
+                Action::JumpBottom => p.jump_bottom(),
+                Action::OpenInBrowser => {
+                    open_http_url(p.selected_submission().and_then(|i| i.url.as_deref()));
+                }
+                // Exhaustive no-op list — see note in reader block above.
+                Action::Quit
+                | Action::OpenReader
+                | Action::SwitchPane
+                | Action::SwitchFeed(_)
+                | Action::Refresh
+                | Action::EnterSearch
+                | Action::ToggleHelp
+                | Action::TogglePriorDiscussions
+                | Action::PageDown
+                | Action::PageUp
+                | Action::None => {}
+                Action::Back | Action::Select => unreachable!("handled above"),
+            }
+            return;
         }
 
         match action {
@@ -921,13 +886,7 @@ impl App {
             id.map(|id| format!("https://news.ycombinator.com/item?id={}", id))
         });
 
-        if let Some(url) = url {
-            if let Ok(parsed) = url::Url::parse(&url) {
-                if parsed.scheme() == "http" || parsed.scheme() == "https" {
-                    let _ = open::that(parsed.as_str());
-                }
-            }
-        }
+        open_http_url(url.as_deref());
     }
 
     /// If the selection has crossed the lazy-load threshold, kicks off
@@ -1091,5 +1050,20 @@ impl App {
                 }
             }
         }
+    }
+}
+
+/// Opens `url` in the system browser — but only when it parses as an
+/// `http`/`https` URL. Silently drops `None`, parse failures, and other
+/// schemes (so `file://`, `javascript:`, and `data:` can never reach
+/// `open::that`). All three overlay-dispatch sites and
+/// [`App::open_in_browser`] share this entry point.
+fn open_http_url(url: Option<&str>) {
+    let Some(raw) = url else { return };
+    let Ok(parsed) = url::Url::parse(raw) else {
+        return;
+    };
+    if matches!(parsed.scheme(), "http" | "https") {
+        let _ = open::that(parsed.as_str());
     }
 }

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -148,6 +148,8 @@ fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) {
     let visible_height = inner.height as usize;
     let scroll = reader.scroll;
 
+    // Borrow fragment text instead of cloning — Span<'_> holds a Cow<str>
+    // and happily borrows from `reader.lines` for the frame's lifetime.
     let visible_lines = reader
         .lines
         .iter()
@@ -156,7 +158,7 @@ fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) {
         .map(|fragments| {
             let spans: Vec<Span> = fragments
                 .iter()
-                .map(|f| Span::styled(f.text.clone(), f.style))
+                .map(|f| Span::styled(f.text.as_str(), f.style))
                 .collect();
             Line::from(spans)
         })

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -361,7 +361,7 @@ fn measure_comments(
         let collapse_indicator = if is_collapsed { " [+]" } else { "" };
 
         let child_count = if is_collapsed {
-            let count = count_hidden_children(all_comments, comment);
+            let count = count_hidden_children(all_comments, idx);
             if count > 0 {
                 format!(" ({} hidden)", count)
             } else {
@@ -431,22 +431,15 @@ fn measure_comments(
     result
 }
 
-/// Counts descendants of `parent` in the flat list — the contiguous run
-/// of comments with strictly greater depth that follow it.
-fn count_hidden_children(all: &[FlatComment], parent: &FlatComment) -> usize {
-    let parent_idx = all.iter().position(|c| c.item.id == parent.item.id);
-    match parent_idx {
-        Some(idx) => {
-            let mut count = 0;
-            for c in &all[idx + 1..] {
-                if c.depth > parent.depth {
-                    count += 1;
-                } else {
-                    break;
-                }
-            }
-            count
-        }
-        None => 0,
-    }
+/// Counts descendants of `all[parent_idx]` in the flat list — the
+/// contiguous run of comments with strictly greater depth that follow it.
+/// The caller already has the index from its own iteration, so we take
+/// it directly instead of re-scanning for it (which was quadratic when
+/// many siblings were collapsed).
+fn count_hidden_children(all: &[FlatComment], parent_idx: usize) -> usize {
+    let parent_depth = all[parent_idx].depth;
+    all[parent_idx + 1..]
+        .iter()
+        .take_while(|c| c.depth > parent_depth)
+        .count()
 }


### PR DESCRIPTION
Closes #85.

## Summary

- **Perf**: removes an O(n²) scan per frame in `count_hidden_children` (hot path during `j`-hold on a collapsed thread).
- **Perf**: drops one full `Item` clone per item in `HnClient::fetch_items`.
- **Perf**: removes per-frame `String` clones for every visible article line in the reader overlay.
- **Clarity**: one `open_http_url(Option<&str>)` helper replaces three copy-pasted URL-parse pyramids.
- **Safety**: reader and prior-discussions overlays now match `Action` exhaustively — a future `Action::NewFeature` will provoke a compile error instead of being silently swallowed.
- Net diff: **100 insertions, 129 deletions**.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` — 179 passed / 0 failed
- `cargo build --release` ✓

## Test plan

- [ ] Open a story with a long, partly-collapsed comment thread; hold `j` — should feel snappier than before (fewer stutters on long threads).
- [ ] Open the article reader (`p`) on a long article; scroll up and down — still works as before, no visual regression.
- [ ] Open the prior-discussions overlay (`h`) and press `o` — opens the external URL in the browser.
- [ ] Press `o` on a selected story from both the Stories and Comments panes — opens the URL or HN item page.
- [ ] Try `file://` / `javascript:` URLs via a crafted Algolia response (not normally reachable, but the helper is defensive about scheme).

## Deferred — candidates for follow-up PRs

From the same audit but intentionally kept out of this PR:

- [#85 mentions] `item_type: Option<String>` → `enum ItemType`
- `append: bool` → `LoadMode` enum in `AppMessage`
- `Vec<(Item, usize)>` → `CommentWithDepth` struct
- LRU cache holding `Arc<Item>` to share cache entries without cloning
- `StatusBar<'a>` with borrowed `&str` fields
- `TryFrom<SearchHit> for Item` instead of the `unwrap_or(0)` sentinel