### PR TITLE
Rust idiom polish: allocation-free nav, const theme, table-driven badges

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -65,37 +65,20 @@ impl Item {
             _ => {}
         }
         let title = self.title.as_deref()?;
-        if title.starts_with("Ask HN:") {
-            return Some(StoryBadge::Ask);
-        }
-        if title.starts_with("Show HN:") {
-            return Some(StoryBadge::Show);
-        }
-        if title.starts_with("Tell HN:") {
-            return Some(StoryBadge::Tell);
-        }
-        if title.starts_with("Launch HN:") {
-            return Some(StoryBadge::Launch);
-        }
-        None
+        BADGE_PREFIXES
+            .iter()
+            .find(|(prefix, _)| title.starts_with(prefix))
+            .map(|(_, badge)| *badge)
     }
 
     /// Title with badge prefix stripped (e.g. `"Ask HN: Foo"` → `"Foo"`).
     pub fn display_title(&self) -> &str {
         let title = self.title.as_deref().unwrap_or("[no title]");
-        if let Some(rest) = title.strip_prefix("Ask HN:") {
-            return rest.trim_start();
-        }
-        if let Some(rest) = title.strip_prefix("Show HN:") {
-            return rest.trim_start();
-        }
-        if let Some(rest) = title.strip_prefix("Tell HN:") {
-            return rest.trim_start();
-        }
-        if let Some(rest) = title.strip_prefix("Launch HN:") {
-            return rest.trim_start();
-        }
-        title
+        BADGE_PREFIXES
+            .iter()
+            .find_map(|(prefix, _)| title.strip_prefix(prefix))
+            .map(str::trim_start)
+            .unwrap_or(title)
     }
 }
 
@@ -136,6 +119,16 @@ pub enum StoryBadge {
     Job,
     Poll,
 }
