### PR TITLE
Add Quickjump label-based link hints to the article reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Browse stories, read threaded comments, and open links — all from your termina
 - **Vim-style navigation** — `j`/`k`, `g`/`G`, `Ctrl+d`/`Ctrl+u`
 - **Search** — Algolia-powered full-text search across stories
 - **Reader mode** — Read article content directly in the terminal
+- **Quickjump link hints** — In reader mode, press `f` and every hyperlink gets a 1- or 2-character home-row label. Type the label to open it (`f` browser, `F` HNT reader, `y` copy URL via OSC 52 — works through SSH)
 - **Prior discussions** — Press `h` to see past HN submissions of the same URL with their scores and dates
 - **Read-state tracking** — Visited stories render dimmed; stories with new comments since your last visit get a `+N` badge. Persisted to `$XDG_DATA_HOME/hnt/read.json`
 - **Open in browser** — Press `o` to open the story URL
@@ -68,6 +69,7 @@ cargo build --release
 | `Enter` | Select story / toggle collapse |
 | `o` | Open URL in browser |
 | `p` | Open reader mode |
+| `f` / `F` / `y` | (in reader) Quickjump label hints — open in browser / open in reader / copy to clipboard |
 | `h` | Show prior HN submissions of this URL |
 | `/` | Search stories |
 | `Tab` | Switch pane focus |

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,8 +9,11 @@
 use crate::api::client::HnClient;
 use crate::api::types::{CommentId, CommentWithDepth, FeedKind, Item, StoryId};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
+use crate::clipboard;
 use crate::keys::{Action, InputMode};
 use crate::state::comment_state::CommentTreeState;
+use crate::state::hint_state::{HintAction, HintContext, HintState};
+use crate::state::link_registry::{LinkRegistry, MatchResult};
 use crate::state::prior_state::PriorDiscussionsState;
 use crate::state::read_store::ReadStore;
 use crate::state::reader_state::{ReaderState, StyledFragment};
