### PR TITLE
Eliminate per-frame string allocations on render path

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1183,12 +1183,12 @@ impl App {
             Ok(p) if matches!(p.scheme(), "http" | "https") => p,
             _ => return,
         };
-        let domain = parsed.host_str().map(|s| s.to_string());
-        let title = parsed.path().trim_matches('/').to_string();
-        let title = if title.is_empty() {
-            domain.clone().unwrap_or_else(|| url.to_string())
+        let domain = parsed.host_str().map(str::to_string);
+        let path_seg = parsed.path().trim_matches('/');
+        let title = if path_seg.is_empty() {
+            domain.as_deref().unwrap_or(url).to_string()
         } else {
-            title
+            path_seg.to_string()
         };
 
         self.reader_state = Some(ReaderState::new_loading(

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -63,12 +63,9 @@ pub fn render_article_overlay(
 }
 
 fn build_title(reader: &ReaderState) -> String {
-    let title = if reader.title.chars().count() > 60 {
-        let truncated: String = reader.title.chars().take(57).collect();
-        format!("{}...", truncated)
-    } else {
-        reader.title.clone()
-    };
+    let truncated: Option<String> = (reader.title.chars().count() > 60)
+        .then(|| reader.title.chars().take(57).collect::<String>() + "...");
+    let title: &str = truncated.as_deref().unwrap_or(reader.title.as_str());
 
     match &reader.domain {
         Some(domain) => format!(" {} ({}) ", title, domain),
@@ -120,7 +117,7 @@ fn render_error(frame: &mut Frame, area: Rect, reader: &ReaderState, error: &str
                 .add_modifier(ratatui::style::Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from(Span::styled(error.to_string(), theme::dim_style())),
+        Line::from(Span::styled(error, theme::dim_style())),
         Line::from(""),
         Line::from(Span::styled(
             "Press 'o' to open in browser, Esc to close",

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -169,10 +169,7 @@ impl<'a> Widget for CommentTree<'a> {
                         buf.set_line(
                             inner.left(),
                             inner.top() + header_height,
-                            &Line::from(Span::styled(
-                                format!("  {}", line),
-                                theme::base_style(),
-                            )),
+                            &Line::from(Span::styled(format!("  {}", line), theme::base_style())),
                             inner.width,
                         );
                         header_height += 1;

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -59,17 +59,18 @@ impl<'a> Widget for CommentTree<'a> {
             theme::dim_style()
         };
 
-        let title_text = if let Some(story) = &self.state.story {
-            if let Some(badge) = story.badge() {
+        let title_span = if let Some(story) = &self.state.story {
+            let label = if let Some(badge) = story.badge() {
                 format!(" [{}] {} ", badge.label(), story.display_title())
             } else {
                 format!(" {} ", story.display_title())
-            }
+            };
+            Span::styled(label, theme::title_style())
         } else {
-            " Comments ".to_string()
+            Span::styled(" Comments ", theme::title_style())
         };
 
-        let mut title_spans = vec![Span::styled(title_text, theme::title_style())];
+        let mut title_spans = vec![title_span];
         if self.prior_count > 0 {
             title_spans.push(Span::styled(
                 format!("· {} prior (h) ", self.prior_count),
@@ -114,84 +115,82 @@ impl<'a> Widget for CommentTree<'a> {
             return;
         }
 
-        // Render story meta header (fixed, not scrolled)
+        // Render story meta header (fixed, not scrolled).
+        // Snapshot the meta-line scalars first so the immutable borrow on
+        // self.state.story can be released before story_plain_text mutably
+        // borrows self.state.story_text_cache. This lets the body lines flow
+        // straight from the cache as `&str`, eliminating the per-frame body
+        // text clone the old two-step `.map(str::to_owned)` +
+        // `.clone().unwrap_or_default()` dance needed.
         let mut header_height: u16 = 0;
 
-        let story_plain = self
-            .state
-            .story_plain_text(inner.width as usize)
-            .map(str::to_owned);
-
-        if let Some(story) = &self.state.story {
-            if let Some(_text) = &story.text {
-                let plain = story_plain.clone().unwrap_or_default();
-                let meta = format!(
+        let meta_snapshot = self.state.story.as_ref().map(|s| {
+            let has_text = s.text.is_some();
+            let line = if has_text {
+                format!(
                     "  {} pts | {} | {} comments",
-                    story.score.unwrap_or(0),
-                    story.by.as_deref().unwrap_or("?"),
-                    story.descendants.unwrap_or(0),
-                );
-                buf.set_line(
-                    inner.left(),
-                    inner.top() + header_height,
-                    &Line::from(Span::styled(meta, theme::meta_style())),
-                    inner.width,
-                );
-                header_height += 1;
-
-                for line in plain.lines().take((inner.height / 4) as usize) {
-                    if header_height >= inner.height {
-                        break;
-                    }
-                    buf.set_line(
-                        inner.left(),
-                        inner.top() + header_height,
-                        &Line::from(Span::styled(format!("  {}", line), theme::base_style())),
-                        inner.width,
-                    );
-                    header_height += 1;
-                }
-
-                if header_height < inner.height {
-                    buf.set_line(
-                        inner.left(),
-                        inner.top() + header_height,
-                        &Line::from(Span::styled(
-                            "  ────────────────────────────────────────",
-                            theme::dim_style(),
-                        )),
-                        inner.width,
-                    );
-                    header_height += 1;
-                }
+                    s.score.unwrap_or(0),
+                    s.by.as_deref().unwrap_or("?"),
+                    s.descendants.unwrap_or(0),
+                )
             } else {
-                let meta = format!(
+                format!(
                     "  {} pts | {} | {} comments | {}",
-                    story.score.unwrap_or(0),
-                    story.by.as_deref().unwrap_or("?"),
-                    story.descendants.unwrap_or(0),
-                    story.url.as_deref().unwrap_or(""),
-                );
+                    s.score.unwrap_or(0),
+                    s.by.as_deref().unwrap_or("?"),
+                    s.descendants.unwrap_or(0),
+                    s.url.as_deref().unwrap_or(""),
+                )
+            };
+            (has_text, line)
+        });
+
+        let story_plain: Option<&str> = if meta_snapshot.as_ref().is_some_and(|(t, _)| *t) {
+            self.state.story_plain_text(inner.width as usize)
+        } else {
+            None
+        };
+
+        if let Some((has_text, meta_line)) = meta_snapshot {
+            buf.set_line(
+                inner.left(),
+                inner.top() + header_height,
+                &Line::from(Span::styled(meta_line, theme::meta_style())),
+                inner.width,
+            );
+            header_height += 1;
+
+            if has_text {
+                if let Some(plain) = story_plain {
+                    for line in plain.lines().take((inner.height / 4) as usize) {
+                        if header_height >= inner.height {
+                            break;
+                        }
+                        buf.set_line(
+                            inner.left(),
+                            inner.top() + header_height,
+                            &Line::from(Span::styled(
+                                format!("  {}", line),
+                                theme::base_style(),
+                            )),
+                            inner.width,
+                        );
+                        header_height += 1;
+                    }
+                }
+            }
+
+            if header_height < inner.height {
                 buf.set_line(
                     inner.left(),
                     inner.top() + header_height,
-                    &Line::from(Span::styled(meta, theme::meta_style())),
+                    &Line::from(Span::styled(
+                        "  ────────────────────────────────────────",
+                        theme::dim_style(),
+                    )),
                     inner.width,
                 );
                 header_height += 1;
-
-                if header_height < inner.height {
-                    buf.set_line(
-                        inner.left(),
-                        inner.top() + header_height,
-                        &Line::from(Span::styled(
-                            "  ────────────────────────────────────────",
-                            theme::dim_style(),
-                        )),
-                        inner.width,
-                    );
-                    header_height += 1;
-                }
             }
         }
 

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -37,16 +37,16 @@ impl<'a> Widget for StoryList<'a> {
             theme::dim_style()
         };
 
-        let title = if let Some(q) = &self.search_query {
-            format!(" Search: {} ", q)
+        let title_span = if let Some(q) = &self.search_query {
+            Span::styled(format!(" Search: {} ", q), theme::title_style())
         } else {
-            " Stories ".to_string()
+            Span::styled(" Stories ", theme::title_style())
         };
 
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(border_style)
-            .title(Span::styled(title, theme::title_style()))
+            .title(title_span)
             .style(theme::base_style());
 
         let inner = block.inner(area);


### PR DESCRIPTION
## Summary

Generated by `/idiom-check`. Four allocation cleanups along the per-frame render path. None of these change rendered output — they only delete per-frame `String` allocations.

- **[I1]** Comment-tree story header: split borrows so `story_plain_text` (which `&mut`-borrows `story_text_cache`) returns `&str` and the body lines flow straight from the cache. Removes the old `.map(str::to_owned)` + `.clone().unwrap_or_default()` pair that needed two `String` allocations per frame just to detangle the borrow checker. (`src/ui/comment_tree.rs:120-127`)
- **[I16]** Story-list and comment-tree titles: build `Span` directly in each branch so the no-story branch becomes `Span::styled(\" Comments \", ...)` with `Cow::Borrowed`. (`src/ui/comment_tree.rs:69`, `src/ui/story_list.rs:43`)
- **[I17]** `App::open_url_in_reader`: reorder the `(title, domain)` build so neither is cloned defensively — pick between `path_seg` and `domain.as_deref()` before constructing the title. (`src/app.rs:1186-1192`)
- **[I18]** `article_reader::render_error`: pass the `error` `&str` directly to `Span::styled` — `Paragraph` borrows for the render lifetime, so no `to_string()` is needed. Also drop the `reader.title.clone()` in `build_title` for the short-title path. (`src/ui/article_reader.rs:70, 123`)

The bigger comment-tree `Span<'static>` lifetime change (the agent's [I2]) is intentionally not in this PR — it requires re-introducing a lifetime parameter on `CommentLine` / `MeasuredComment`, so it lands separately if/when reviewed.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 216 passing, 0 failed
- [ ] Manual smoke: open an Ask HN story (body text path), open a regular story (URL path), open the article reader, force an article-reader error