### PR TITLE
Bump version to 0.3.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bumps \`Cargo.toml\` from \`0.3.10\` → \`0.3.11\`
- Triggers the \`Release\` workflow to build the four target binaries and publish \`v0.3.11\`

## What's in this release

Seven PRs' worth of Rust-idiom cleanups, completing the full codebase audit:

- **#86** quick wins — O(n²) → O(n) in `count_hidden_children`, exhaustive overlay dispatch, `open_http_url` helper, `fetch_items` clone reduction, article-reader `Span` borrowing
- **#88** type-system wins — `CommentWithDepth` struct, `LoadMode` enum, `ItemType` enum, `TryFrom<SearchHit>`
- **#90** polish — iterator-based comment navigation, `const` theme helpers, static indent table, table-driven badge prefixes, single-hash collapse toggle
- **#92** `StatusBar<'a>` borrows, cache-lock helper
- **#94** LRU cache holds `Arc<Item>`
- **#99** Comment tree stores `Vec<Span<'static>>` directly — major per-frame allocation reduction
- **#98** Newtype `StoryId` / `CommentId` for type-safe ID boundaries

Zero test regressions across all seven — 179 tests passed throughout the series.

## Test plan

- [ ] Merge → Release workflow kicks off
- [ ] All 4 target builds succeed (\`x86_64-linux\`, \`aarch64-linux\`, \`x86_64-darwin\`, \`aarch64-darwin\`)
- [ ] \`v0.3.11\` appears under [Releases](https://github.com/thijsvos/hnt/releases) with 5 assets (4 binaries + checksums)