+
+/// Title-prefix → badge mapping used by both [`Item::badge`] and
+/// [`Item::display_title`]. Adding a new "X HN:" prefix is a one-line
+/// change here — both lookup sites pick it up automatically.
+const BADGE_PREFIXES: &[(&str, StoryBadge)] = &[
+    ("Ask HN:", StoryBadge::Ask),
+    ("Show HN:", StoryBadge::Show),
+    ("Tell HN:", StoryBadge::Tell),
+    ("Launch HN:", StoryBadge::Launch),
+];
 
 impl StoryBadge {
     /// Human-readable label (e.g. `"Ask HN"`, `"Show HN"`) used in the UI.

--- a/src/app.rs
+++ b/src/app.rs
@@ -990,7 +990,7 @@ impl App {
                 .flatten();
 
             if let Some(vi) = visual_index {
-                let visible_len = self.comment_state.visible_comments().len();
+                let visible_len = self.comment_state.visible_len();
                 if vi < visible_len {
                     // Check for double-click to toggle collapse
                     let now = std::time::Instant::now();

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -135,40 +135,58 @@ impl CommentTreeState {
         }
     }
 
-    /// Walk the comment tree, skipping subtrees rooted at a collapsed comment.
-    /// Returns the indices (into `self.comments`) that should be shown.
-    pub fn visible_indices(&self) -> Vec<usize> {
-        let mut indices = Vec::with_capacity(self.comments.len());
+    /// Walks the comment tree, skipping subtrees rooted at a collapsed
+    /// comment, and yields the indices (into `self.comments`) that should
+    /// be shown. Allocation-free — prefer this for `.count()` /
+    /// `.nth(...)` over the `Vec`-returning [`Self::visible_indices`].
+    pub fn visible_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
         let mut skip_depth: Option<usize> = None;
-        for (i, comment) in self.comments.iter().enumerate() {
-            if let Some(sd) = skip_depth {
-                if comment.depth > sd {
-                    continue;
-                } else {
+        self.comments
+            .iter()
+            .enumerate()
+            .filter_map(move |(i, comment)| {
+                if let Some(sd) = skip_depth {
+                    if comment.depth > sd {
+                        return None;
+                    }
                     skip_depth = None;
                 }
-            }
-            if self.collapsed.contains(&comment.item.id) {
-                skip_depth = Some(comment.depth);
-            }
-            indices.push(i);
-        }
-        indices
+                if self.collapsed.contains(&comment.item.id) {
+                    skip_depth = Some(comment.depth);
+                }
+                Some(i)
+            })
     }
 
-    /// Resolves [`visible_indices`](Self::visible_indices) into borrowed
-    /// comment references.
+    /// `Vec`-backed form of [`Self::visible_indices_iter`] — used by the
+    /// renderer which needs to index the list as `&[usize]` for scroll
+    /// calculations.
+    pub fn visible_indices(&self) -> Vec<usize> {
+        self.visible_indices_iter().collect()
+    }
+
+    /// Count of currently-visible comments. Replaces a `Vec`-allocating
+    /// `visible_comments().len()` in navigation hot paths (every
+    /// keystroke).
+    pub fn visible_len(&self) -> usize {
+        self.visible_indices_iter().count()
+    }
+
+    /// Resolves [`Self::visible_indices`] into borrowed comment
+    /// references. Test-only — production code should prefer
+    /// [`Self::visible_indices_iter`] (no allocation) or
+    /// [`Self::visible_len`] (just the count).
+    #[cfg(test)]
     pub fn visible_comments(&self) -> Vec<&FlatComment> {
-        self.visible_indices()
-            .into_iter()
+        self.visible_indices_iter()
             .map(|i| &self.comments[i])
             .collect()
     }
 
     pub fn select_next(&mut self) {
-        let visible_len = self.visible_comments().len();
-        if visible_len > 0 {
-            self.selected = (self.selected + 1).min(visible_len - 1);
+        let len = self.visible_len();
+        if len > 0 {
+            self.selected = (self.selected + 1).min(len - 1);
         }
     }
 
@@ -182,16 +200,16 @@ impl CommentTreeState {
     }
 
     pub fn jump_bottom(&mut self) {
-        let visible_len = self.visible_comments().len();
-        if visible_len > 0 {
-            self.selected = visible_len - 1;
+        let len = self.visible_len();
+        if len > 0 {
+            self.selected = len - 1;
         }
     }
 
     pub fn page_down(&mut self, page_size: usize) {
-        let visible_len = self.visible_comments().len();
-        if visible_len > 0 {
-            self.selected = (self.selected + page_size).min(visible_len - 1);
+        let len = self.visible_len();
+        if len > 0 {
+            self.selected = (self.selected + page_size).min(len - 1);
         }
     }
 
@@ -202,14 +220,14 @@ impl CommentTreeState {
     /// Flips the collapse state of the currently selected comment.
     /// Collapsing hides the subtree on the next `visible_indices` call.
     pub fn toggle_collapse(&mut self) {
-        let visible = self.visible_comments();
-        if let Some(comment) = visible.get(self.selected) {
-            let id = comment.item.id;
-            if self.collapsed.contains(&id) {
-                self.collapsed.remove(&id);
-            } else {
-                self.collapsed.insert(id);
-            }
+        let Some(idx) = self.visible_indices_iter().nth(self.selected) else {
+            return;
+        };
+        let id = self.comments[idx].item.id;
+        // Single-lookup toggle: `HashSet::remove` returns whether the key
+        // was present, so we can skip the explicit `contains` probe.
+        if !self.collapsed.remove(&id) {
+            self.collapsed.insert(id);
         }
     }
 

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -340,7 +340,7 @@ fn measure_comments(
     for (vi, &idx) in visible_indices.iter().enumerate() {
         let mut lines = Vec::new();
         let depth = all_comments[idx].depth;
-        let indent = "  ".repeat(depth);
+        let indent = indent_for(depth);
         let bar = "│ ";
         let text_width = width.saturating_sub(indent.len() + bar.len() + 2);
         let is_collapsed = collapsed.contains(&all_comments[idx].item.id);
@@ -442,4 +442,24 @@ fn count_hidden_children(all: &[FlatComment], parent_idx: usize) -> usize {
         .iter()
         .take_while(|c| c.depth > parent_depth)
         .count()
+}
+
+/// Precomputed indentation strings for comment depths 0..=MAX_COMMENT_DEPTH.
+/// Avoids a `"  ".repeat(depth)` allocation per visible comment per frame.
+const INDENTS: [&str; 11] = [
+    "",
+    "  ",
+    "    ",
+    "      ",
+    "        ",
+    "          ",
+    "            ",
+    "              ",
+    "                ",
+    "                  ",
+    "                    ",
+];
+
+fn indent_for(depth: usize) -> &'static str {
+    INDENTS[depth.min(INDENTS.len() - 1)]
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -26,71 +26,75 @@ pub const PEACH: Color = Color::Rgb(250, 179, 135);
 /// Colors for comment depth levels (cycles through these).
 pub const DEPTH_COLORS: [Color; 6] = [HN_ORANGE, BLUE, GREEN, MAUVE, TEAL, PEACH];
 
+// Each style helper is `const fn` so the compiler can fold it into a
+// compile-time constant at every call site — the per-frame render loop
+// calls these helpers dozens of times.
+
 /// Default foreground on the base background — body text.
-pub fn base_style() -> Style {
-    Style::default().fg(TEXT).bg(BG)
+pub const fn base_style() -> Style {
+    Style::new().fg(TEXT).bg(BG)
 }
 
 /// Highlighted row: base fg on surface bg, bold.
-pub fn selected_style() -> Style {
-    Style::default()
+pub const fn selected_style() -> Style {
+    Style::new()
         .fg(TEXT)
         .bg(SURFACE)
         .add_modifier(Modifier::BOLD)
 }
 
 /// HN-orange bold for widget titles.
-pub fn title_style() -> Style {
-    Style::default().fg(HN_ORANGE).add_modifier(Modifier::BOLD)
+pub const fn title_style() -> Style {
+    Style::new().fg(HN_ORANGE).add_modifier(Modifier::BOLD)
 }
 
 /// Default header-bar style: body fg on surface bg.
-pub fn header_style() -> Style {
-    Style::default().fg(TEXT).bg(SURFACE)
+pub const fn header_style() -> Style {
+    Style::new().fg(TEXT).bg(SURFACE)
 }
 
 /// Default status-bar style: muted fg on surface bg.
-pub fn status_style() -> Style {
-    Style::default().fg(SUBTEXT).bg(SURFACE)
+pub const fn status_style() -> Style {
+    Style::new().fg(SUBTEXT).bg(SURFACE)
 }
 
 /// HN-orange foreground — brand accents.
-pub fn accent_style() -> Style {
-    Style::default().fg(HN_ORANGE)
+pub const fn accent_style() -> Style {
+    Style::new().fg(HN_ORANGE)
 }
 
 /// Dimmed foreground — hints and secondary text.
-pub fn dim_style() -> Style {
-    Style::default().fg(DIM)
+pub const fn dim_style() -> Style {
+    Style::new().fg(DIM)
 }
 
 /// Secondary foreground — author/score metadata.
-pub fn meta_style() -> Style {
-    Style::default().fg(SUBTEXT)
+pub const fn meta_style() -> Style {
+    Style::new().fg(SUBTEXT)
 }
 
 /// Selected feed-tab: bg swapped with HN-orange, bold.
-pub fn active_tab_style() -> Style {
-    Style::default()
+pub const fn active_tab_style() -> Style {
+    Style::new()
         .fg(BG)
         .bg(HN_ORANGE)
         .add_modifier(Modifier::BOLD)
 }
 
 /// Unselected feed-tab: muted fg on surface bg.
-pub fn inactive_tab_style() -> Style {
-    Style::default().fg(SUBTEXT).bg(SURFACE)
+pub const fn inactive_tab_style() -> Style {
+    Style::new().fg(SUBTEXT).bg(SURFACE)
 }
 
 /// Wraps `depth` modulo 6 into [`DEPTH_COLORS`]; used to color comment
 /// indentation bars so nested replies are visually distinct.
-pub fn depth_color(depth: usize) -> Color {
+pub const fn depth_color(depth: usize) -> Color {
     DEPTH_COLORS[depth % DEPTH_COLORS.len()]
 }
 
 /// Bold badge color on the surface background — one color per
 /// [`StoryBadge`](crate::api::types::StoryBadge) variant.
-pub fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
+pub const fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
     use crate::api::types::StoryBadge;
     let color = match badge {
         StoryBadge::Ask => BLUE,
@@ -100,7 +104,7 @@ pub fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
         StoryBadge::Job => YELLOW,
         StoryBadge::Poll => TEAL,
     };
-    Style::default()
+    Style::new()
         .fg(color)
         .bg(SURFACE)
         .add_modifier(Modifier::BOLD)


### PR DESCRIPTION
Closes #89. Third bundle from the Rust-idiom audit.

## Summary

- **W3** — `visible_indices_iter()` + `visible_len()` on `CommentTreeState` replace the `Vec<&FlatComment>`-allocating `visible_comments().len()` used on every nav keystroke. `visible_comments` is now test-only (`#[cfg(test)]`).
- **S6** — `toggle_collapse` uses `HashSet::remove`'s boolean return to flip state in one hash lookup instead of two.
- **S1** — `"  ".repeat(depth)` per-comment-per-frame → `const INDENTS: [&str; 11]` table lookup.
- **S3** — Duplicated "Ask HN:" / "Show HN:" / "Tell HN:" / "Launch HN:" ladder in `Item::badge` and `Item::display_title` → one `const BADGE_PREFIXES` table.
- **S2** — All `theme::*_style()` helpers are now `pub const fn` (ratatui 0.30's `Style` builders are `const`-compatible), so each call folds to a compile-time constant.

Net diff: **+123 / −88** across 5 files.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` — 179 passed
- `cargo build --release` ✓

## Not in this bundle

- **W6** (LRU `Arc<Item>`) needs public-API changes through `fetch_item` / `fetch_items` and several `app.rs` call sites to actually save allocations — deferred as its own PR.
- **W1** comment-tree span refactor — the biggest remaining change, still deferred.
- **W12** `StatusBar<'a>` — deferred.

## Test plan

- [ ] `cargo run`, navigate comments with `j` / `k`, collapse/expand with Enter — no visual regression.
- [ ] Open the help overlay (`?`), switch feeds (1-6), search (`/`), open articles (`p`), open prior discussions (`h`) — every style looks identical.
- [ ] `Ask HN` / `Show HN` / `Tell HN` / `Launch HN` / job / poll stories still show correct badges and truncated titles.