### PR TITLE
Newtype StoryId/CommentId for typed ID boundaries

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -92,6 +92,18 @@ pub struct CommentWithDepth {
     pub depth: usize,
 }
 
+/// Newtype wrapper for a story's HN item ID. Distinct from [`CommentId`]
+/// at the type level so story-keyed maps (`prior_results`, `read_store`
+/// entries, in-flight query tracking) can't accidentally hold comment
+/// IDs, or vice versa. `Item::id` stays as `u64` for serde simplicity —
+/// the newtypes apply where different ID kinds share scope.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StoryId(pub u64);
+
+/// Newtype wrapper for a comment's HN item ID. See [`StoryId`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CommentId(pub u64);
+
 /// Firebase `type` field — tags an [`Item`] as story / comment / job /
 /// poll / poll option. Unknown future strings deserialize to
 /// [`ItemType::Unknown`] via `#[serde(other)]` so wire-format evolution

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 //! [`App::process_messages`] drains pending async results each frame.
 
 use crate::api::client::HnClient;
-use crate::api::types::{CommentWithDepth, FeedKind, Item};
+use crate::api::types::{CommentId, CommentWithDepth, FeedKind, Item, StoryId};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::keys::{Action, InputMode};
 use crate::state::comment_state::CommentTreeState;
