### PR TITLE
Type-system cleanups: CommentWithDepth, LoadMode, ItemType, TryFrom

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -5,7 +5,7 @@
 //! Item fetches are cached up to `CACHE_CAPACITY` entries and fan out
 //! with `CONCURRENT_REQUESTS` in flight.
 
-use super::types::{FeedKind, Item, SearchResponse};
+use super::types::{CommentWithDepth, FeedKind, Item, SearchResponse};
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
 use lru::LruCache;
@@ -162,7 +162,7 @@ impl HnClient {
         Ok(resp
             .hits
             .into_iter()
-            .map(Item::from)
+            .filter_map(|h| Item::try_from(h).ok())
             .filter(|item| {
                 item.url
                     .as_deref()
@@ -189,20 +189,24 @@ impl HnClient {
             ALGOLIA_URL, encoded_query, hits_per_page, page
         );
         let resp: SearchResponse = self.client.get(&url).send().await?.json().await?;
-        let stories = resp.hits.into_iter().map(Item::from).collect();
+        let stories = resp
+            .hits
+            .into_iter()
+            .filter_map(|h| Item::try_from(h).ok())
+            .collect();
         Ok((stories, resp.nb_pages, resp.nb_hits))
     }
 
-    /// Walks a comment subtree depth-first, appending `(Item, depth)` into
-    /// `result` for every live descendant up to `max_depth`. Dead/deleted
-    /// comments are skipped. Returns a boxed future so the recursion can
-    /// cross `async` boundaries.
+    /// Walks a comment subtree depth-first, appending [`CommentWithDepth`]
+    /// records into `result` for every live descendant up to `max_depth`.
+    /// Dead/deleted comments are skipped. Returns a boxed future so the
+    /// recursion can cross `async` boundaries.
     pub fn fetch_children_recursive<'a>(
         &'a self,
         ids: &'a [u64],
         depth: usize,
         max_depth: usize,
-        result: &'a mut Vec<(Item, usize)>,
+        result: &'a mut Vec<CommentWithDepth>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
             if depth > max_depth || ids.is_empty() {
@@ -216,7 +220,7 @@ impl HnClient {
                     continue;
                 }
                 let kids = item.kids.clone().unwrap_or_default();
-                result.push((item, depth));
+                result.push(CommentWithDepth { item, depth });
 
                 if !kids.is_empty() {
                     self.fetch_children_recursive(&kids, depth + 1, max_depth, result)

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -35,7 +35,7 @@ pub struct Item {
     #[serde(default)]
     pub descendants: Option<i64>,
     #[serde(rename = "type", default)]
-    pub item_type: Option<String>,
+    pub item_type: Option<ItemType>,
     #[serde(default)]
     pub dead: Option<bool>,
     #[serde(default)]
@@ -59,11 +59,10 @@ impl Item {
     /// (`Ask HN:`, `Show HN:`, `Tell HN:`, `Launch HN:`). Returns `None`
     /// for plain stories. `item_type` takes priority over title prefix.
     pub fn badge(&self) -> Option<StoryBadge> {
-        if self.item_type.as_deref() == Some("job") {
-            return Some(StoryBadge::Job);
-        }
-        if self.item_type.as_deref() == Some("poll") {
-            return Some(StoryBadge::Poll);
+        match self.item_type {
+            Some(ItemType::Job) => return Some(StoryBadge::Job),
+            Some(ItemType::Poll) => return Some(StoryBadge::Poll),
+            _ => {}
         }
         let title = self.title.as_deref()?;
         if title.starts_with("Ask HN:") {
@@ -100,6 +99,32 @@ impl Item {
     }
 }
 
+/// A comment paired with its depth in the tree — the transport form for
+/// async fetches into [`crate::state::comment_state::CommentTreeState`].
+/// `depth == 0` is a root comment; children have strictly greater depth
+/// and appear contiguously after their parent in pre-order.
+#[derive(Debug, Clone)]
+pub struct CommentWithDepth {
+    pub item: Item,
+    pub depth: usize,
+}
+
+/// Firebase `type` field — tags an [`Item`] as story / comment / job /
+/// poll / poll option. Unknown future strings deserialize to
+/// [`ItemType::Unknown`] via `#[serde(other)]` so wire-format evolution
+/// doesn't crash the app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ItemType {
+    Story,
+    Comment,
+    Job,
+    Poll,
+    Pollopt,
+    #[serde(other)]
+    Unknown,
+}
+
 /// A classification label shown next to a story title. See [`Item::badge`]
 /// for how values are derived.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -129,7 +154,11 @@ impl StoryBadge {
 // --- Algolia Search types ---
 
 /// One result entry returned by the Algolia HN search endpoint. Shape
-/// differs from the Firebase [`Item`]; convert via [`From`].
+/// differs from the Firebase [`Item`]; convert via [`TryFrom`] — which
+/// fails when Algolia's string `objectID` can't be parsed as `u64`
+/// (effectively never in practice, but letting callers filter rather
+/// than relying on an `id=0` sentinel keeps the rest of the app free
+/// of "is this id real" guards).
 #[derive(Debug, Deserialize)]
 pub struct SearchHit {
     #[serde(rename = "objectID")]
@@ -153,10 +182,12 @@ pub struct SearchResponse {
     pub nb_hits: usize,
 }
 
-impl From<SearchHit> for Item {
-    fn from(hit: SearchHit) -> Self {
-        Item {
-            id: hit.object_id.parse::<u64>().unwrap_or(0),
+impl TryFrom<SearchHit> for Item {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(hit: SearchHit) -> Result<Self, Self::Error> {
+        Ok(Item {
+            id: hit.object_id.parse::<u64>()?,
             title: hit.title,
             url: hit.url,
             text: hit.story_text,
@@ -165,10 +196,10 @@ impl From<SearchHit> for Item {
             time: hit.created_at_i,
             kids: None,
             descendants: hit.num_comments,
-            item_type: Some("story".to_string()),
+            item_type: Some(ItemType::Story),
             dead: None,
             deleted: None,
-        }
+        })
     }
 }
 
@@ -354,14 +385,14 @@ mod tests {
     #[test]
     fn badge_job() {
         let mut item = make_item();
-        item.item_type = Some("job".into());
+        item.item_type = Some(ItemType::Job);
         assert_eq!(item.badge(), Some(StoryBadge::Job));
     }
 
     #[test]
     fn badge_poll() {
         let mut item = make_item();
-        item.item_type = Some("poll".into());
+        item.item_type = Some(ItemType::Poll);
         assert_eq!(item.badge(), Some(StoryBadge::Poll));
     }
 
@@ -409,7 +440,7 @@ mod tests {
     #[test]
     fn badge_job_takes_priority_over_title() {
         let mut item = make_item();
-        item.item_type = Some("job".into());
+        item.item_type = Some(ItemType::Job);
         item.title = Some("Ask HN: Something".into());
         assert_eq!(item.badge(), Some(StoryBadge::Job));
     }
@@ -498,7 +529,7 @@ mod tests {
         assert_eq!(format!("{}", FeedKind::Jobs), "Jobs");
     }
 
-    // --- From<SearchHit> for Item ---
+    // --- TryFrom<SearchHit> for Item ---
 
     #[test]
     fn search_hit_to_item() {
@@ -512,18 +543,18 @@ mod tests {
             created_at_i: Some(1000),
             story_text: Some("body".into()),
         };
-        let item = Item::from(hit);
+        let item = Item::try_from(hit).expect("valid numeric object_id");
         assert_eq!(item.id, 12345);
         assert_eq!(item.title.as_deref(), Some("Test"));
         assert_eq!(item.by.as_deref(), Some("user"));
         assert_eq!(item.score, Some(42));
         assert_eq!(item.descendants, Some(10));
         assert_eq!(item.text.as_deref(), Some("body"));
-        assert_eq!(item.item_type.as_deref(), Some("story"));
+        assert_eq!(item.item_type, Some(ItemType::Story));
     }
 
     #[test]
-    fn search_hit_invalid_object_id() {
+    fn search_hit_invalid_object_id_errors() {
         let hit = SearchHit {
             object_id: "not_a_number".into(),
             title: None,
@@ -534,7 +565,6 @@ mod tests {
             created_at_i: None,
             story_text: None,
         };
-        let item = Item::from(hit);
-        assert_eq!(item.id, 0);
+        assert!(Item::try_from(hit).is_err());
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 //! [`App::process_messages`] drains pending async results each frame.
 
 use crate::api::client::HnClient;
-use crate::api::types::{FeedKind, Item};
+use crate::api::types::{CommentWithDepth, FeedKind, Item};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::keys::{Action, InputMode};
 use crate::state::comment_state::CommentTreeState;
@@ -30,6 +30,16 @@ pub enum Pane {
     Comments,
 }
 
+/// Whether a paginated load should replace the current story list or
+/// append to it. Previously a `bool` in [`AppMessage`] variants — named
+/// variants make call sites self-documenting (`LoadMode::Append` vs
+/// `false`) and prevent flipped-arg bugs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadMode {
+    Replace,
+    Append,
+}
+
 /// Messages sent from async tasks back to the main loop.
 ///
 /// Variants correspond to the lifecycle of each async operation: a one-shot
@@ -45,19 +55,19 @@ pub enum AppMessage {
         /// reuse the cached ID list to avoid drift when the feed changes
         /// mid-session.
         all_ids: Option<Vec<u64>>,
-        append: bool,
+        mode: LoadMode,
     },
     /// Root-level comments for a story are available; deeper descendants
     /// still pending.
     CommentsLoaded {
         story: Box<Item>,
-        comments: Vec<(Item, usize)>,
+        comments: Vec<CommentWithDepth>,
         pending_roots: HashSet<u64>,
     },
     /// Progressive update — append more child comments into the tree.
     CommentsAppended {
         parent_id: u64,
-        children: Vec<(Item, usize)>,
+        children: Vec<CommentWithDepth>,
     },
     /// All outstanding comment fetches finished; clear any "loading"
     /// spinners.
@@ -69,7 +79,7 @@ pub enum AppMessage {
         stories: Vec<Item>,
         total_pages: usize,
         total_hits: usize,
-        append: bool,
+        mode: LoadMode,
     },
     /// Article fetch/extract failed; surface in the reader overlay.
     ArticleError(String),
@@ -185,7 +195,7 @@ impl App {
     /// Intended to be called once at startup; calling it concurrently will
     /// race two `StoriesLoaded` messages into the channel.
     pub fn load_initial_feed(&self) {
-        self.spawn_load_stories(false);
+        self.spawn_load_stories(LoadMode::Replace);
     }
 
     /// Processes any pending async messages (non-blocking).
@@ -195,12 +205,11 @@ impl App {
                 AppMessage::StoriesLoaded {
                     stories,
                     all_ids,
-                    append,
+                    mode,
                 } => {
-                    if append {
-                        self.story_state.stories.extend(stories);
-                    } else {
-                        self.story_state.stories = stories;
+                    match mode {
+                        LoadMode::Append => self.story_state.stories.extend(stories),
+                        LoadMode::Replace => self.story_state.stories = stories,
                     }
                     if let Some(ids) = all_ids {
                         self.story_state.all_ids = ids;
@@ -208,7 +217,7 @@ impl App {
                     self.story_state.loading = false;
                     self.error = None;
                     // Auto-load comments for the first story on initial load
-                    if !append
+                    if matches!(mode, LoadMode::Replace)
                         && !self.story_state.stories.is_empty()
                         && self.comment_state.story.is_none()
                     {
@@ -220,12 +229,11 @@ impl App {
                     stories,
                     total_pages,
                     total_hits,
-                    append,
+                    mode,
                 } => {
-                    if append {
-                        self.story_state.stories.extend(stories);
-                    } else {
-                        self.story_state.stories = stories;
+                    match mode {
+                        LoadMode::Append => self.story_state.stories.extend(stories),
+                        LoadMode::Replace => self.story_state.stories = stories,
                     }
                     self.story_state.loading = false;
                     self.error = None;
@@ -233,7 +241,7 @@ impl App {
                         ss.total_pages = total_pages;
                         ss.total_hits = total_hits;
                     }
-                    if !append && !self.story_state.stories.is_empty() {
+                    if matches!(mode, LoadMode::Replace) && !self.story_state.stories.is_empty() {
                         self.load_selected_comments();
                         self.focus = Pane::Stories;
                     }
@@ -425,7 +433,7 @@ impl App {
                         self.comment_state.reset();
                         self.client.clear_cache();
                         self.focus = Pane::Stories;
-                        self.spawn_load_stories(false);
+                        self.spawn_load_stories(LoadMode::Replace);
                     }
                 }
             }
@@ -435,13 +443,13 @@ impl App {
                     if !query.is_empty() {
                         self.story_state.reset();
                         self.comment_state.reset();
-                        self.spawn_search(&query, 0, false);
+                        self.spawn_search(&query, 0, LoadMode::Replace);
                     }
                 } else {
                     self.story_state.reset();
                     self.comment_state.reset();
                     self.client.clear_cache();
-                    self.spawn_load_stories(false);
+                    self.spawn_load_stories(LoadMode::Replace);
                 }
             }
             Action::EnterSearch => {
@@ -521,7 +529,10 @@ impl App {
         let needs_full_fetch = item.kids.is_none();
 
         tokio::spawn(async move {
-            let kids = if needs_full_fetch && story.id > 0 {
+            // Search results arrive with kids == None — fetch the full item to
+            // populate them. TryFrom<SearchHit> filters out id=0 upstream, so
+            // no sentinel guard is needed.
+            let kids = if needs_full_fetch {
                 match client.fetch_item(story.id).await {
                     Ok(Some(full_item)) => full_item.kids.unwrap_or_default(),
                     _ => kids,
@@ -530,28 +541,28 @@ impl App {
                 kids
             };
             let root_items = client.fetch_items(&kids).await;
-            let root_comments: Vec<(Item, usize)> = root_items
+            let root_comments: Vec<CommentWithDepth> = root_items
                 .into_iter()
                 .flatten()
                 .filter(|item| !item.is_dead_or_deleted())
-                .map(|item| (item, 0))
+                .map(|item| CommentWithDepth { item, depth: 0 })
                 .collect();
             let pending_roots: HashSet<u64> = root_comments
                 .iter()
-                .filter(|(r, _)| r.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                .map(|(r, _)| r.id)
+                .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
+                .map(|c| c.item.id)
                 .collect();
             let _ = tx.send(AppMessage::CommentsLoaded {
                 story: Box::new(story.clone()),
                 comments: root_comments.clone(),
                 pending_roots,
             });
-            for (root, _) in &root_comments {
-                let child_ids = root.kids.clone().unwrap_or_default();
+            for c in &root_comments {
+                let child_ids = c.item.kids.clone().unwrap_or_default();
                 if child_ids.is_empty() {
                     continue;
                 }
-                let parent_id = root.id;
+                let parent_id = c.item.id;
                 let mut children = Vec::new();
                 client
                     .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
@@ -596,7 +607,7 @@ impl App {
         self.input_mode = InputMode::Normal;
         self.story_state.reset();
         self.comment_state.reset();
-        self.spawn_search(&query, 0, false);
+        self.spawn_search(&query, 0, LoadMode::Replace);
     }
 
     /// Exits search mode, clears the cache, and reloads the current feed.
@@ -606,7 +617,7 @@ impl App {
         self.story_state.reset();
         self.comment_state.reset();
         self.client.clear_cache();
-        self.spawn_load_stories(false);
+        self.spawn_load_stories(LoadMode::Replace);
     }
 
     /// Appends a typed character to the in-progress search input.
@@ -623,9 +634,9 @@ impl App {
         }
     }
 
-    /// Kicks off an async Algolia search. `append = true` extends the
-    /// current result list (lazy pagination); `append = false` replaces it.
-    fn spawn_search(&mut self, query: &str, page: usize, append: bool) {
+    /// Kicks off an async Algolia search. [`LoadMode::Append`] extends the
+    /// current result list (lazy pagination); [`LoadMode::Replace`] replaces it.
+    fn spawn_search(&mut self, query: &str, page: usize, mode: LoadMode) {
         self.story_state.loading = true;
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
@@ -639,7 +650,7 @@ impl App {
                         stories,
                         total_pages,
                         total_hits,
-                        append,
+                        mode,
                     });
                 }
                 Err(e) => {
@@ -649,15 +660,15 @@ impl App {
         });
     }
 
-    /// Kicks off an async feed-page load. When `append` is true, reuses
-    /// the cached ID list to compute a stable offset (so newly posted
-    /// stories don't shift the page); otherwise fetches a fresh ID list.
-    fn spawn_load_stories(&self, append: bool) {
+    /// Kicks off an async feed-page load. [`LoadMode::Append`] reuses the
+    /// cached ID list to compute a stable offset (so newly posted stories
+    /// don't shift the page); [`LoadMode::Replace`] fetches a fresh ID list.
+    fn spawn_load_stories(&self, mode: LoadMode) {
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
         let page_size = self.page_size();
 
-        if append {
+        if matches!(mode, LoadMode::Append) {
             // Reuse the ID list from the initial load so offsets stay stable
             // even if new stories have been posted to the feed since.
             let cached_ids = self.story_state.all_ids.clone();
@@ -671,7 +682,7 @@ impl App {
                         let _ = tx.send(AppMessage::StoriesLoaded {
                             stories,
                             all_ids: None,
-                            append: true,
+                            mode: LoadMode::Append,
                         });
                     }
                     Err(e) => {
@@ -688,7 +699,7 @@ impl App {
                         let _ = tx.send(AppMessage::StoriesLoaded {
                             stories,
                             all_ids: Some(all_ids),
-                            append: false,
+                            mode: LoadMode::Replace,
                         });
                     }
                     Err(e) => {
@@ -750,8 +761,9 @@ impl App {
             let kids = story.kids.clone().unwrap_or_default();
 
             tokio::spawn(async move {
-                // For search results, kids is None — fetch the full item first
-                let kids = if needs_full_fetch && story_clone.id > 0 {
+                // For search results, kids is None — fetch the full item first.
+                // TryFrom<SearchHit> filters out id=0 upstream.
+                let kids = if needs_full_fetch {
                     match client.fetch_item(story_clone.id).await {
                         Ok(Some(full_item)) => full_item.kids.unwrap_or_default(),
                         _ => kids,
@@ -762,17 +774,17 @@ impl App {
 
                 // Step 1: Fetch root-level comments and show them immediately
                 let root_items = client.fetch_items(&kids).await;
-                let root_comments: Vec<(Item, usize)> = root_items
+                let root_comments: Vec<CommentWithDepth> = root_items
                     .into_iter()
                     .flatten()
                     .filter(|item| !item.is_dead_or_deleted())
-                    .map(|item| (item, 0))
+                    .map(|item| CommentWithDepth { item, depth: 0 })
                     .collect();
 
                 let pending_roots: HashSet<u64> = root_comments
                     .iter()
-                    .filter(|(r, _)| r.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                    .map(|(r, _)| r.id)
+                    .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
+                    .map(|c| c.item.id)
                     .collect();
 
                 let _ = tx.send(AppMessage::CommentsLoaded {
@@ -782,12 +794,12 @@ impl App {
                 });
 
                 // Step 2: For each root comment, fetch its children progressively
-                for (root, _) in &root_comments {
-                    let child_ids = root.kids.clone().unwrap_or_default();
+                for c in &root_comments {
+                    let child_ids = c.item.kids.clone().unwrap_or_default();
                     if child_ids.is_empty() {
                         continue;
                     }
-                    let parent_id = root.id;
+                    let parent_id = c.item.id;
                     let mut children = Vec::new();
                     client
                         .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
@@ -904,11 +916,11 @@ impl App {
                 ss.current_page += 1;
                 let query = ss.query.clone();
                 let page = ss.current_page;
-                self.spawn_search(&query, page, true);
+                self.spawn_search(&query, page, LoadMode::Append);
             }
         } else if self.story_state.needs_more() {
             self.story_state.loading = true;
-            self.spawn_load_stories(true);
+            self.spawn_load_stories(LoadMode::Append);
         }
     }
 

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -6,7 +6,9 @@
 //! rules by skipping subtrees. [`CommentTreeState::insert_children`]
 //! splices a root's children in-place as async fetches complete.
 
-use crate::api::types::Item;
+#[cfg(test)]
+use crate::api::types::ItemType;
+use crate::api::types::{CommentWithDepth, Item};
 use std::collections::HashSet;
 
 /// One comment in the flattened, depth-tagged comment tree.
@@ -105,18 +107,18 @@ impl CommentTreeState {
     }
 
     /// Replaces the flat list and resets selection/scroll to the top.
-    /// Each tuple is `(item, depth)` in pre-order.
-    pub fn set_comments(&mut self, items: Vec<(Item, usize)>) {
+    /// `items` must be in pre-order (parents before their descendants).
+    pub fn set_comments(&mut self, items: Vec<CommentWithDepth>) {
         self.comments = items
             .into_iter()
-            .map(|(item, depth)| FlatComment::new(item, depth))
+            .map(|c| FlatComment::new(c.item, c.depth))
             .collect();
         self.scroll = 0;
         self.selected = 0;
     }
 
     /// Insert child comments right after their parent in the flattened list.
-    pub fn insert_children(&mut self, parent_id: u64, children: Vec<(Item, usize)>) {
+    pub fn insert_children(&mut self, parent_id: u64, children: Vec<CommentWithDepth>) {
         let insert_pos = self
             .comments
             .iter()
@@ -126,7 +128,7 @@ impl CommentTreeState {
         if let Some(pos) = insert_pos {
             let new_comments: Vec<FlatComment> = children
                 .into_iter()
-                .map(|(item, depth)| FlatComment::new(item, depth))
+                .map(|c| FlatComment::new(c.item, c.depth))
                 .collect();
             // Splice them in after the parent
             self.comments.splice(pos..pos, new_comments);
@@ -238,19 +240,31 @@ mod tests {
             time: None,
             kids: None,
             descendants: None,
-            item_type: Some("comment".into()),
+            item_type: Some(ItemType::Comment),
             dead: None,
             deleted: None,
         }
     }
 
     /// Build a simple tree: root(1) -> child(2, depth 1) -> grandchild(3, depth 2), sibling(4, depth 0)
-    fn sample_tree() -> Vec<(Item, usize)> {
+    fn sample_tree() -> Vec<CommentWithDepth> {
         vec![
-            (make_item(1), 0),
-            (make_item(2), 1),
-            (make_item(3), 2),
-            (make_item(4), 0),
+            CommentWithDepth {
+                item: make_item(1),
+                depth: 0,
+            },
+            CommentWithDepth {
+                item: make_item(2),
+                depth: 1,
+            },
+            CommentWithDepth {
+                item: make_item(3),
+                depth: 2,
+            },
+            CommentWithDepth {
+                item: make_item(4),
+                depth: 0,
+            },
         ]
     }
 
@@ -274,11 +288,18 @@ mod tests {
         assert_eq!(state.selected, 0);
     }
 
+    fn cwd(id: u64, depth: usize) -> CommentWithDepth {
+        CommentWithDepth {
+            item: make_item(id),
+            depth,
+        }
+    }
+
     #[test]
     fn insert_children_after_parent() {
         let mut state = CommentTreeState::new();
-        state.set_comments(vec![(make_item(1), 0), (make_item(4), 0)]);
-        state.insert_children(1, vec![(make_item(2), 1), (make_item(3), 1)]);
+        state.set_comments(vec![cwd(1, 0), cwd(4, 0)]);
+        state.insert_children(1, vec![cwd(2, 1), cwd(3, 1)]);
         assert_eq!(state.comments.len(), 4);
         assert_eq!(state.comments[1].item.id, 2);
         assert_eq!(state.comments[2].item.id, 3);
@@ -288,8 +309,8 @@ mod tests {
     #[test]
     fn insert_children_missing_parent_noop() {
         let mut state = CommentTreeState::new();
-        state.set_comments(vec![(make_item(1), 0)]);
-        state.insert_children(999, vec![(make_item(2), 1)]);
+        state.set_comments(vec![cwd(1, 0)]);
+        state.insert_children(999, vec![cwd(2, 1)]);
         assert_eq!(state.comments.len(), 1);
     }
 
@@ -519,7 +540,7 @@ mod tests {
         assert_eq!(state.pending_root_ids.len(), 2);
 
         // CommentsAppended for root 1 → children arrive, remove from pending
-        state.insert_children(1, vec![(make_item(10), 1)]);
+        state.insert_children(1, vec![cwd(10, 1)]);
         state.pending_root_ids.remove(&1);
         assert!(!state.pending_root_ids.contains(&1));
         assert!(state.pending_root_ids.contains(&4));

--- a/src/state/prior_state.rs
+++ b/src/state/prior_state.rs
@@ -7,6 +7,8 @@
 //! presses `h`.
 
 use crate::api::types::Item;
+#[cfg(test)]
+use crate::api::types::ItemType;
 
 /// State backing the prior-discussions overlay.
 ///
@@ -81,7 +83,7 @@ mod tests {
             time: Some(1000),
             kids: None,
             descendants: Some(10),
-            item_type: Some("story".into()),
+            item_type: Some(ItemType::Story),
             dead: None,
             deleted: None,
         }


### PR DESCRIPTION
Closes #87. Second bundle from the Rust-idiom audit — this one focuses on pushing invariants into the type system.

## Summary

- **`Vec<(Item, usize)>` → `Vec<CommentWithDepth>`** — named struct replaces the anonymous `(item, depth)` tuple (11 call sites).
- **`append: bool` → `enum LoadMode`** — `AppMessage::StoriesLoaded` / `SearchResultsLoaded` variants + `spawn_search` / `spawn_load_stories` now take `LoadMode::Replace` / `LoadMode::Append`.
- **`item_type: Option<String>` → `Option<ItemType>`** — enum with `#[serde(rename_all = \"lowercase\")]` + `#[serde(other)] Unknown` fallback. All `Some(\"job\")`/`Some(\"poll\")` string matches become typed variants.
- **`From<SearchHit> for Item` → `TryFrom`** — drops the silent `unwrap_or(0)` sentinel, `filter_map`s bad hits upstream, and removes the two `story.id > 0` guards in `src/app.rs` that were compensating for it.

Net diff: **+171 / −102** across 5 files.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` — 179 passed (updated the `search_hit_invalid_object_id` test to assert `is_err()` now that we no longer fall back to `id=0`)
- `cargo build --release` ✓

## Test plan

- [ ] `cargo run` — open a story, navigate comments, open prior discussions, search — all flows behave as before.
- [ ] Switch feeds (1-6) — confirm stories load (exercises `LoadMode::Replace`).
- [ ] Scroll to the bottom of the story list — confirm pagination (exercises `LoadMode::Append`).
- [ ] Press `h` on a story with prior discussions — confirm submissions load (exercises the Algolia `TryFrom` path).
- [ ] Search for a term (`/` then typing) — confirm results arrive (exercises the `search_stories` `TryFrom` path).

## Deferred — still available for a future PR

From the same audit, not touched here:

- LRU cache holding `Arc<Item>` instead of owned `Item` to avoid clone-on-insert + clone-on-hit (W6)
- `StatusBar<'a>` with borrowed `&str` fields instead of owned `String` (W12)
- Comment-tree `Vec<Span<'static>>` refactor to avoid double-cloning (W1)
- Per-frame `Vec` allocations in `visible_comments` / `visible_indices` (W3)
- `static INDENTS` table instead of `"  ".repeat(depth)` per frame (S1)
- `const`/`OnceLock`-cached `theme::*_style()` helpers (S2)
- Table-driven `BADGE_PREFIXES` in `Item::badge` / `display_title` (S3)
- `HashSet` toggle one-hash idiom in `toggle_collapse` (S6)
- Newtype `StoryId`/`CommentId` (S7)
- `parking_lot::Mutex` or helper for cache lock (S10)