### PR TITLE
Fix Quickjump docstring drift and rustdoc warning

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,10 +43,10 @@ pub enum LoadMode {
     Append,
 }
 
-/// Tri-state outcome of a [`crate::state::link_registry::LinkRegistry::match_prefix`]
-/// resolved against the current hint buffer. Carries the resolved URL by
-/// value so the borrow on the registry can be released before mutating
-/// `self`.
+/// Tri-state outcome of a hint-buffer match against the active registry.
+///
+/// Carries the resolved URL by value so the borrow on the registry can
+/// be released before mutating `self`. See [`LinkRegistry::match_prefix`].
 enum HintResolve {
     /// Multiple labels still match — keep accepting characters.
     Continue,
@@ -58,11 +58,11 @@ enum HintResolve {
 
 /// Messages sent from async tasks back to the main loop.
 ///
-/// Variants correspond to the lifecycle of each async operation: a one-shot
-/// load (`StoriesLoaded`, `SearchResultsLoaded`, `ArticleLoaded`), a
-/// multi-step progressive load (`CommentsLoaded` → zero or more
-/// `CommentsAppended` → `CommentsDone`), or a terminal error (`Error`,
-/// `ArticleError`).
+/// Variants correspond to the lifecycle of each async operation: a
+/// one-shot load (`StoriesLoaded`, `SearchResultsLoaded`,
+/// `ArticleLoaded`, `PriorDiscussionsLoaded`), a multi-step progressive
+/// load (`CommentsLoaded` → zero or more `CommentsAppended` →
+/// `CommentsDone`), or a terminal error (`Error`, `ArticleError`).
 pub enum AppMessage {
     /// Initial or paginated batch of stories finished loading.
     StoriesLoaded {
@@ -331,10 +331,19 @@ impl App {
 
     /// Applies an [`Action`] from the keybinding layer.
     ///
-    /// Routing is context-sensitive: when the article reader is open, a
-    /// restricted set of actions drives the reader and others are consumed.
-    /// Otherwise the action mutates the focused pane's state or spawns an
-    /// async task (feed switch, refresh, comment load, search).
+    /// Routing is context-sensitive, in priority order:
+    ///
+    /// 1. Hint actions ([`Action::EnterHintMode`] / [`Action::HintKey`] /
+    ///    [`Action::ExitHintMode`]) short-circuit ahead of every overlay
+    ///    so a mid-selection keypress never leaks through to the
+    ///    underlying pane.
+    /// 2. When the article-reader overlay is open, a restricted set of
+    ///    navigation actions drives the reader; others are consumed.
+    /// 3. When the prior-discussions overlay is open, a reduced action
+    ///    set drives the overlay; others are consumed.
+    /// 4. Otherwise the action mutates the focused pane's state or
+    ///    spawns an async task (feed switch, refresh, comment load,
+    ///    search).
     pub fn dispatch(&mut self, action: Action) {
         // Hint-mode actions short-circuit ahead of every overlay route
         // because the user is mid-selection and any keypress should be
@@ -1069,7 +1078,9 @@ impl App {
 
     /// Enters Quickjump hint-label mode. Determines context from current
     /// app state — reader if the article-reader overlay is open, comments
-    /// if the comments pane is focused. No-op if no surface has links.
+    /// if the comments pane is focused. No-op when the active surface has
+    /// no labeled links (currently always the case for comments — see
+    /// [`Self::active_link_registry`]).
     fn enter_hint_mode(&mut self, action: HintAction) {
         // Already in hint mode? Re-entering with a different action is
         // ambiguous; treat as a re-arm with the new action but reset the
@@ -1135,14 +1146,17 @@ impl App {
         }
     }
 
-    /// Returns the [`LinkRegistry`] backing the current hint context. For
-    /// reader: the article's pre-built registry. For comments: the
-    /// per-frame snapshot built when hint mode was entered (populated in
-    /// the comment-tree integration step).
+    /// Returns the [`LinkRegistry`] backing the current hint context.
+    ///
+    /// For the reader, this is the article's pre-built registry. The
+    /// comments path is currently a stub returning `None` — the per-frame
+    /// registry build is scoped to a follow-up PR. Hint mode entered from
+    /// the comments pane therefore degrades to a no-op via
+    /// [`HintResolve::Cancel`] on the first key.
     fn active_link_registry(&self, context: HintContext) -> Option<&LinkRegistry> {
         match context {
             HintContext::Reader => self.reader_state.as_ref().map(|r| &r.links),
-            HintContext::Comments => None, // populated by step 9 (comment-tree integration)
+            HintContext::Comments => None, // TODO: build registry from visible comments on hint-mode entry
         }
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -18,9 +18,15 @@ const BASE64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123
 
 /// Sends `text` to the host terminal's system clipboard via OSC 52.
 ///
-/// Returns the underlying I/O error if the write or flush fails. In
-/// practice the error is non-fatal — the caller should surface it in the
-/// status bar but keep running.
+/// The escape sequence is written to stdout and the buffer flushed
+/// immediately. Works through SSH because the terminal — not the remote
+/// process — handles the clipboard write.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] if the write or flush fails.
+/// In practice the error is non-fatal — the caller should surface it
+/// in the status bar but keep running.
 pub fn copy(text: &str) -> io::Result<()> {
     let encoded = base64_encode(text.as_bytes());
     let mut out = io::stdout().lock();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,9 +1,12 @@
 //! Keybinding → [`Action`] translation.
 //!
-//! [`map_key`] is a pure, context-aware dispatch: search-input mode
-//! suppresses normal keys, the help overlay eats any keypress, and
-//! the reader overlay has its own reduced map. The [`InputMode`] enum
-//! distinguishes character-capturing search input from normal navigation.
+//! [`map_key`] is a pure, context-aware dispatch: search-input and
+//! hint-mode both suppress normal keys (`main.rs` routes the raw
+//! characters); the help overlay eats any keypress; the article-reader
+//! and prior-discussions overlays each have their own reduced keymap,
+//! with the article reader taking precedence when both are open. The
+//! [`InputMode`] enum distinguishes character-capturing search input
+//! and Quickjump hint selection from normal navigation.
 
 use crate::state::hint_state::HintAction;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};

--- a/src/state/hint_state.rs
+++ b/src/state/hint_state.rs
@@ -18,7 +18,7 @@ pub enum HintAction {
 
 /// Which surface holds the labeled links.
 ///
-/// The article reader carries its own [`crate::state::link_registry::LinkRegistry`]
+/// The article reader carries its own [`LinkRegistry`](crate::state::link_registry::LinkRegistry)
 /// alongside its content; the comment-tree registry is built on demand
 /// when the user enters hint mode there.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -2,7 +2,7 @@
 //!
 //! [`ReaderState`] tracks the pre-rendered [`StyledFragment`] lines,
 //! scroll position, loading/error status, and the
-//! [`LinkRegistry`](crate::state::link_registry::LinkRegistry) of every
+//! [`LinkRegistry`] of every
 //! hyperlink in the article body — populated by `crate::article` and
 //! consulted by Quickjump's hint-mode dispatch. [`StyledFragment`] is the
 //! shared line-fragment type used by both article extraction and HTML

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -188,15 +188,18 @@ fn render_content(frame: &mut Frame, area: Rect, reader: &ReaderState) -> Rect {
 }
 
 /// Paints Quickjump hint labels atop visible hyperlinks. Each label
-/// renders at the link's first column in inverse video; labels whose full
-/// text no longer starts with the typed prefix are dimmed instead so the
-/// user can see what they've ruled out without having labels disappear.
+/// renders at the link's first column with a high-contrast highlight
+/// (HN-orange background); labels whose full text no longer starts with
+/// the typed prefix dim instead, so the user can see what they've
+/// ruled out without having labels disappear.
 ///
 /// Column positioning uses `chars().count()` rather than full unicode
 /// width — adequate for the URLs and ASCII link text typical of news
-/// articles; wide-char link anchors (CJK, emoji) may be off by a column.
-/// Wrapped lines (rare; html2text already wrapped to width) place the
-/// label on the unwrapped logical row.
+/// articles; wide-char link anchors (CJK, emoji) may be off by a
+/// column. Labels paint at the html2text logical row index, so any
+/// further re-wrap by ratatui's `Paragraph` (e.g. when the terminal is
+/// narrower than the width html2text was given) misplaces labels by
+/// the number of intervening wraps.
 fn paint_hint_labels(frame: &mut Frame, inner: Rect, reader: &ReaderState, hint: &HintState) {
     let buf = frame.buffer_mut();
     let scroll = reader.scroll;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -148,7 +148,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 }
 
 /// Draws the centered modal help overlay listing every keybinding.
-/// Bounded to at most 50×22 cells; auto-shrinks on small terminals.
+/// Bounded to at most 56×28 cells; auto-shrinks on small terminals.
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let width = 56u16.min(area.width.saturating_sub(4));
     let height = 28u16.min(area.height.saturating_sub(4));


### PR DESCRIPTION
Closes #103

## Summary

- **rustdoc warning fix**: removed the only warning `cargo doc --no-deps` emits today — `rustdoc::redundant_explicit_links` at `src/state/reader_state.rs:5`.
- **Drift fixes** in code touched by the Quickjump PR (#102):
  - `src/ui/mod.rs:151` — help-overlay doc said `50×22`, code uses `56×28` (I bumped it for the new `f / F / y` line and forgot the doc).
  - `src/app.rs::dispatch` — doc described 1 of 3 routing layers; now lists the actual priority chain (hint short-circuit → article-reader → prior-discussions → normal).
  - `src/app.rs::enter_hint_mode` and `active_link_registry` — both implied the comments path produces labels; it doesn't yet. Now explicit about the stub and that it'll be wired in a follow-up.
  - `src/keys.rs` module `//!` — extended to mention `HintMode` (Quickjump) and the prior-discussions overlay; both were left out of the single-paragraph summary.
  - `src/ui/article_reader.rs::paint_hint_labels` — "inverse video" was wrong (terminal reverse-video attribute is NOT what `hint_active_style()` does — it sets explicit fg/bg). The wrap-fallback claim was also misleading: re-wrap by ratatui's `Paragraph` *misplaces* labels, it doesn't keep them at the logical row in any useful sense.
- **Convention fix**: `src/clipboard.rs::copy` lifted its error-condition prose under a `# Errors` heading per project rustdoc convention.
- **Style polish**: shortened a verbose intra-doc link in `HintResolve`, fixed link form in `HintContext`, and added the missing `PriorDiscussionsLoaded` to the `AppMessage` enum-summary list.
- Replaced an inline `// populated by step 9 (comment-tree integration)` comment with a generic TODO — that "step 9" was my own dev-task numbering and didn't belong in source.

All 11 fixes were caught by `/docstring-check` after the Quickjump merge — the audit found inaccuracies the merged PR introduced. Pure documentation changes; no code semantics changed.

## Test plan

- [ ] `cargo doc --no-deps 2>&1 | grep -E "warning|error"` — zero output (the known warning is fixed).
- [ ] `cargo fmt --check` — clean.
- [ ] `cargo clippy --no-deps --all-targets -- -D warnings` — clean.
- [ ] `cargo test` — all 216 pass.
- [ ] Open `target/doc/hnt/index.html` and spot-check the rendered docs for `App::dispatch`, `enter_hint_mode`, `active_link_registry`, `clipboard::copy`, `paint_hint_labels` — each should match its current behavior, with `# Errors` rendering as a heading on `clipboard::copy`.