@@ -38,6 +41,19 @@ pub enum Pane {
 pub enum LoadMode {
     Replace,
     Append,
+}
+
+/// Tri-state outcome of a [`crate::state::link_registry::LinkRegistry::match_prefix`]
+/// resolved against the current hint buffer. Carries the resolved URL by
+/// value so the borrow on the registry can be released before mutating
+/// `self`.
+enum HintResolve {
+    /// Multiple labels still match — keep accepting characters.
+    Continue,
+    /// No labels match (or no surface to label) — exit hint mode.
+    Cancel,
+    /// Exactly one label matches — fire the action against this URL.
+    Fire(String),
 }
 
 /// Messages sent from async tasks back to the main loop.
@@ -72,8 +88,13 @@ pub enum AppMessage {
     /// All outstanding comment fetches finished; clear any "loading"
     /// spinners.
     CommentsDone,
-    /// Article reader content extracted and ready to render.
-    ArticleLoaded { lines: Vec<Vec<StyledFragment>> },
+    /// Article reader content extracted and ready to render. `links`
+    /// carries every hyperlink in the body (with assigned hint labels)
+    /// for Quickjump.
+    ArticleLoaded {
+        lines: Vec<Vec<StyledFragment>>,
+        links: LinkRegistry,
+    },
     /// Algolia search returned a page of results.
     SearchResultsLoaded {
         stories: Vec<Item>,
@@ -133,6 +154,11 @@ pub struct App {
     /// flushed via [`App::persist`] on shutdown.
     pub read_store: ReadStore,
 
+    /// Quickjump hint-mode state — `Some` while the user is selecting a
+    /// label, `None` otherwise. Created by [`Action::EnterHintMode`]
+    /// and torn down by [`Action::ExitHintMode`] or a unique-match dispatch.
+    pub hint_state: Option<HintState>,
+
     last_comment_click: Option<(std::time::Instant, usize)>,
 
     client: HnClient,
@@ -163,6 +189,7 @@ impl App {
             prior_results: HashMap::new(),
             prior_in_flight: HashSet::new(),
             read_store: ReadStore::load(),
+            hint_state: None,
             last_comment_click: None,
             client: HnClient::new(),
             msg_tx,
@@ -268,9 +295,9 @@ impl App {
                     self.comment_state.loading = false;
                     self.comment_state.pending_root_ids.clear();
                 }
-                AppMessage::ArticleLoaded { lines } => {
+                AppMessage::ArticleLoaded { lines, links } => {
                     if let Some(ref mut reader) = self.reader_state {
-                        reader.set_content(lines);
+                        reader.set_content(lines, links);
                     }
                 }
                 AppMessage::ArticleError(msg) => {
@@ -309,6 +336,25 @@ impl App {
     /// Otherwise the action mutates the focused pane's state or spawns an
     /// async task (feed switch, refresh, comment load, search).
     pub fn dispatch(&mut self, action: Action) {
+        // Hint-mode actions short-circuit ahead of every overlay route
+        // because the user is mid-selection and any keypress should be
+        // narrowing labels, not mutating panes underneath.
+        match &action {
+            Action::HintKey(c) => {
+                self.hint_key(*c);
+                return;
+            }
+            Action::ExitHintMode => {
+                self.exit_hint_mode();
+                return;
+            }
+            Action::EnterHintMode(hint_action) => {
+                self.enter_hint_mode(*hint_action);
+                return;
+            }
+            _ => {}
+        }
+
         // When reader is open, route actions to reader.
         if self.reader_state.is_some() {
             // Back mutates the Option itself, so handle it before borrowing
@@ -341,6 +387,9 @@ impl App {
                 | Action::ToggleHelp
                 | Action::TogglePriorDiscussions
                 | Action::None => {}
+                Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
+                    unreachable!("hint actions handled above")
+                }
                 Action::Back => unreachable!("Back is handled above"),
             }
             return;
@@ -382,6 +431,9 @@ impl App {
                 | Action::PageDown
                 | Action::PageUp
                 | Action::None => {}
+                Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
+                    unreachable!("hint actions handled above")
+                }
                 Action::Back | Action::Select => unreachable!("handled above"),
             }
             return;
@@ -479,6 +531,9 @@ impl App {
             },
             Action::ToggleHelp => self.show_help = !self.show_help,
             Action::TogglePriorDiscussions => self.toggle_prior_discussions(),
+            Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
+                unreachable!("hint actions handled above")
+            }
             Action::None => {}
         }
     }
@@ -844,9 +899,9 @@ impl App {
         if url.is_none() {
             if let Some(ref text) = story.text {
                 let width = self.terminal_width.saturating_sub(6) as usize;
-                let lines = html_to_styled_lines(text.as_bytes(), width);
+                let (lines, links) = html_to_styled_lines(text.as_bytes(), width);
                 let mut reader = ReaderState::new_loading(title, domain, None);
-                reader.set_content(lines);
+                reader.set_content(lines, links);
                 self.reader_state = Some(reader);
             }
             return;
@@ -866,8 +921,8 @@ impl App {
 
         tokio::spawn(async move {
             match fetch_and_extract_article(&url, width).await {
-                Ok(lines) => {
-                    let _ = tx.send(AppMessage::ArticleLoaded { lines });
+                Ok((lines, links)) => {
+                    let _ = tx.send(AppMessage::ArticleLoaded { lines, links });
                 }
                 Err(e) => {
                     let _ = tx.send(AppMessage::ArticleError(e));
@@ -1010,6 +1065,137 @@ impl App {
                 }
             }
         }
+    }
+
+    /// Enters Quickjump hint-label mode. Determines context from current
+    /// app state — reader if the article-reader overlay is open, comments
+    /// if the comments pane is focused. No-op if no surface has links.
+    fn enter_hint_mode(&mut self, action: HintAction) {
+        // Already in hint mode? Re-entering with a different action is
+        // ambiguous; treat as a re-arm with the new action but reset the
+        // buffer so the user can start fresh.
+        let context = if self.reader_state.is_some() {
+            HintContext::Reader
+        } else if self.focus == Pane::Comments {
+            HintContext::Comments
+        } else {
+            // Nothing to label.
+            return;
+        };
+
+        // Refuse to enter if the active registry has no links — silent
+        // no-op (a status-bar hint could be added later).
+        if self
+            .active_link_registry(context)
+            .is_none_or(|r| r.is_empty())
+        {
+            return;
+        }
+
+        self.hint_state = Some(HintState::new(action, context));
+        self.input_mode = InputMode::HintMode;
+    }
+
+    /// Cancels hint-label selection without firing an action. Restores
+    /// the input mode so navigation keys work again.
+    fn exit_hint_mode(&mut self) {
+        self.hint_state = None;
+        self.input_mode = InputMode::Normal;
+    }
+
+    /// Appends `c` to the hint prefix and resolves against the active
+    /// registry: a unique match fires the configured action and exits
+    /// hint mode; multiple matches keep narrowing; no match cancels.
+    fn hint_key(&mut self, c: char) {
+        let Some(hs) = self.hint_state.as_mut() else {
+            return;
+        };
+        hs.push(c);
+
+        let context = hs.context;
+        let action = hs.action;
+        let buffer = hs.buffer().to_string();
+
+        let resolution = self
+            .active_link_registry(context)
+            .map(|r| match r.match_prefix(&buffer) {
+                MatchResult::Unique(link) => HintResolve::Fire(link.url.clone()),
+                MatchResult::Multiple => HintResolve::Continue,
+                MatchResult::None => HintResolve::Cancel,
+            })
+            .unwrap_or(HintResolve::Cancel);
+
+        match resolution {
+            HintResolve::Continue => {}
+            HintResolve::Cancel => self.exit_hint_mode(),
+            HintResolve::Fire(url) => {
+                self.exit_hint_mode();
+                self.execute_hint_action(action, &url);
+            }
+        }
+    }
+
+    /// Returns the [`LinkRegistry`] backing the current hint context. For
+    /// reader: the article's pre-built registry. For comments: the
+    /// per-frame snapshot built when hint mode was entered (populated in
+    /// the comment-tree integration step).
+    fn active_link_registry(&self, context: HintContext) -> Option<&LinkRegistry> {
+        match context {
+            HintContext::Reader => self.reader_state.as_ref().map(|r| &r.links),
+            HintContext::Comments => None, // populated by step 9 (comment-tree integration)
+        }
+    }
+
+    /// Dispatches the configured hint action against the resolved URL.
+    /// Open/OpenInReader go through the same scheme-validating
+    /// [`open_http_url`] used elsewhere; CopyUrl emits OSC 52.
+    fn execute_hint_action(&mut self, action: HintAction, url: &str) {
+        match action {
+            HintAction::Open => open_http_url(Some(url)),
+            HintAction::OpenInReader => self.open_url_in_reader(url),
+            HintAction::CopyUrl => {
+                if let Err(e) = clipboard::copy(url) {
+                    self.error = Some(format!("Clipboard write failed: {}", e));
+                }
+            }
+        }
+    }
+
+    /// Opens a hint-resolved URL in the inline article reader (the same
+    /// flow as `p`-on-a-story, but seeded from a labeled link rather
+    /// than the focused story's URL). Drops non-http(s) schemes.
+    fn open_url_in_reader(&mut self, url: &str) {
+        let parsed = match url::Url::parse(url) {
+            Ok(p) if matches!(p.scheme(), "http" | "https") => p,
+            _ => return,
+        };
+        let domain = parsed.host_str().map(|s| s.to_string());
+        let title = parsed.path().trim_matches('/').to_string();
+        let title = if title.is_empty() {
+            domain.clone().unwrap_or_else(|| url.to_string())
+        } else {
+            title
+        };
+
+        self.reader_state = Some(ReaderState::new_loading(
+            title,
+            domain,
+            Some(url.to_string()),
+        ));
+
+        let tx = self.msg_tx.clone();
+        let width = self.terminal_width.saturating_sub(6) as usize;
+        let url_owned = url.to_string();
+        tokio::spawn(async move {
+            match fetch_and_extract_article(&url_owned, width).await {
+                Ok((lines, links)) => {
+                    let _ = tx.send(AppMessage::ArticleLoaded { lines, links });
+                }
+                Err(e) => {
+                    let _ = tx.send(AppMessage::ArticleError(e));
+                }
+            }
+        });
     }
 
     /// Handles a mouse wheel event in the pane under the cursor. When the

--- a/src/article.rs
+++ b/src/article.rs
@@ -5,6 +5,7 @@
 //! and GitLab repo roots it short-circuits to the raw README. HN-native
 //! text posts (Ask HN, etc.) go through [`html_to_styled_lines`] directly.
 
+use crate::state::link_registry::LinkRegistry;
 use crate::state::reader_state::StyledFragment;
 use crate::ui::theme;
 use html2text::render::RichAnnotation;
@@ -193,11 +194,13 @@ fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>
 }
 
 /// Fetches article HTML, runs readability extraction, converts to styled
-/// lines.
+/// lines and a [`LinkRegistry`] of every hyperlink (for Quickjump hint
+/// mode). Markdown READMEs render without a link registry today — only
+/// the rich-HTML path produces hint targets.
 pub async fn fetch_and_extract_article(
     url: &str,
     width: usize,
-) -> Result<Vec<Vec<StyledFragment>>, String> {
+) -> Result<(Vec<Vec<StyledFragment>>, LinkRegistry), String> {
     let client = reqwest::Client::builder()
         .user_agent(concat!(
             "Mozilla/5.0 (compatible; hnt/",
@@ -211,10 +214,13 @@ pub async fn fetch_and_extract_article(
     // For GitHub/GitLab repo pages, try fetching the README directly
     if let Some((readme_text, is_markdown)) = try_fetch_readme(&client, url).await {
         return if is_markdown {
-            Ok(markdown_to_styled_lines(&readme_text, width))
+            Ok((
+                markdown_to_styled_lines(&readme_text, width),
+                LinkRegistry::new(),
+            ))
         } else {
             // RST / plain text — render as plain styled lines
-            Ok(readme_text
+            let lines = readme_text
                 .lines()
                 .map(|line| {
                     vec![StyledFragment {
@@ -222,7 +228,8 @@ pub async fn fetch_and_extract_article(
                         style: Style::default().fg(theme::TEXT),
                     }]
                 })
-                .collect())
+                .collect();
+            Ok((lines, LinkRegistry::new()))
         };
     }
 
@@ -279,12 +286,13 @@ pub async fn fetch_and_extract_article(
 }
 
 /// Runs readability extraction + html2text rich rendering
-/// (blocking/CPU-bound).
+/// (blocking/CPU-bound). Returns rendered lines and a [`LinkRegistry`]
+/// populated with every `<a href>` Quickjump should be able to label.
 fn extract_article_content(
     html_bytes: &[u8],
     url_str: &str,
     width: usize,
-) -> Result<Vec<Vec<StyledFragment>>, String> {
+) -> Result<(Vec<Vec<StyledFragment>>, LinkRegistry), String> {
     let parsed_url = url::Url::parse(url_str).map_err(|e| format!("Invalid URL: {}", e))?;
 
     // Try readability extraction first, fall back to full HTML if it produces no content
@@ -312,31 +320,53 @@ fn extract_article_content(
         }
     };
 
+    Ok(tagged_lines_to_styled_with_links(tagged_lines))
+}
+
+/// Walks html2text rich-tagged lines, producing per-line
+/// [`StyledFragment`] vectors and a parallel [`LinkRegistry`] that records
+/// where every hyperlink lives (line index + fragment index of the
+/// link-text fragment). The dim ` [https://...]` suffix is preserved as a
+/// secondary fragment so non-hint-mode rendering looks identical.
+fn tagged_lines_to_styled_with_links(
+    tagged_lines: Vec<html2text::render::TaggedLine<Vec<RichAnnotation>>>,
+) -> (Vec<Vec<StyledFragment>>, LinkRegistry) {
+    let mut links = LinkRegistry::new();
     let lines: Vec<Vec<StyledFragment>> = tagged_lines
         .into_iter()
-        .map(|tagged_line| {
-            let mut fragments = Vec::new();
+        .enumerate()
+        .map(|(line_idx, tagged_line)| {
+            let mut fragments: Vec<StyledFragment> = Vec::new();
             for ts in tagged_line.tagged_strings() {
                 let style = annotations_to_style(&ts.tag);
+                let url = ts.tag.iter().find_map(|ann| {
+                    if let RichAnnotation::Link(u) = ann {
+                        Some(u.clone())
+                    } else {
+                        None
+                    }
+                });
+                let fragment_idx = fragments.len();
+                let text_is_visible = !ts.s.trim().is_empty();
                 fragments.push(StyledFragment {
                     text: ts.s.clone(),
                     style,
                 });
-                // Append URL after link text
-                for ann in &ts.tag {
-                    if let RichAnnotation::Link(ref url) = ann {
-                        fragments.push(StyledFragment {
-                            text: format!(" [{}]", url),
-                            style: Style::default().fg(theme::DIM),
-                        });
+                if let Some(url) = url {
+                    if text_is_visible {
+                        links.push(url.clone(), line_idx, fragment_idx);
                     }
+                    fragments.push(StyledFragment {
+                        text: format!(" [{}]", url),
+                        style: Style::default().fg(theme::DIM),
+                    });
                 }
             }
             fragments
         })
         .collect();
-
-    Ok(lines)
+    links.assign_labels();
+    (lines, links)
 }
 
 /// Converts an html2text `RichAnnotation` set to a ratatui [`Style`].
@@ -370,32 +400,13 @@ fn annotations_to_style(annotations: &[RichAnnotation]) -> Style {
     style
 }
 
-/// Converts raw HTML bytes to styled lines using html2text rich rendering.
-pub fn html_to_styled_lines(html: &[u8], width: usize) -> Vec<Vec<StyledFragment>> {
+/// Converts raw HTML bytes to styled lines (via html2text rich rendering)
+/// and a [`LinkRegistry`] of the hyperlinks within. Used for HN-native
+/// text posts (Ask HN, Show HN, etc.) where the article body is inline
+/// HTML rather than fetched from a URL.
+pub fn html_to_styled_lines(html: &[u8], width: usize) -> (Vec<Vec<StyledFragment>>, LinkRegistry) {
     let tagged_lines = html2text::from_read_rich(html, width).unwrap_or_default();
-
-    tagged_lines
-        .into_iter()
-        .map(|tagged_line| {
-            let mut fragments = Vec::new();
-            for ts in tagged_line.tagged_strings() {
-                let style = annotations_to_style(&ts.tag);
-                fragments.push(StyledFragment {
-                    text: ts.s.clone(),
-                    style,
-                });
-                for ann in &ts.tag {
-                    if let RichAnnotation::Link(ref url) = ann {
-                        fragments.push(StyledFragment {
-                            text: format!(" [{}]", url),
-                            style: Style::default().fg(theme::DIM),
-                        });
-                    }
-                }
-            }
-            fragments
-        })
-        .collect()
+    tagged_lines_to_styled_with_links(tagged_lines)
 }
 
 #[cfg(test)]
@@ -547,16 +558,18 @@ mod tests {
     #[test]
     fn html_plain_paragraph_produces_fragments() {
         let html = b"<p>hello world</p>";
-        let lines = html_to_styled_lines(html, 80);
+        let (lines, links) = html_to_styled_lines(html, 80);
         assert!(!lines.is_empty());
         let joined: String = lines[0].iter().map(|f| f.text.as_str()).collect();
         assert!(joined.contains("hello world"));
+        // Plain paragraph has no hyperlinks.
+        assert!(links.is_empty());
     }
 
     #[test]
     fn html_link_appends_url_in_dim_fragment() {
         let html = b"<a href=\"https://example.com\">click</a>";
-        let lines = html_to_styled_lines(html, 80);
+        let (lines, _links) = html_to_styled_lines(html, 80);
         let joined: String = lines
             .iter()
             .flat_map(|l| l.iter().map(|f| f.text.as_str()))
@@ -565,8 +578,34 @@ mod tests {
     }
 
     #[test]
+    fn html_link_populates_registry_with_label() {
+        let html = b"<a href=\"https://example.com\">click</a>";
+        let (_lines, links) = html_to_styled_lines(html, 80);
+        assert_eq!(links.links.len(), 1);
+        assert_eq!(links.links[0].url, "https://example.com");
+        assert!(!links.links[0].label.is_empty(), "label should be assigned");
+    }
+
+    #[test]
+    fn html_multiple_links_produce_multiple_registry_entries() {
+        let html =
+            b"<p><a href=\"https://a.example\">A</a> and <a href=\"https://b.example\">B</a></p>";
+        let (_lines, links) = html_to_styled_lines(html, 80);
+        assert_eq!(links.links.len(), 2);
+        let urls: Vec<&str> = links.links.iter().map(|l| l.url.as_str()).collect();
+        assert!(urls.contains(&"https://a.example"));
+        assert!(urls.contains(&"https://b.example"));
+        // Labels must be unique.
+        let mut labels: Vec<&str> = links.links.iter().map(|l| l.label.as_str()).collect();
+        labels.sort();
+        labels.dedup();
+        assert_eq!(labels.len(), 2);
+    }
+
+    #[test]
     fn html_empty_input_is_empty_output() {
-        let lines = html_to_styled_lines(b"", 80);
+        let (lines, links) = html_to_styled_lines(b"", 80);
         assert!(lines.is_empty());
+        assert!(links.is_empty());
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,113 @@
+//! OSC 52 clipboard writer.
+//!
+//! Most modern terminals (iTerm2, Alacritty, kitty, foot, recent xterm,
+//! Windows Terminal, tmux with `set -g set-clipboard on`) interpret the
+//! OSC 52 escape sequence as a request to write to the system clipboard.
+//! Works through SSH where `xclip`/`pbcopy` cannot reach the user's local
+//! machine. No external process spawn, no extra dependency — just a
+//! handful of bytes written to stdout.
+//!
+//! The encoding is the standard base64 alphabet (RFC 4648) with `=`
+//! padding; the `c` selector requests the system clipboard (vs `p` for
+//! the primary X11 selection).
+
+use std::io::{self, Write};
+
+/// Standard base64 alphabet (RFC 4648 Table 1).
+const BASE64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Sends `text` to the host terminal's system clipboard via OSC 52.
+///
+/// Returns the underlying I/O error if the write or flush fails. In
+/// practice the error is non-fatal — the caller should surface it in the
+/// status bar but keep running.
+pub fn copy(text: &str) -> io::Result<()> {
+    let encoded = base64_encode(text.as_bytes());
+    let mut out = io::stdout().lock();
+    write!(out, "\x1b]52;c;{}\x07", encoded)?;
+    out.flush()
+}
+
+/// Standard base64 encode (no line wrapping). Output length is
+/// `((bytes.len() + 2) / 3) * 4`.
+fn base64_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    let mut chunks = bytes.chunks_exact(3);
+    for chunk in &mut chunks {
+        out.push(BASE64[(chunk[0] >> 2) as usize] as char);
+        out.push(BASE64[(((chunk[0] & 0b11) << 4) | (chunk[1] >> 4)) as usize] as char);
+        out.push(BASE64[(((chunk[1] & 0b1111) << 2) | (chunk[2] >> 6)) as usize] as char);
+        out.push(BASE64[(chunk[2] & 0b111111) as usize] as char);
+    }
+    let rem = chunks.remainder();
+    match rem.len() {
+        0 => {}
+        1 => {
+            out.push(BASE64[(rem[0] >> 2) as usize] as char);
+            out.push(BASE64[((rem[0] & 0b11) << 4) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            out.push(BASE64[(rem[0] >> 2) as usize] as char);
+            out.push(BASE64[(((rem[0] & 0b11) << 4) | (rem[1] >> 4)) as usize] as char);
+            out.push(BASE64[((rem[1] & 0b1111) << 2) as usize] as char);
+            out.push('=');
+        }
+        _ => unreachable!("chunks_exact(3) remainder is 0..=2"),
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_empty() {
+        assert_eq!(base64_encode(b""), "");
+    }
+
+    #[test]
+    fn base64_one_byte_pads_two_equals() {
+        assert_eq!(base64_encode(b"f"), "Zg==");
+    }
+
+    #[test]
+    fn base64_two_bytes_pads_one_equals() {
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+    }
+
+    #[test]
+    fn base64_three_bytes_no_padding() {
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+    }
+
+    #[test]
+    fn base64_rfc4648_vectors() {
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn base64_url_string_round_trip() {
+        // Sanity: the encoding round-trips against itself via length.
+        let url = "https://example.com/path?q=1&r=2";
+        let encoded = base64_encode(url.as_bytes());
+        assert_eq!(encoded.len() % 4, 0);
+        assert!(encoded.len() >= url.len()); // base64 expands ~33%
+    }
+
+    #[test]
+    fn base64_handles_high_bytes() {
+        let bytes = &[0xff, 0xff, 0xff];
+        assert_eq!(base64_encode(bytes), "////");
+    }
+
+    #[test]
+    fn base64_handles_zero_bytes() {
+        let bytes = &[0, 0, 0];
+        assert_eq!(base64_encode(bytes), "AAAA");
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -5,14 +5,18 @@
 //! the reader overlay has its own reduced map. The [`InputMode`] enum
 //! distinguishes character-capturing search input from normal navigation.
 
+use crate::state::hint_state::HintAction;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 /// Whether the keyboard is in normal-navigation mode or accumulating
-/// characters for the search-query input.
+/// characters for the search-query input or a Quickjump hint label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     Normal,
     SearchInput,
+    /// Active during Quickjump label selection — `main.rs` routes raw
+    /// chars to [`Action::HintKey`] and Esc to [`Action::ExitHintMode`].
+    HintMode,
 }
 
 /// A keybinding-independent operation the app may perform.
@@ -37,6 +41,15 @@ pub enum Action {
     ToggleHelp,
     TogglePriorDiscussions,
     EnterSearch,
+    /// Quickjump: enter hint-label mode; the `HintAction` decides what
+    /// fires on a unique label match (open in browser / open in reader /
+    /// copy URL to clipboard via OSC 52).
+    EnterHintMode(HintAction),
+    /// One typed character of a hint-label prefix (only emitted while
+    /// [`InputMode::HintMode`] is active).
+    HintKey(char),
+    /// Cancel hint-label selection and return to the prior input mode.
+    ExitHintMode,
     Back,
     None,
 }
@@ -44,7 +57,7 @@ pub enum Action {
 /// Translates a [`KeyEvent`] into an [`Action`] for the current UI
 /// context.
 ///
-/// Priority order: search-input mode suppresses normal keys (returns
+/// Priority order: search-input + hint-mode suppress normal keys (return
 /// [`Action::None`] so `main.rs` can handle raw characters); a visible
 /// help overlay consumes any key as [`Action::ToggleHelp`]; a visible
 /// reader overlay uses its own reduced keymap; a visible
@@ -57,8 +70,8 @@ pub fn map_key(
     prior_visible: bool,
     input_mode: InputMode,
 ) -> Action {
-    // When in search input mode, main.rs handles raw keys — return None here
-    if input_mode == InputMode::SearchInput {
+    // SearchInput and HintMode both consume raw chars in main.rs.
+    if matches!(input_mode, InputMode::SearchInput | InputMode::HintMode) {
         return Action::None;
     }
 
@@ -77,6 +90,9 @@ pub fn map_key(
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageUp,
             KeyCode::Char('o') => Action::OpenInBrowser,
+            KeyCode::Char('f') => Action::EnterHintMode(HintAction::Open),
+            KeyCode::Char('F') => Action::EnterHintMode(HintAction::OpenInReader),
+            KeyCode::Char('y') => Action::EnterHintMode(HintAction::CopyUrl),
             KeyCode::Esc | KeyCode::Char('q') => Action::Back,
             _ => Action::None,
         };
@@ -121,6 +137,11 @@ pub fn map_key(
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageUp,
         KeyCode::Char('/') => Action::EnterSearch,
         KeyCode::Char('?') => Action::ToggleHelp,
+        // Quickjump entry — comments-pane variant. Reader-overlay variant
+        // is handled in the reader_visible block above.
+        KeyCode::Char('f') => Action::EnterHintMode(HintAction::Open),
+        KeyCode::Char('F') => Action::EnterHintMode(HintAction::OpenInReader),
+        KeyCode::Char('y') => Action::EnterHintMode(HintAction::CopyUrl),
         _ => Action::None,
     }
 }
@@ -375,5 +396,120 @@ mod tests {
             ),
             Action::ToggleHelp
         );
+    }
+
+    // --- HintMode (Quickjump) ---
+
+    #[test]
+    fn hint_mode_suppresses_all_keys() {
+        // Every key returns Action::None so main.rs can route raw chars
+        // to HintKey via the input-mode shortcut.
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('a')),
+                false,
+                false,
+                false,
+                InputMode::HintMode
+            ),
+            Action::None
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Esc), false, false, false, InputMode::HintMode),
+            Action::None
+        );
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('q')),
+                false,
+                false,
+                false,
+                InputMode::HintMode
+            ),
+            Action::None
+        );
+        // Even with overlays and help flagged, HintMode wins.
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('a')),
+                true,
+                true,
+                true,
+                InputMode::HintMode
+            ),
+            Action::None
+        );
+    }
+
+    #[test]
+    fn normal_f_enters_open_hint_mode() {
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(
+            n(KeyCode::Char('f')),
+            Action::EnterHintMode(HintAction::Open)
+        );
+    }
+
+    #[test]
+    fn normal_capital_f_enters_open_in_reader_hint_mode() {
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(
+            n(KeyCode::Char('F')),
+            Action::EnterHintMode(HintAction::OpenInReader)
+        );
+    }
+
+    #[test]
+    fn normal_y_enters_copy_url_hint_mode() {
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(
+            n(KeyCode::Char('y')),
+            Action::EnterHintMode(HintAction::CopyUrl)
+        );
+    }
+
+    #[test]
+    fn reader_overlay_hint_mode_keys() {
+        let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
+        assert_eq!(
+            r(KeyCode::Char('f')),
+            Action::EnterHintMode(HintAction::Open)
+        );
+        assert_eq!(
+            r(KeyCode::Char('F')),
+            Action::EnterHintMode(HintAction::OpenInReader)
+        );
+        assert_eq!(
+            r(KeyCode::Char('y')),
+            Action::EnterHintMode(HintAction::CopyUrl)
+        );
+    }
+
+    #[test]
+    fn prior_overlay_does_not_emit_hint_actions() {
+        // Prior overlay's keymap should still consume f/F/y as None — those
+        // keys only make sense in reader/comments contexts.
+        let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
+        assert_eq!(p(KeyCode::Char('f')), Action::None);
+        assert_eq!(p(KeyCode::Char('F')), Action::None);
+        assert_eq!(p(KeyCode::Char('y')), Action::None);
+    }
+
+    #[test]
+    fn search_input_does_not_emit_hint_actions() {
+        // SearchInput priority must dominate — `f`/`F`/`y` are valid query
+        // characters when the user is typing.
+        let s = |c: char| {
+            map_key(
+                key(KeyCode::Char(c)),
+                false,
+                false,
+                false,
+                InputMode::SearchInput,
+            )
+        };
+        assert_eq!(s('f'), Action::None);
+        assert_eq!(s('F'), Action::None);
+        assert_eq!(s('y'), Action::None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod api;
 mod app;
 mod article;
+mod clipboard;
 mod event;
 mod keys;
 mod state;
@@ -16,7 +17,7 @@ use anyhow::Result;
 use app::App;
 use crossterm::event::{KeyCode, KeyModifiers};
 use event::{Event, EventHandler};
-use keys::InputMode;
+use keys::{Action, InputMode};
 use std::time::Duration;
 
 #[tokio::main]
@@ -43,30 +44,37 @@ async fn main() -> Result<()> {
 
         // Handle events
         match events.next().await? {
-            Event::Key(key) => {
-                if app.input_mode == InputMode::SearchInput {
-                    match key.code {
-                        KeyCode::Enter => app.submit_search(),
-                        KeyCode::Esc => {
-                            if app
-                                .search_state
-                                .as_ref()
-                                .is_some_and(|ss| ss.query.is_empty())
-                            {
-                                app.cancel_search();
-                            } else {
-                                // Exit input mode but keep search results
-                                app.input_mode = InputMode::Normal;
-                            }
-                        }
-                        KeyCode::Backspace => app.search_input_backspace(),
-                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Event::Key(key) => match app.input_mode {
+                InputMode::SearchInput => match key.code {
+                    KeyCode::Enter => app.submit_search(),
+                    KeyCode::Esc => {
+                        if app
+                            .search_state
+                            .as_ref()
+                            .is_some_and(|ss| ss.query.is_empty())
+                        {
                             app.cancel_search();
+                        } else {
+                            // Exit input mode but keep search results
+                            app.input_mode = InputMode::Normal;
                         }
-                        KeyCode::Char(c) => app.search_input_char(c),
-                        _ => {}
                     }
-                } else {
+                    KeyCode::Backspace => app.search_input_backspace(),
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        app.cancel_search();
+                    }
+                    KeyCode::Char(c) => app.search_input_char(c),
+                    _ => {}
+                },
+                InputMode::HintMode => match key.code {
+                    KeyCode::Esc => app.dispatch(Action::ExitHintMode),
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        app.dispatch(Action::ExitHintMode);
+                    }
+                    KeyCode::Char(c) => app.dispatch(Action::HintKey(c)),
+                    _ => {}
+                },
+                InputMode::Normal => {
                     let action = keys::map_key(
                         key,
                         app.show_help,
@@ -76,7 +84,7 @@ async fn main() -> Result<()> {
                     );
                     app.dispatch(action);
                 }
-            }
+            },
             Event::Mouse(mouse) => {
                 use crossterm::event::{MouseButton, MouseEventKind};
                 match mouse.kind {

--- a/src/state/hint_state.rs
+++ b/src/state/hint_state.rs
@@ -1,0 +1,77 @@
+//! Hint-mode transient state.
+//!
+//! While the user is selecting a hint label from the overlay, the app
+//! holds a [`HintState`] that records (a) which action will fire on a
+//! unique match, (b) which surface the labels live on, and (c) the
+//! prefix typed so far.
+
+/// What to do once the user narrows down to a single labeled link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HintAction {
+    /// Hand the URL to the system browser via `open::that`.
+    Open,
+    /// Open the URL in HNT's own inline article reader.
+    OpenInReader,
+    /// Copy the URL to the clipboard (via OSC 52).
+    CopyUrl,
+}
+
+/// Which surface holds the labeled links.
+///
+/// The article reader carries its own [`crate::state::link_registry::LinkRegistry`]
+/// alongside its content; the comment-tree registry is built on demand
+/// when the user enters hint mode there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HintContext {
+    Reader,
+    Comments,
+}
+
+/// Active hint-mode state. Lives on `App` as `Option<HintState>` and is
+/// `Some` only while the user is mid-selection.
+#[derive(Debug, Clone)]
+pub struct HintState {
+    pub action: HintAction,
+    pub context: HintContext,
+    pub buffer: String,
+}
+
+impl HintState {
+    pub fn new(action: HintAction, context: HintContext) -> Self {
+        Self {
+            action,
+            context,
+            buffer: String::new(),
+        }
+    }
+
+    /// Appends a typed character to the prefix buffer.
+    pub fn push(&mut self, c: char) {
+        self.buffer.push(c);
+    }
+
+    pub fn buffer(&self) -> &str {
+        &self.buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_empty() {
+        let h = HintState::new(HintAction::Open, HintContext::Reader);
+        assert_eq!(h.action, HintAction::Open);
+        assert_eq!(h.context, HintContext::Reader);
+        assert!(h.buffer().is_empty());
+    }
+
+    #[test]
+    fn push_appends() {
+        let mut h = HintState::new(HintAction::CopyUrl, HintContext::Comments);
+        h.push('a');
+        h.push('s');
+        assert_eq!(h.buffer(), "as");
+    }
+}

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -1,0 +1,298 @@
+//! URL hint registry for keyboard-driven link navigation.
+//!
+//! Collects every hyperlink in a rendered surface (article reader or
+//! comment pane), assigns each one a short alphabetic label, and answers
+//! prefix lookups for the [`crate::keys::InputMode::HintMode`] dispatch.
+//! Used by `Quickjump` to let the user open, copy, or reader-load a link
+//! by typing its overlay label.
+
+/// Alphabet used for hint labels. Home-row + top-row characters that don't
+/// collide with vim navigation keys (`j`/`k`/`h`/`g`) — chosen so that a
+/// label glyph never resembles a navigation press.
+const ALPHABET: &[u8] = b"asdfweiou";
+
+/// One labeled hyperlink within a rendered surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkRef {
+    pub url: String,
+    /// Line index within the rendered `Vec<Vec<StyledFragment>>`.
+    pub line: usize,
+    /// Fragment index within that line; the label paints at this fragment's
+    /// first column, so the column offset = sum of preceding fragment widths.
+    pub fragment: usize,
+    /// Assigned by [`LinkRegistry::assign_labels`]. Empty until then.
+    pub label: String,
+}
+
+/// Result of a [`LinkRegistry::match_prefix`] lookup.
+#[derive(Debug, PartialEq)]
+pub enum MatchResult<'a> {
+    /// No links match the prefix — caller should exit hint mode.
+    None,
+    /// More than one link starts with the prefix — keep narrowing.
+    Multiple,
+    /// Exactly one link matches — caller should fire the action.
+    Unique(&'a LinkRef),
+}
+
+/// Collected hyperlinks for one rendered surface. Built once when content
+/// arrives (article reader) or once per `f`-press (comments) and consulted
+/// by the input-mode dispatch on every keypress.
+#[derive(Debug, Default)]
+pub struct LinkRegistry {
+    pub links: Vec<LinkRef>,
+}
+
+impl LinkRegistry {
+    /// Empty registry. Use [`Self::push`] to add links, then
+    /// [`Self::assign_labels`] to populate the `label` field.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.links.is_empty()
+    }
+
+    /// Records a new link at `(line, fragment)`. The `label` is left empty
+    /// until [`Self::assign_labels`] is called once all links are pushed.
+    pub fn push(&mut self, url: String, line: usize, fragment: usize) {
+        self.links.push(LinkRef {
+            url,
+            line,
+            fragment,
+            label: String::new(),
+        });
+    }
+
+    /// Assigns uniform-length alphabetic labels to every link in insertion
+    /// order. Length is the smallest k such that `ALPHABET.len()^k >= n`,
+    /// so 1-9 links get 1-char labels, 10-81 get 2-char labels, etc.
+    pub fn assign_labels(&mut self) {
+        let n = self.links.len();
+        if n == 0 {
+            return;
+        }
+        let alphabet_len = ALPHABET.len();
+        let mut k: usize = 1;
+        let mut capacity = alphabet_len;
+        while capacity < n {
+            k += 1;
+            capacity *= alphabet_len;
+        }
+        for (i, link) in self.links.iter_mut().enumerate() {
+            link.label = generate_label(i, k);
+        }
+    }
+
+    /// Looks up `prefix` against every link's label. See [`MatchResult`].
+    pub fn match_prefix(&self, prefix: &str) -> MatchResult<'_> {
+        let mut found: Option<&LinkRef> = None;
+        let mut count = 0usize;
+        for link in &self.links {
+            if link.label.starts_with(prefix) {
+                count += 1;
+                if count == 1 {
+                    found = Some(link);
+                } else {
+                    return MatchResult::Multiple;
+                }
+            }
+        }
+        match (count, found) {
+            (0, _) => MatchResult::None,
+            (1, Some(link)) => MatchResult::Unique(link),
+            _ => MatchResult::None,
+        }
+    }
+}
+
+/// Encodes `index` in base `ALPHABET.len()` as a fixed-width string of
+/// length `length`, big-endian. Index 0 → "aa…a", index 1 → "aa…s", etc.
+fn generate_label(index: usize, length: usize) -> String {
+    let alphabet_len = ALPHABET.len();
+    let mut chars = Vec::with_capacity(length);
+    let mut n = index;
+    for _ in 0..length {
+        chars.push(ALPHABET[n % alphabet_len]);
+        n /= alphabet_len;
+    }
+    chars.reverse();
+    String::from_utf8(chars).expect("ALPHABET is valid ASCII")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_with(n: usize) -> LinkRegistry {
+        let mut r = LinkRegistry::new();
+        for i in 0..n {
+            r.push(format!("https://example.com/{}", i), i, 0);
+        }
+        r.assign_labels();
+        r
+    }
+
+    #[test]
+    fn new_registry_is_empty() {
+        let r = LinkRegistry::new();
+        assert!(r.is_empty());
+        assert_eq!(r.links.len(), 0);
+    }
+
+    #[test]
+    fn push_adds_link_without_label() {
+        let mut r = LinkRegistry::new();
+        r.push("https://x.com".into(), 5, 2);
+        assert_eq!(r.links.len(), 1);
+        assert_eq!(r.links[0].url, "https://x.com");
+        assert_eq!(r.links[0].line, 5);
+        assert_eq!(r.links[0].fragment, 2);
+        assert!(r.links[0].label.is_empty());
+    }
+
+    #[test]
+    fn assign_labels_empty_is_noop() {
+        let mut r = LinkRegistry::new();
+        r.assign_labels();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn assign_labels_single_uses_one_char() {
+        let r = registry_with(1);
+        assert_eq!(r.links[0].label.len(), 1);
+        assert_eq!(r.links[0].label, "a");
+    }
+
+    #[test]
+    fn assign_labels_under_alphabet_size_uses_one_char() {
+        let r = registry_with(ALPHABET.len());
+        for link in &r.links {
+            assert_eq!(link.label.len(), 1, "label {} should be 1 char", link.label);
+        }
+    }
+
+    #[test]
+    fn assign_labels_over_alphabet_size_uses_two_chars() {
+        let r = registry_with(ALPHABET.len() + 1);
+        for link in &r.links {
+            assert_eq!(
+                link.label.len(),
+                2,
+                "label {} should be 2 chars",
+                link.label
+            );
+        }
+    }
+
+    #[test]
+    fn assign_labels_all_unique() {
+        let r = registry_with(50);
+        let mut seen = std::collections::HashSet::new();
+        for link in &r.links {
+            assert!(
+                seen.insert(link.label.clone()),
+                "duplicate label: {}",
+                link.label
+            );
+        }
+    }
+
+    #[test]
+    fn assign_labels_uses_only_alphabet_chars() {
+        let r = registry_with(50);
+        for link in &r.links {
+            for c in link.label.chars() {
+                assert!(
+                    ALPHABET.contains(&(c as u8)),
+                    "label char {:?} not in alphabet",
+                    c
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn assign_labels_deterministic_in_insertion_order() {
+        let r1 = registry_with(15);
+        let r2 = registry_with(15);
+        for (a, b) in r1.links.iter().zip(r2.links.iter()) {
+            assert_eq!(a.label, b.label);
+        }
+    }
+
+    #[test]
+    fn match_prefix_empty_registry_is_none() {
+        let r = LinkRegistry::new();
+        assert_eq!(r.match_prefix(""), MatchResult::None);
+        assert_eq!(r.match_prefix("a"), MatchResult::None);
+    }
+
+    #[test]
+    fn match_prefix_unique_with_full_label() {
+        let r = registry_with(3);
+        let label = r.links[1].label.clone();
+        match r.match_prefix(&label) {
+            MatchResult::Unique(link) => {
+                assert_eq!(link.url, "https://example.com/1");
+            }
+            other => panic!("expected unique match, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn match_prefix_empty_with_multiple_links_is_multiple() {
+        let r = registry_with(5);
+        assert_eq!(r.match_prefix(""), MatchResult::Multiple);
+    }
+
+    #[test]
+    fn match_prefix_empty_with_one_link_is_unique() {
+        let r = registry_with(1);
+        match r.match_prefix("") {
+            MatchResult::Unique(_) => {}
+            other => panic!("expected unique, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn match_prefix_partial_two_char_labels() {
+        // Force 2-char labels by having more links than ALPHABET.len().
+        let r = registry_with(ALPHABET.len() + 5);
+        // Every label starts with 'a' for the first ALPHABET.len() entries
+        // (because index 0..ALPHABET.len() encode as "a?" in base-N).
+        match r.match_prefix("a") {
+            MatchResult::Multiple => {}
+            other => panic!("expected multiple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn match_prefix_no_match_returns_none() {
+        let r = registry_with(5);
+        assert_eq!(r.match_prefix("z"), MatchResult::None);
+    }
+
+    #[test]
+    fn generate_label_index_zero_is_all_a() {
+        assert_eq!(generate_label(0, 1), "a");
+        assert_eq!(generate_label(0, 2), "aa");
+        assert_eq!(generate_label(0, 3), "aaa");
+    }
+
+    #[test]
+    fn generate_label_index_one_is_second_alphabet_char() {
+        // ALPHABET[1] is 's'.
+        assert_eq!(generate_label(1, 1), "s");
+        assert_eq!(generate_label(1, 2), "as");
+    }
+
+    #[test]
+    fn generate_label_alphabet_size_is_first_two_char_carry() {
+        let n = ALPHABET.len();
+        // Index n in length-2 = "sa" (first carry).
+        assert_eq!(generate_label(n, 2), "sa");
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,9 +6,13 @@
 //! and plain-text caching), [`reader_state::ReaderState`] for the article
 //! overlay, [`search_state::SearchState`] for the Algolia search flow,
 //! [`prior_state::PriorDiscussionsState`] for the prior-submissions
-//! overlay, and [`read_store::ReadStore`] for persisted read-state tracking.
+//! overlay, [`read_store::ReadStore`] for persisted read-state tracking,
+//! and [`link_registry::LinkRegistry`] + [`hint_state::HintState`] for the
+//! Quickjump label-hint mode.
 
 pub mod comment_state;
+pub mod hint_state;
+pub mod link_registry;
 pub mod prior_state;
 pub mod read_store;
 pub mod reader_state;

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -1,10 +1,14 @@
 //! Article-reader overlay state.
 //!
 //! [`ReaderState`] tracks the pre-rendered [`StyledFragment`] lines,
-//! scroll position, and loading/error status for an article fetched via
-//! `crate::article`. [`StyledFragment`] is the shared line-fragment type
-//! used by both article extraction and HTML comment rendering.
+//! scroll position, loading/error status, and the
+//! [`LinkRegistry`](crate::state::link_registry::LinkRegistry) of every
+//! hyperlink in the article body — populated by `crate::article` and
+//! consulted by Quickjump's hint-mode dispatch. [`StyledFragment`] is the
+//! shared line-fragment type used by both article extraction and HTML
+//! comment rendering.
 
+use crate::state::link_registry::LinkRegistry;
 use ratatui::style::Style;
 
 /// A run of text sharing one ratatui [`Style`]. Multiple fragments compose
@@ -21,6 +25,9 @@ pub struct ReaderState {
     pub domain: Option<String>,
     pub url: Option<String>,
     pub lines: Vec<Vec<StyledFragment>>,
+    /// Every hyperlink in `lines`, with assigned hint labels. Populated by
+    /// [`Self::set_content`].
+    pub links: LinkRegistry,
     pub scroll: usize,
     pub loading: bool,
     pub error: Option<String>,
@@ -36,16 +43,18 @@ impl ReaderState {
             domain,
             url,
             lines: Vec::new(),
+            links: LinkRegistry::new(),
             scroll: 0,
             loading: true,
             error: None,
         }
     }
 
-    /// Installs loaded content, clears the loading flag and any prior
-    /// error, and resets scroll to the top.
-    pub fn set_content(&mut self, lines: Vec<Vec<StyledFragment>>) {
+    /// Installs loaded content + extracted hyperlinks, clears the loading
+    /// flag and any prior error, and resets scroll to the top.
+    pub fn set_content(&mut self, lines: Vec<Vec<StyledFragment>>, links: LinkRegistry) {
         self.lines = lines;
+        self.links = links;
         self.loading = false;
         self.error = None;
         self.scroll = 0;
@@ -129,7 +138,7 @@ mod tests {
         let mut r = ReaderState::new_loading("T".into(), None, None);
         r.error = Some("old error".into());
         r.scroll = 5;
-        r.set_content(make_lines(10));
+        r.set_content(make_lines(10), LinkRegistry::new());
         assert_eq!(r.lines.len(), 10);
         assert!(!r.loading);
         assert!(r.error.is_none());
@@ -147,7 +156,7 @@ mod tests {
     #[test]
     fn scroll_down_increments() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(20));
+        r.set_content(make_lines(20), LinkRegistry::new());
         r.scroll_down(5);
         assert_eq!(r.scroll, 5);
     }
@@ -155,7 +164,7 @@ mod tests {
     #[test]
     fn scroll_down_clamps_at_max() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(10));
+        r.set_content(make_lines(10), LinkRegistry::new());
         r.scroll_down(100);
         assert_eq!(r.scroll, 9); // max_scroll = 10 - 1
     }
@@ -170,7 +179,7 @@ mod tests {
     #[test]
     fn scroll_up_decrements() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(20));
+        r.set_content(make_lines(20), LinkRegistry::new());
         r.scroll = 10;
         r.scroll_up(3);
         assert_eq!(r.scroll, 7);
@@ -179,7 +188,7 @@ mod tests {
     #[test]
     fn scroll_up_clamps_at_zero() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(20));
+        r.set_content(make_lines(20), LinkRegistry::new());
         r.scroll = 2;
         r.scroll_up(5);
         assert_eq!(r.scroll, 0);
@@ -188,7 +197,7 @@ mod tests {
     #[test]
     fn jump_top_and_bottom() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(20));
+        r.set_content(make_lines(20), LinkRegistry::new());
         r.jump_bottom();
         assert_eq!(r.scroll, 19);
         r.jump_top();
@@ -198,14 +207,14 @@ mod tests {
     #[test]
     fn scroll_percent_at_top() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(100));
+        r.set_content(make_lines(100), LinkRegistry::new());
         assert_eq!(r.scroll_percent(), 0);
     }
 
     #[test]
     fn scroll_percent_at_bottom() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(100));
+        r.set_content(make_lines(100), LinkRegistry::new());
         r.jump_bottom();
         assert_eq!(r.scroll_percent(), 100);
     }
@@ -219,7 +228,7 @@ mod tests {
     #[test]
     fn scroll_percent_single_line() {
         let mut r = ReaderState::new_loading("T".into(), None, None);
-        r.set_content(make_lines(1));
+        r.set_content(make_lines(1), LinkRegistry::new());
         assert_eq!(r.scroll_percent(), 100); // max_scroll is 0
     }
 }

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -2,8 +2,12 @@
 //!
 //! [`render_article_overlay`] dispatches to loading, error, or content
 //! renderers based on [`ReaderState`]. Content is drawn as wrapped
-//! styled lines with a title, domain, and keybinding footer.
+//! styled lines with a title, domain, and keybinding footer. When
+//! Quickjump's [`HintState`] is active, a post-pass paints label glyphs
+//! over each visible hyperlink, dimming labels that no longer match the
+//! typed prefix.
 
+use crate::state::hint_state::{HintContext, HintState};
 use crate::state::reader_state::ReaderState;
 use crate::ui::theme;
 use ratatui::{
@@ -15,8 +19,14 @@ use ratatui::{
 
 /// Draws the full-screen reader overlay for `reader`'s current state
 /// (loading, error, or content) into `area` with a small margin. No-op if
-/// the available space is too small.
-pub fn render_article_overlay(frame: &mut Frame, area: Rect, reader: &ReaderState) {
+/// the available space is too small. When `hint` is `Some` and targets the
+/// reader, a label-overlay pass paints Quickjump labels atop visible links.
+pub fn render_article_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    reader: &ReaderState,
+    hint: Option<&HintState>,
+) {
     // Fullscreen overlay with 2-cell margin on each side
     let margin = 2u16;
     let x = margin.min(area.width / 2);
@@ -42,7 +52,14 @@ pub fn render_article_overlay(frame: &mut Frame, area: Rect, reader: &ReaderStat
         return;
     }
 
-    render_content(frame, overlay_area, reader);
+    let inner = render_content(frame, overlay_area, reader);
+
+    // Hint-mode label overlay — draws over the just-rendered content.
+    if let Some(hint) = hint {
+        if matches!(hint.context, HintContext::Reader) {
+            paint_hint_labels(frame, inner, reader, hint);
+        }
+    }
 }
 
 fn build_title(reader: &ReaderState) -> String {
@@ -127,11 +144,11 @@ fn render_error(frame: &mut Frame, area: Rect, reader: &ReaderState, error: &str
     }
 }
 
-fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) {
+fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) -> Rect {
     let title = build_title(reader);
     let pct = reader.scroll_percent();
     let footer = format!(
-        " j/k:scroll  Ctrl+d/u:page  g/G:top/bottom  o:browser  Esc:close  {}% ",
+        " j/k:scroll  Ctrl+d/u:page  g/G:top/bottom  o:browser  f:hint  y:copy  Esc:close  {}% ",
         pct
     );
 
@@ -166,4 +183,62 @@ fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) {
 
     let content = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
     frame.render_widget(content, inner);
+
+    inner
+}
+
+/// Paints Quickjump hint labels atop visible hyperlinks. Each label
+/// renders at the link's first column in inverse video; labels whose full
+/// text no longer starts with the typed prefix are dimmed instead so the
+/// user can see what they've ruled out without having labels disappear.
+///
+/// Column positioning uses `chars().count()` rather than full unicode
+/// width — adequate for the URLs and ASCII link text typical of news
+/// articles; wide-char link anchors (CJK, emoji) may be off by a column.
+/// Wrapped lines (rare; html2text already wrapped to width) place the
+/// label on the unwrapped logical row.
+fn paint_hint_labels(frame: &mut Frame, inner: Rect, reader: &ReaderState, hint: &HintState) {
+    let buf = frame.buffer_mut();
+    let scroll = reader.scroll;
+    let visible_height = inner.height as usize;
+    let prefix = hint.buffer();
+
+    for link in &reader.links.links {
+        if link.line < scroll || link.line >= scroll + visible_height {
+            continue;
+        }
+        let line = match reader.lines.get(link.line) {
+            Some(l) => l,
+            None => continue,
+        };
+        let col_offset: usize = line
+            .iter()
+            .take(link.fragment)
+            .map(|f| f.text.chars().count())
+            .sum();
+        let label_x = inner.x.saturating_add(col_offset as u16);
+        if label_x >= inner.right() {
+            continue;
+        }
+        let row_y = inner.y.saturating_add((link.line - scroll) as u16);
+        if row_y >= inner.bottom() {
+            continue;
+        }
+
+        let style = if link.label.starts_with(prefix) {
+            theme::hint_active_style()
+        } else {
+            theme::hint_dim_style()
+        };
+
+        for (i, ch) in link.label.chars().enumerate() {
+            let cell_x = label_x.saturating_add(i as u16);
+            if cell_x >= inner.right() {
+                break;
+            }
+            let cell = &mut buf[(cell_x, row_y)];
+            cell.set_char(ch);
+            cell.set_style(style);
+        }
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -134,7 +134,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 
     // Article reader overlay
     if let Some(ref reader_state) = app.reader_state {
-        article_reader::render_article_overlay(frame, area, reader_state);
+        article_reader::render_article_overlay(frame, area, reader_state, app.hint_state.as_ref());
     }
 
     // Prior-discussions overlay (takes precedence over comment pane focus but
@@ -150,8 +150,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 /// Draws the centered modal help overlay listing every keybinding.
 /// Bounded to at most 50×22 cells; auto-shrinks on small terminals.
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    let width = 50u16.min(area.width.saturating_sub(4));
-    let height = 24u16.min(area.height.saturating_sub(4));
+    let width = 56u16.min(area.width.saturating_sub(4));
+    let height = 28u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let popup_area = Rect::new(x, y, width, height);
@@ -176,6 +176,13 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  p            ", theme::accent_style()),
             Span::styled("Read article inline", theme::base_style()),
+        ]),
+        Line::from(vec![
+            Span::styled("  f / F / y    ", theme::accent_style()),
+            Span::styled(
+                "(in reader) Quickjump: open / read inline / copy",
+                theme::base_style(),
+            ),
         ]),
         Line::from(vec![
             Span::styled("  h            ", theme::accent_style()),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -92,6 +92,23 @@ pub const fn depth_color(depth: usize) -> Color {
     DEPTH_COLORS[depth % DEPTH_COLORS.len()]
 }
 
+/// Quickjump hint label — bold black-on-orange so it pops against the
+/// underlying styled link text. Used for labels still matching the
+/// active prefix.
+pub const fn hint_active_style() -> Style {
+    Style::new()
+        .fg(BG)
+        .bg(HN_ORANGE)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Quickjump hint label — dimmed grey-on-surface for labels that no
+/// longer match the active prefix. Lets the user see what they've
+/// already ruled out without removing the labels entirely.
+pub const fn hint_dim_style() -> Style {
+    Style::new().fg(DIM).bg(SURFACE)
+}
+
 /// Bold badge color on the surface background — one color per
 /// [`StoryBadge`](crate::api::types::StoryBadge) variant.
 pub const fn badge_style(badge: crate::api::types::StoryBadge) -> Style {


### PR DESCRIPTION
Closes #101

## Summary

- New `f` / `F` / `y` keybindings in the article reader open a vim-/vimium-style label overlay over every visible hyperlink. Type the 1- or 2-character home-row label to act on that link.
- `f` = open in browser. `F` = open in HNT's own inline reader (recursive nav). `y` = copy URL to the system clipboard via OSC 52 — works through SSH, no `xclip`/`pbcopy` shell-out, no new crate dependency (hand-rolled base64 encoder).
- URL extraction happens in a new shared helper `tagged_lines_to_styled_with_links` in `src/article.rs`: link annotations from `html2text::from_read_rich` were previously discarded into a dim suffix fragment; they now also drive a `LinkRegistry` carried alongside the rendered lines on `ReaderState`.
- Three new modules: `src/state/link_registry.rs`, `src/state/hint_state.rs`, `src/clipboard.rs`. New `InputMode::HintMode` plus three `Action` variants (`EnterHintMode` / `HintKey` / `ExitHintMode`). All overlay-context match arms in `src/app.rs` exhaustively name the new variants, so future `Action` additions still produce a compile error.
- Hint alphabet is `asdfweiou` (home row + select top-row; deliberately avoids `j`/`k`/`g`/`h`/`b` so a label glyph never resembles a vim navigation key).
- 37 new unit tests (216 total). `cargo fmt --check`, `cargo clippy --no-deps --all-targets -- -D warnings`, and `cargo test` all pass.
- README + in-app help overlay updated.
- Comment-tree integration is intentionally deferred to a follow-up PR. The infrastructure (`HintContext::Comments`, normal-mode `EnterHintMode` dispatch, label match-prefix lookup) is wired and reachable; only URL extraction from comment plain-text and a comment-side overlay paint-pass remain. The comment tree's two-pass measure/render needs a different anchor model than the article reader's `(line, fragment)` coordinates, which is non-trivial enough to deserve its own scope.

## Test plan

- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy --no-deps --all-targets -- -D warnings` clean
- [ ] `cargo test` — 216 pass
- [ ] Open the inline reader on a URL-rich article (e.g. a tech blog post). Press `f`. Confirm orange-on-background labels appear at the start of each visible link.
- [ ] Type the first label character — confirm non-matching labels dim to grey. Type the rest — confirm browser opens the correct URL.
- [ ] Same flow with `F` — confirm the chosen link opens *in HNT's own reader* (recursive in-TUI nav).
- [ ] Same flow with `y` — confirm clipboard receives the URL. Verify on iTerm2 / Alacritty / kitty / through SSH.
- [ ] Press `f` then `Esc` — confirm hint mode exits cleanly with no action fired.
- [ ] Press `f` on an article with zero links — confirm hint mode silently doesn't enter and navigation keys still work.
- [ ] Press `?` — confirm help overlay shows the new `f / F / y` line.