@@ -62,11 +62,11 @@ pub enum AppMessage {
     CommentsLoaded {
         story: Box<Item>,
         comments: Vec<CommentWithDepth>,
-        pending_roots: HashSet<u64>,
+        pending_roots: HashSet<CommentId>,
     },
     /// Progressive update — append more child comments into the tree.
     CommentsAppended {
-        parent_id: u64,
+        parent_id: CommentId,
         children: Vec<CommentWithDepth>,
     },
     /// All outstanding comment fetches finished; clear any "loading"
@@ -89,7 +89,7 @@ pub enum AppMessage {
     /// by Algolia. `story_id` identifies the originating query so stale
     /// results (user has since deselected the story) can be dropped.
     PriorDiscussionsLoaded {
-        story_id: u64,
+        story_id: StoryId,
         submissions: Vec<Item>,
     },
 }
@@ -122,9 +122,9 @@ pub struct App {
     /// Prior-submissions query results, keyed by the story ID that was
     /// queried. Keeps each result around for the rest of the session so
     /// reopening the [`PriorDiscussionsState`] overlay doesn't trigger a refetch.
-    pub prior_results: HashMap<u64, Vec<Item>>,
+    pub prior_results: HashMap<StoryId, Vec<Item>>,
     /// Story IDs whose URL queries are in flight. Prevents duplicate spawns.
-    prior_in_flight: HashSet<u64>,
+    prior_in_flight: HashSet<StoryId>,
 
     /// Persisted read-state — records which stories have been opened and
     /// how many comments each had at the time. Rendered by
@@ -495,7 +495,7 @@ impl App {
         let Some(story) = self.comment_state.story.as_ref() else {
             return;
         };
-        let story_id = story.id;
+        let story_id = StoryId(story.id);
         if let Some(submissions) = self.prior_results.get(&story_id) {
             self.prior_state = Some(PriorDiscussionsState::new(story_id, submissions.clone()));
         } else if let Some(url) = story.url.clone() {
@@ -517,7 +517,8 @@ impl App {
         else {
             return;
         };
-        self.read_store.mark(item.id, item.descendants.unwrap_or(0));
+        self.read_store
+            .mark(StoryId(item.id), item.descendants.unwrap_or(0));
         self.prior_state = None;
         self.focus = Pane::Comments;
         self.comment_state.loading = true;
@@ -548,10 +549,10 @@ impl App {
                 .filter(|item| !item.is_dead_or_deleted())
                 .map(|item| CommentWithDepth { item, depth: 0 })
                 .collect();
-            let pending_roots: HashSet<u64> = root_comments
+            let pending_roots: HashSet<CommentId> = root_comments
                 .iter()
                 .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                .map(|c| c.item.id)
+                .map(|c| CommentId(c.item.id))
                 .collect();
             let _ = tx.send(AppMessage::CommentsLoaded {
                 story: Box::new(story.clone()),
@@ -563,7 +564,7 @@ impl App {
                 if child_ids.is_empty() {
                     continue;
                 }
-                let parent_id = c.item.id;
+                let parent_id = CommentId(c.item.id);
                 let mut children = Vec::new();
                 client
                     .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
@@ -716,7 +717,7 @@ impl App {
     /// given URL. No-ops if the story's URL has already been queried or a
     /// query is already in flight. Failures silently no-op — prior-discussions
     /// is optional UX, not critical-path.
-    fn spawn_prior_discussions(&mut self, story_id: u64, url: &str) {
+    fn spawn_prior_discussions(&mut self, story_id: StoryId, url: &str) {
         if self.prior_results.contains_key(&story_id) || self.prior_in_flight.contains(&story_id) {
             return;
         }
@@ -727,7 +728,7 @@ impl App {
         let url = url.to_string();
         tokio::spawn(async move {
             let submissions = match client.search_by_url(&url).await {
-                Ok(items) => items.into_iter().filter(|i| i.id != story_id).collect(),
+                Ok(items) => items.into_iter().filter(|i| i.id != story_id.0).collect(),
                 Err(_) => Vec::new(),
             };
             let _ = tx.send(AppMessage::PriorDiscussionsLoaded {
@@ -745,14 +746,14 @@ impl App {
     fn load_selected_comments(&mut self) {
         if let Some(story) = self.story_state.selected_story().cloned() {
             self.read_store
-                .mark(story.id, story.descendants.unwrap_or(0));
+                .mark(StoryId(story.id), story.descendants.unwrap_or(0));
             self.comment_state.loading = true;
             self.focus = Pane::Comments;
 
             // Fire a background prior-submissions query for this story's URL
             // so the `h` overlay has data ready when the user asks for it.
             if let Some(url) = story.url.as_deref() {
-                self.spawn_prior_discussions(story.id, url);
+                self.spawn_prior_discussions(StoryId(story.id), url);
             }
 
             let client = self.client.clone();
@@ -783,10 +784,10 @@ impl App {
                     .map(|item| CommentWithDepth { item, depth: 0 })
                     .collect();
 
-                let pending_roots: HashSet<u64> = root_comments
+                let pending_roots: HashSet<CommentId> = root_comments
                     .iter()
                     .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                    .map(|c| c.item.id)
+                    .map(|c| CommentId(c.item.id))
                     .collect();
 
                 let _ = tx.send(AppMessage::CommentsLoaded {
@@ -801,7 +802,7 @@ impl App {
                     if child_ids.is_empty() {
                         continue;
                     }
-                    let parent_id = c.item.id;
+                    let parent_id = CommentId(c.item.id);
                     let mut children = Vec::new();
                     client
                         .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -8,7 +8,7 @@
 
 #[cfg(test)]
 use crate::api::types::ItemType;
-use crate::api::types::{CommentWithDepth, Item};
+use crate::api::types::{CommentId, CommentWithDepth, Item};
 use std::collections::HashSet;
 
 /// One comment in the flattened, depth-tagged comment tree.
@@ -61,11 +61,11 @@ pub struct CommentTreeState {
     pub selected: usize,
     /// Collapsed-subtree comment IDs; their descendants are hidden from
     /// `visible_comments()`.
-    pub collapsed: HashSet<u64>,
+    pub collapsed: HashSet<CommentId>,
     pub loading: bool,
     pub story: Option<Item>,
     /// Root-comment IDs whose subtrees are still being fetched.
-    pub pending_root_ids: HashSet<u64>,
+    pub pending_root_ids: HashSet<CommentId>,
     /// Maps screen row (relative to inner area top) → visible comment index.
     /// Populated during render for mouse click handling.
     pub row_map: Vec<Option<usize>>,
@@ -118,11 +118,11 @@ impl CommentTreeState {
     }
 
     /// Insert child comments right after their parent in the flattened list.
-    pub fn insert_children(&mut self, parent_id: u64, children: Vec<CommentWithDepth>) {
+    pub fn insert_children(&mut self, parent_id: CommentId, children: Vec<CommentWithDepth>) {
         let insert_pos = self
             .comments
             .iter()
-            .position(|c| c.item.id == parent_id)
+            .position(|c| c.item.id == parent_id.0)
             .map(|i| i + 1);
 
         if let Some(pos) = insert_pos {
@@ -151,7 +151,7 @@ impl CommentTreeState {
                     }
                     skip_depth = None;
                 }
-                if self.collapsed.contains(&comment.item.id) {
+                if self.collapsed.contains(&CommentId(comment.item.id)) {
                     skip_depth = Some(comment.depth);
                 }
                 Some(i)
@@ -223,7 +223,7 @@ impl CommentTreeState {
         let Some(idx) = self.visible_indices_iter().nth(self.selected) else {
             return;
         };
-        let id = self.comments[idx].item.id;
+        let id = CommentId(self.comments[idx].item.id);
         // Single-lookup toggle: `HashSet::remove` returns whether the key
         // was present, so we can skip the explicit `contains` probe.
         if !self.collapsed.remove(&id) {
@@ -313,11 +313,15 @@ mod tests {
         }
     }
 
+    fn cid(n: u64) -> CommentId {
+        CommentId(n)
+    }
+
     #[test]
     fn insert_children_after_parent() {
         let mut state = CommentTreeState::new();
         state.set_comments(vec![cwd(1, 0), cwd(4, 0)]);
-        state.insert_children(1, vec![cwd(2, 1), cwd(3, 1)]);
+        state.insert_children(cid(1), vec![cwd(2, 1), cwd(3, 1)]);
         assert_eq!(state.comments.len(), 4);
         assert_eq!(state.comments[1].item.id, 2);
         assert_eq!(state.comments[2].item.id, 3);
@@ -328,7 +332,7 @@ mod tests {
     fn insert_children_missing_parent_noop() {
         let mut state = CommentTreeState::new();
         state.set_comments(vec![cwd(1, 0)]);
-        state.insert_children(999, vec![cwd(2, 1)]);
+        state.insert_children(cid(999), vec![cwd(2, 1)]);
         assert_eq!(state.comments.len(), 1);
     }
 
@@ -343,7 +347,7 @@ mod tests {
     fn visible_comments_collapse_root_hides_children() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1); // collapse root comment
+        state.collapsed.insert(cid(1)); // collapse root comment
         let visible = state.visible_comments();
         let ids: Vec<u64> = visible.iter().map(|c| c.item.id).collect();
         // Root 1 visible (but collapsed), children 2,3 hidden, sibling 4 visible
@@ -354,7 +358,7 @@ mod tests {
     fn visible_comments_collapse_mid_level() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(2); // collapse child at depth 1
+        state.collapsed.insert(cid(2)); // collapse child at depth 1
         let visible = state.visible_comments();
         let ids: Vec<u64> = visible.iter().map(|c| c.item.id).collect();
         // 1 visible, 2 visible (collapsed), 3 hidden (child of 2), 4 visible
@@ -448,7 +452,7 @@ mod tests {
     fn select_next_clamps_at_visible_end_when_collapsed() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1); // visible: [1, 4]
+        state.collapsed.insert(cid(1)); // visible: [1, 4] still works below
         state.select_next();
         assert_eq!(state.selected, 1);
         state.select_next();
@@ -459,7 +463,7 @@ mod tests {
     fn jump_bottom_respects_collapse() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1); // visible: [1, 4]
+        state.collapsed.insert(cid(1)); // visible: [1, 4] still works below
         state.jump_bottom();
         assert_eq!(state.selected, 1);
     }
@@ -500,7 +504,7 @@ mod tests {
     fn page_down_respects_collapse() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1); // visible: [1, 4]
+        state.collapsed.insert(cid(1)); // visible: [1, 4] still works below
         state.page_down(5);
         assert_eq!(state.selected, 1);
     }
@@ -510,16 +514,16 @@ mod tests {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
         state.toggle_collapse();
-        assert!(state.collapsed.contains(&1));
+        assert!(state.collapsed.contains(&cid(1)));
     }
 
     #[test]
     fn toggle_collapse_removes_from_set() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1);
+        state.collapsed.insert(cid(1));
         state.toggle_collapse();
-        assert!(!state.collapsed.contains(&1));
+        assert!(!state.collapsed.contains(&cid(1)));
     }
 
     #[test]
@@ -533,11 +537,11 @@ mod tests {
     fn reset_clears_all() {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
-        state.collapsed.insert(1);
+        state.collapsed.insert(cid(1));
         state.selected = 2;
         state.loading = true;
         state.story = Some(make_item(99));
-        state.pending_root_ids.insert(1);
+        state.pending_root_ids.insert(cid(1));
         state.reset();
         assert!(state.comments.is_empty());
         assert_eq!(state.scroll, 0);
@@ -553,15 +557,15 @@ mod tests {
         let mut state = CommentTreeState::new();
         state.set_comments(sample_tree());
         // Populate — simulating app.rs inserting after CommentsLoaded
-        state.pending_root_ids.insert(1);
-        state.pending_root_ids.insert(4);
+        state.pending_root_ids.insert(cid(1));
+        state.pending_root_ids.insert(cid(4));
         assert_eq!(state.pending_root_ids.len(), 2);
 
         // CommentsAppended for root 1 → children arrive, remove from pending
-        state.insert_children(1, vec![cwd(10, 1)]);
-        state.pending_root_ids.remove(&1);
-        assert!(!state.pending_root_ids.contains(&1));
-        assert!(state.pending_root_ids.contains(&4));
+        state.insert_children(cid(1), vec![cwd(10, 1)]);
+        state.pending_root_ids.remove(&cid(1));
+        assert!(!state.pending_root_ids.contains(&cid(1)));
+        assert!(state.pending_root_ids.contains(&cid(4)));
 
         // CommentsDone → clear remaining
         state.pending_root_ids.clear();

--- a/src/state/prior_state.rs
+++ b/src/state/prior_state.rs
@@ -6,9 +6,9 @@
 //! here and displayed via the prior-discussions overlay when the user
 //! presses `h`.
 
-use crate::api::types::Item;
 #[cfg(test)]
 use crate::api::types::ItemType;
+use crate::api::types::{Item, StoryId};
 
 /// State backing the prior-discussions overlay.
 ///
@@ -19,7 +19,7 @@ use crate::api::types::ItemType;
 pub struct PriorDiscussionsState {
     /// Story whose URL was queried. Checked against the currently selected
     /// story so stale results from a prior selection are dropped.
-    pub story_id: u64,
+    pub story_id: StoryId,
     /// Prior HN submissions of `story_id`'s URL, in Algolia default order
     /// (most recent first). May be empty when the URL has no prior submissions.
     pub submissions: Vec<Item>,
@@ -29,7 +29,7 @@ pub struct PriorDiscussionsState {
 
 impl PriorDiscussionsState {
     /// Starts a fresh overlay positioned at the first entry.
-    pub fn new(story_id: u64, submissions: Vec<Item>) -> Self {
+    pub fn new(story_id: StoryId, submissions: Vec<Item>) -> Self {
         Self {
             story_id,
             submissions,
@@ -91,15 +91,15 @@ mod tests {
 
     #[test]
     fn new_defaults_selected_to_zero() {
-        let s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        let s = PriorDiscussionsState::new(StoryId(1), vec![item(1), item(2)]);
         assert_eq!(s.selected, 0);
-        assert_eq!(s.story_id, 1);
+        assert_eq!(s.story_id, StoryId(1));
         assert_eq!(s.submissions.len(), 2);
     }
 
     #[test]
     fn select_next_clamps_at_end() {
-        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        let mut s = PriorDiscussionsState::new(StoryId(1), vec![item(1), item(2)]);
         s.select_next();
         s.select_next();
         s.select_next();
@@ -108,14 +108,14 @@ mod tests {
 
     #[test]
     fn select_prev_clamps_at_zero() {
-        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2)]);
+        let mut s = PriorDiscussionsState::new(StoryId(1), vec![item(1), item(2)]);
         s.select_prev();
         assert_eq!(s.selected, 0);
     }
 
     #[test]
     fn empty_submissions_nav_is_noop() {
-        let mut s = PriorDiscussionsState::new(1, Vec::new());
+        let mut s = PriorDiscussionsState::new(StoryId(1), Vec::new());
         s.select_next();
         s.jump_bottom();
         assert_eq!(s.selected, 0);
@@ -124,14 +124,14 @@ mod tests {
 
     #[test]
     fn jump_bottom_selects_last() {
-        let mut s = PriorDiscussionsState::new(1, vec![item(1), item(2), item(3)]);
+        let mut s = PriorDiscussionsState::new(StoryId(1), vec![item(1), item(2), item(3)]);
         s.jump_bottom();
         assert_eq!(s.selected, 2);
     }
 
     #[test]
     fn selected_submission_returns_current() {
-        let mut s = PriorDiscussionsState::new(1, vec![item(10), item(20)]);
+        let mut s = PriorDiscussionsState::new(StoryId(1), vec![item(10), item(20)]);
         assert_eq!(s.selected_submission().unwrap().id, 10);
         s.select_next();
         assert_eq!(s.selected_submission().unwrap().id, 20);

--- a/src/state/read_store.rs
+++ b/src/state/read_store.rs
@@ -9,6 +9,7 @@
 //! the path or read the file leave the store in-memory only — the feature
 //! still works within the session but is not persisted across restarts.
 
+use crate::api::types::StoryId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -36,8 +37,12 @@ pub struct ReadEntry {
 /// Constructed via [`ReadStore::load`] at startup. Mark a story as visited
 /// with [`ReadStore::mark`] and flush with [`ReadStore::save`]. Reads
 /// ([`ReadStore::is_read`], [`ReadStore::new_comments_since`]) are cheap.
+///
+/// Keyed by [`StoryId`] so the compiler catches attempts to mix in
+/// comment IDs. The JSON on disk still uses stringified-u64 keys —
+/// conversion happens at the serde boundary.
 pub struct ReadStore {
-    entries: HashMap<u64, ReadEntry>,
+    entries: HashMap<StoryId, ReadEntry>,
     path: Option<PathBuf>,
     dirty: bool,
 }
@@ -81,7 +86,7 @@ impl ReadStore {
             .map(|disk| {
                 disk.entries
                     .into_iter()
-                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (id, v)))
+                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (StoryId(id), v)))
                     .collect()
             })
             .unwrap_or_default();
@@ -109,7 +114,7 @@ impl ReadStore {
             entries: self
                 .entries
                 .iter()
-                .map(|(&id, entry)| (id.to_string(), *entry))
+                .map(|(&id, entry)| (id.0.to_string(), *entry))
                 .collect(),
         };
         let Ok(json) = serde_json::to_string(&disk) else {
@@ -127,13 +132,13 @@ impl ReadStore {
     /// Records or refreshes the entry for `id` with the current wall-clock
     /// timestamp and comment count. Evicts oldest entries if the store
     /// would overflow [`MAX_ENTRIES`].
-    pub fn mark(&mut self, id: u64, current_comment_count: i64) {
+    pub fn mark(&mut self, id: StoryId, current_comment_count: i64) {
         self.mark_at(id, current_comment_count, chrono::Utc::now().timestamp());
     }
 
     /// Variant of [`ReadStore::mark`] that uses an explicit timestamp —
     /// used by tests to keep behavior deterministic.
-    pub fn mark_at(&mut self, id: u64, current_comment_count: i64, now: i64) {
+    pub fn mark_at(&mut self, id: StoryId, current_comment_count: i64, now: i64) {
         self.entries.insert(
             id,
             ReadEntry {
@@ -148,20 +153,20 @@ impl ReadStore {
     }
 
     /// Returns whether `id` has ever been visited.
-    pub fn is_read(&self, id: u64) -> bool {
+    pub fn is_read(&self, id: StoryId) -> bool {
         self.entries.contains_key(&id)
     }
 
     /// Persisted entry for `id`, if any.
     #[cfg(test)]
-    pub fn entry(&self, id: u64) -> Option<&ReadEntry> {
+    pub fn entry(&self, id: StoryId) -> Option<&ReadEntry> {
         self.entries.get(&id)
     }
 
     /// New comments since the last visit, if any. Returns `Some(n)` when
     /// `n > 0`; `None` when the story was never visited or has no new
     /// comments. A shrinking count (rare — deletions) is clamped to `None`.
-    pub fn new_comments_since(&self, id: u64, current_count: i64) -> Option<i64> {
+    pub fn new_comments_since(&self, id: StoryId, current_count: i64) -> Option<i64> {
         let entry = self.entries.get(&id)?;
         let delta = current_count - entry.last_comment_count;
         if delta > 0 {
@@ -174,7 +179,7 @@ impl ReadStore {
     /// Drops entries with the lowest `last_seen_at` until the store is
     /// back within [`MAX_ENTRIES`].
     fn evict_oldest(&mut self) {
-        let mut ages: Vec<(i64, u64)> = self
+        let mut ages: Vec<(i64, StoryId)> = self
             .entries
             .iter()
             .map(|(&id, e)| (e.last_seen_at, id))
@@ -233,54 +238,58 @@ mod tests {
         ReadStore::load_from(p)
     }
 
+    fn sid(n: u64) -> StoryId {
+        StoryId(n)
+    }
+
     #[test]
     fn empty_store_has_no_entries() {
         let s = ReadStore::empty();
-        assert!(!s.is_read(42));
-        assert!(s.new_comments_since(42, 10).is_none());
+        assert!(!s.is_read(sid(42)));
+        assert!(s.new_comments_since(sid(42), 10).is_none());
     }
 
     #[test]
     fn mark_then_is_read() {
         let mut s = fresh_store("mark_then_is_read");
-        s.mark_at(42, 10, 1_700_000_000);
-        assert!(s.is_read(42));
-        assert!(!s.is_read(99));
+        s.mark_at(sid(42), 10, 1_700_000_000);
+        assert!(s.is_read(sid(42)));
+        assert!(!s.is_read(sid(99)));
     }
 
     #[test]
     fn new_comments_since_returns_positive_delta() {
         let mut s = fresh_store("new_comments_delta");
-        s.mark_at(42, 10, 1_700_000_000);
-        assert_eq!(s.new_comments_since(42, 15), Some(5));
+        s.mark_at(sid(42), 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(sid(42), 15), Some(5));
     }
 
     #[test]
     fn new_comments_since_returns_none_when_unchanged() {
         let mut s = fresh_store("new_comments_unchanged");
-        s.mark_at(42, 10, 1_700_000_000);
-        assert_eq!(s.new_comments_since(42, 10), None);
+        s.mark_at(sid(42), 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(sid(42), 10), None);
     }
 
     #[test]
     fn new_comments_since_returns_none_when_shrunk() {
         let mut s = fresh_store("new_comments_shrunk");
-        s.mark_at(42, 10, 1_700_000_000);
-        assert_eq!(s.new_comments_since(42, 5), None);
+        s.mark_at(sid(42), 10, 1_700_000_000);
+        assert_eq!(s.new_comments_since(sid(42), 5), None);
     }
 
     #[test]
     fn new_comments_since_none_for_unknown_id() {
         let s = ReadStore::empty();
-        assert_eq!(s.new_comments_since(99, 10), None);
+        assert_eq!(s.new_comments_since(sid(99), 10), None);
     }
 
     #[test]
     fn mark_updates_existing_entry_in_place() {
         let mut s = fresh_store("mark_updates");
-        s.mark_at(42, 10, 1_700_000_000);
-        s.mark_at(42, 25, 1_700_000_100);
-        let e = s.entry(42).unwrap();
+        s.mark_at(sid(42), 10, 1_700_000_000);
+        s.mark_at(sid(42), 25, 1_700_000_100);
+        let e = s.entry(sid(42)).unwrap();
         assert_eq!(e.last_seen_at, 1_700_000_100);
         assert_eq!(e.last_comment_count, 25);
         assert_eq!(s.len(), 1);
@@ -292,15 +301,15 @@ mod tests {
         let _ = std::fs::remove_file(&p);
         {
             let mut s = ReadStore::load_from(p.clone());
-            s.mark_at(1, 10, 1_700_000_000);
-            s.mark_at(2, 20, 1_700_000_100);
+            s.mark_at(sid(1), 10, 1_700_000_000);
+            s.mark_at(sid(2), 20, 1_700_000_100);
             s.save();
         }
         let s2 = ReadStore::load_from(p.clone());
-        assert!(s2.is_read(1));
-        assert!(s2.is_read(2));
-        assert_eq!(s2.entry(1).unwrap().last_comment_count, 10);
-        assert_eq!(s2.entry(2).unwrap().last_comment_count, 20);
+        assert!(s2.is_read(sid(1)));
+        assert!(s2.is_read(sid(2)));
+        assert_eq!(s2.entry(sid(1)).unwrap().last_comment_count, 10);
+        assert_eq!(s2.entry(sid(2)).unwrap().last_comment_count, 20);
         let _ = std::fs::remove_file(&p);
     }
 
@@ -325,21 +334,24 @@ mod tests {
     #[test]
     fn in_memory_only_store_silently_drops_save() {
         let mut s = ReadStore::empty();
-        s.mark_at(1, 10, 1000);
+        s.mark_at(sid(1), 10, 1000);
         s.save();
-        assert!(s.is_read(1));
+        assert!(s.is_read(sid(1)));
     }
 
     #[test]
     fn eviction_bounds_size_at_max_and_removes_oldest() {
         let mut s = ReadStore::empty();
         for i in 0..(MAX_ENTRIES as u64 + 5) {
-            s.mark_at(i, 0, i as i64);
+            s.mark_at(sid(i), 0, i as i64);
         }
         assert_eq!(s.len(), MAX_ENTRIES);
         for oldest in 0..5u64 {
-            assert!(!s.is_read(oldest), "oldest id {oldest} should be evicted");
+            assert!(
+                !s.is_read(sid(oldest)),
+                "oldest id {oldest} should be evicted"
+            );
         }
-        assert!(s.is_read(MAX_ENTRIES as u64 + 4));
+        assert!(s.is_read(sid(MAX_ENTRIES as u64 + 4)));
     }
 }

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -6,6 +6,7 @@
 //! populates `CommentTreeState::row_map` so mouse clicks can map rows
 //! back to comment indices.
 
+use crate::api::types::CommentId;
 use crate::state::comment_state::{CommentTreeState, FlatComment};
 use crate::ui::spinner;
 use crate::ui::story_list::format_time_ago;
@@ -329,10 +330,10 @@ impl<'a> Widget for CommentTree<'a> {
 /// fetching children get a spinner glyph.
 fn measure_comments(
     visible_indices: &[usize],
-    collapsed: &std::collections::HashSet<u64>,
+    collapsed: &std::collections::HashSet<CommentId>,
     all_comments: &mut [FlatComment],
     width: usize,
-    pending_root_ids: &std::collections::HashSet<u64>,
+    pending_root_ids: &std::collections::HashSet<CommentId>,
     spinner_frame: &str,
 ) -> Vec<MeasuredComment> {
     let mut result = Vec::new();
@@ -343,7 +344,7 @@ fn measure_comments(
         let indent = indent_for(depth);
         let bar = "│ ";
         let text_width = width.saturating_sub(indent.len() + bar.len() + 2);
-        let is_collapsed = collapsed.contains(&all_comments[idx].item.id);
+        let is_collapsed = collapsed.contains(&CommentId(all_comments[idx].item.id));
 
         // Populate/refresh the plain-text cache for this comment under a
         // short-lived mutable borrow, then read everything else immutably.
@@ -378,7 +379,7 @@ fn measure_comments(
             format!("{}{}", indent, bar),
             ratatui::style::Style::default().fg(depth_color),
         )];
-        if comment.depth == 0 && pending_root_ids.contains(&comment.item.id) {
+        if comment.depth == 0 && pending_root_ids.contains(&CommentId(comment.item.id)) {
             header_spans.push(Span::styled(
                 format!("{} ", spinner_frame),
                 ratatui::style::Style::default().fg(theme::HN_ORANGE),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,7 +72,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         .comment_state
         .story
         .as_ref()
-        .and_then(|s| app.prior_results.get(&s.id))
+        .and_then(|s| app.prior_results.get(&crate::api::types::StoryId(s.id)))
         .map(|v| v.len())
         .unwrap_or(0);
     frame.render_widget(

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -5,7 +5,7 @@
 //! [`format_time_ago`], used by the comment-tree widget for author
 //! timestamps.
 
-use crate::api::types::Item;
+use crate::api::types::{Item, StoryId};
 use crate::state::read_store::ReadStore;
 use crate::ui::theme;
 use ratatui::{
@@ -94,10 +94,11 @@ impl<'a> Widget for StoryList<'a> {
         {
             let y = inner.top() + (i - scroll) as u16;
             let is_selected = i == self.selected;
-            let is_read = self.read_store.is_read(story.id);
+            let sid = StoryId(story.id);
+            let is_read = self.read_store.is_read(sid);
             let new_comments = self
                 .read_store
-                .new_comments_since(story.id, story.descendants.unwrap_or(0));
+                .new_comments_since(sid, story.descendants.unwrap_or(0));
 
             let title = story.display_title();
             let badge = story.badge();


### PR DESCRIPTION
Closes #97. **Stacked on #94 → #96**. Merge #94 first, then #96, then this (or let GitHub auto-retarget).

## Summary

Implements **S7** from the Rust-idiom audit — the final flagged item.

`u64` story IDs and `u64` comment IDs used to flow freely across shared-scope collections. This PR makes them distinct at the type level with lightweight newtypes in `api/types.rs`:

\`\`\`rust
pub struct StoryId(pub u64);
pub struct CommentId(pub u64);
\`\`\`

Applied where different ID kinds share scope — maps, sets, and `AppMessage` variants:

| Before | After |
|---|---|
| `prior_results: HashMap<u64, Vec<Item>>` | `HashMap<StoryId, Vec<Item>>` |
| `prior_in_flight: HashSet<u64>` | `HashSet<StoryId>` |
| `collapsed: HashSet<u64>` | `HashSet<CommentId>` |
| `pending_root_ids: HashSet<u64>` | `HashSet<CommentId>` |
| `AppMessage::PriorDiscussionsLoaded { story_id: u64 }` | `{ story_id: StoryId }` |
| `AppMessage::CommentsLoaded { pending_roots: HashSet<u64> }` | `HashSet<CommentId>` |
| `AppMessage::CommentsAppended { parent_id: u64 }` | `parent_id: CommentId` |
| `PriorDiscussionsState::story_id: u64` | `StoryId` |
| `ReadStore::mark(id: u64, ...)` etc. | `StoryId` in all public signatures |
| `CommentTreeState::insert_children(parent_id: u64, ...)` | `CommentId` |

`Item::id` stays `u64` (audit-recommended — keeps serde wire-format fidelity). Wrapping happens at the boundaries where raw `story.id` meets the typed API. For `read_store`, the JSON on disk still uses stringified-u64 keys; the serde boundary converts `StoryId <-> String` via `.0`.

Net diff: **+127 / −96** across 8 files.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` — 179 passed
- `cargo build --release` ✓

## Test plan

- [ ] `cargo run` — every feature still works (stories, comments, search, article reader, prior discussions, read-state dimming).
- [ ] Open a story, quit, relaunch — read state persists (ReadStore JSON deserializes StoryId from stringified-u64 keys).
- [ ] Open `h` on a story that has prior discussions, pick one, press Enter — `open_selected_prior_discussion` threads StoryId/CommentId correctly end-to-end.
- [ ] Collapse / expand comments (Enter on a comment row) — `toggle_collapse` wraps CommentId at the boundary.
- [ ] `cat ~/.local/share/hnt/read.json` — format unchanged from before this PR.

## Audit completion

With this PR, **every flagged item from the Rust-idiom audit (W1–W12 + S1–S10) ships**. Seven-PR series total:

- #86 quick wins (W2, W4, W5, W8, W9, S9)
- #88 type-system wins (S8, W11, W10, W7)
- #90 polish (W3, S6, S1, S3, S2)
- #92 StatusBar + cache() helper (W12, S10)
- #94 LRU Arc<Item> (W6) — stacked below
- #96 comment-tree span refactor (W1) — stacked below
- This PR (S7)