### PR TITLE
Borrow in StatusBar + extract cache() helper

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -11,7 +11,7 @@ use futures::stream::{self, StreamExt};
 use lru::LruCache;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 const BASE_URL: &str = "https://hacker-news.firebaseio.com/v0";
 const ALGOLIA_URL: &str = "https://hn.algolia.com/api/v1/search";
@@ -40,10 +40,18 @@ impl HnClient {
         }
     }
 
+    /// Locks the item cache, recovering from a poisoned mutex by taking
+    /// the inner guard. Poison can happen if a spawned task panics while
+    /// holding the lock; we'd rather keep serving stale cached items than
+    /// crash the TUI.
+    fn cache(&self) -> MutexGuard<'_, LruCache<u64, Item>> {
+        self.cache.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Drops every cached item. Called on feed switch and refresh to avoid
     /// serving stale data.
     pub fn clear_cache(&self) {
-        self.cache.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        self.cache().clear();
     }
 
     /// Fetches the list of story IDs for a given feed.
@@ -55,12 +63,9 @@ impl HnClient {
 
     /// Fetches a single item by ID, consulting the LRU cache first.
     pub async fn fetch_item(&self, id: u64) -> Result<Option<Item>> {
-        // Check cache first
-        {
-            let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(item) = cache.get(&id) {
-                return Ok(Some(item.clone()));
-            }
+        // Check cache first — release the lock before the network call.
+        if let Some(item) = self.cache().get(&id).cloned() {
+            return Ok(Some(item));
         }
 
         let url = format!("{}/item/{}.json", BASE_URL, id);
@@ -68,8 +73,7 @@ impl HnClient {
         let item: Option<Item> = resp.json().await?;
 
         if let Some(ref item) = item {
-            let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
-            cache.put(id, item.clone());
+            self.cache().put(id, item.clone());
         }
 
         Ok(item)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -114,19 +114,15 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     frame.render_widget(
         status_bar::StatusBar {
             feed: app.current_feed,
-            position,
-            error: app.error.clone(),
+            position: &position,
+            error: app.error.as_deref(),
             focus_pane: match app.focus {
                 crate::app::Pane::Stories => "Stories",
                 crate::app::Pane::Comments => "Comments",
             },
             input_mode: app.input_mode,
-            search_input: app.search_state.as_ref().map(|ss| ss.input.clone()),
-            search_query: if search_active {
-                search_query.map(|s| s.to_string())
-            } else {
-                None
-            },
+            search_input: app.search_state.as_ref().map(|ss| ss.input.as_str()),
+            search_query: if search_active { search_query } else { None },
         },
         layout.status,
     );

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -16,17 +16,21 @@ use ratatui::{
 /// Bottom status bar. Display mode depends on `input_mode` and
 /// `search_query`: a `/` prompt during input, a search-results banner
 /// while search results are shown, or the normal feed/hint line.
-pub struct StatusBar {
+///
+/// All string fields borrow from [`crate::app::App`]. The widget is
+/// rebuilt per-frame and consumed immediately, so ownership is
+/// unnecessary — cloning the same strings every frame was wasted work.
+pub struct StatusBar<'a> {
     pub feed: FeedKind,
-    pub position: String,
-    pub error: Option<String>,
+    pub position: &'a str,
+    pub error: Option<&'a str>,
     pub focus_pane: &'static str,
     pub input_mode: InputMode,
-    pub search_input: Option<String>,
-    pub search_query: Option<String>,
+    pub search_input: Option<&'a str>,
+    pub search_query: Option<&'a str>,
 }
 
-impl Widget for StatusBar {
+impl<'a> Widget for StatusBar<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         // Fill background
         for x in area.left()..area.right() {
@@ -37,7 +41,7 @@ impl Widget for StatusBar {
 
         if self.input_mode == InputMode::SearchInput {
             // Search input mode
-            let input = self.search_input.unwrap_or_default();
+            let input = self.search_input.unwrap_or("");
             spans.push(Span::styled(
                 " / ",
                 theme::accent_style().bg(theme::SURFACE),
@@ -50,7 +54,7 @@ impl Widget for StatusBar {
                 " (Enter:search  Esc:cancel)",
                 theme::dim_style(),
             ));
-        } else if let Some(ref query) = self.search_query {
+        } else if let Some(query) = self.search_query {
             // Search results mode
             spans.push(Span::styled(
                 format!(" Search: \"{}\" ", query),
@@ -58,7 +62,7 @@ impl Widget for StatusBar {
             ));
             spans.push(Span::styled(" ", theme::status_style()));
 
-            if let Some(err) = &self.error {
+            if let Some(err) = self.error {
                 spans.push(Span::styled(
                     format!("Error: {} ", err),
                     ratatui::style::Style::default()
@@ -79,7 +83,7 @@ impl Widget for StatusBar {
             ));
             spans.push(Span::styled(" ", theme::status_style()));
 
-            if let Some(err) = &self.error {
+            if let Some(err) = self.error {
                 spans.push(Span::styled(
                     format!("Error: {} ", err),
                     ratatui::style::Style::default()


### PR DESCRIPTION
Closes #91. Fourth small bundle from the Rust-idiom audit.

## Summary

- **W12** — `StatusBar` becomes `StatusBar<'a>` with borrowed `&str` fields. The widget is rebuilt per-frame and consumed immediately, so ownership was unnecessary. Removes three per-frame clones (`app.error`, `ss.input`, search query) and one `to_string()`.
- **S10** — Extract the `.lock().unwrap_or_else(|e| e.into_inner())` poison-recovery pattern (repeated 3× in `api/client.rs`) into a private `fn cache(&self) -> MutexGuard<'_, LruCache<u64, Item>>` helper. Preserves the intentional poison-recovery behavior — we'd rather serve stale cached items than crash the TUI if a spawned task panics while holding the lock.

Net diff: **+32 / −28** across 3 files.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` — 179 passed
- `cargo build --release` ✓

## Test plan

- [ ] `cargo run` — status bar renders identically (feed tab, search mode, error states, position counter on both panes).
- [ ] Search mode: type a query (`/ … Enter`), error display, pane-switch — status bar rebuilds correctly per frame.
- [ ] Rapidly switch feeds (1-6) — cache clears (exercises `clear_cache` → `cache()` helper).
- [ ] Open several stories to populate the cache, then open a story that's been cached — comments load from cache (exercises `fetch_item` cache-hit path).

## Still deferred

- **W1** — Comment-tree `Vec<Span<'static>>` refactor (biggest remaining perf win, biggest refactor).
- **W6** — LRU cache `Arc<Item>` with API changes through `fetch_item` / `fetch_items` to actually save clones.
- **S7** — Newtype `StoryId` / `CommentId`.