### PR TITLE
Idiomatic control flow in dispatch and link registry

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -225,6 +225,19 @@ impl App {
         self.spawn_load_stories(LoadMode::Replace);
     }
 
+    /// Common housekeeping after either a feed page or a search page lands:
+    /// install/append the new stories, clear the loading flag, clear the
+    /// error banner. Auto-load and search-pagination bookkeeping are
+    /// caller-specific and stay at the call sites.
+    fn apply_loaded_stories(&mut self, stories: Vec<Item>, mode: LoadMode) {
+        match mode {
+            LoadMode::Append => self.story_state.stories.extend(stories),
+            LoadMode::Replace => self.story_state.stories = stories,
+        }
+        self.story_state.loading = false;
+        self.error = None;
+    }
+
     /// Processes any pending async messages (non-blocking).
     pub fn process_messages(&mut self) {
         while let Ok(msg) = self.msg_rx.try_recv() {
@@ -234,15 +247,10 @@ impl App {
                     all_ids,
                     mode,
                 } => {
-                    match mode {
-                        LoadMode::Append => self.story_state.stories.extend(stories),
-                        LoadMode::Replace => self.story_state.stories = stories,
-                    }
+                    self.apply_loaded_stories(stories, mode);
                     if let Some(ids) = all_ids {
                         self.story_state.all_ids = ids;
                     }
-                    self.story_state.loading = false;
-                    self.error = None;
                     // Auto-load comments for the first story on initial load
                     if matches!(mode, LoadMode::Replace)
                         && !self.story_state.stories.is_empty()
@@ -258,12 +266,7 @@ impl App {
                     total_hits,
                     mode,
                 } => {
-                    match mode {
-                        LoadMode::Append => self.story_state.stories.extend(stories),
-                        LoadMode::Replace => self.story_state.stories = stories,
-                    }
-                    self.story_state.loading = false;
-                    self.error = None;
+                    self.apply_loaded_stories(stories, mode);
                     if let Some(ref mut ss) = self.search_state {
                         ss.total_pages = total_pages;
                         ss.total_hits = total_hits;
@@ -348,19 +351,10 @@ impl App {
         // Hint-mode actions short-circuit ahead of every overlay route
         // because the user is mid-selection and any keypress should be
         // narrowing labels, not mutating panes underneath.
-        match &action {
-            Action::HintKey(c) => {
-                self.hint_key(*c);
-                return;
-            }
-            Action::ExitHintMode => {
-                self.exit_hint_mode();
-                return;
-            }
-            Action::EnterHintMode(hint_action) => {
-                self.enter_hint_mode(*hint_action);
-                return;
-            }
+        match action {
+            Action::HintKey(c) => return self.hint_key(c),
+            Action::ExitHintMode => return self.exit_hint_mode(),
+            Action::EnterHintMode(a) => return self.enter_hint_mode(a),
             _ => {}
         }
 
@@ -782,10 +776,14 @@ impl App {
     /// query is already in flight. Failures silently no-op — prior-discussions
     /// is optional UX, not critical-path.
     fn spawn_prior_discussions(&mut self, story_id: StoryId, url: &str) {
-        if self.prior_results.contains_key(&story_id) || self.prior_in_flight.contains(&story_id) {
+        if self.prior_results.contains_key(&story_id) {
             return;
         }
-        self.prior_in_flight.insert(story_id);
+        // HashSet::insert returns false if the value was already present —
+        // single-lookup membership-check + insert.
+        if !self.prior_in_flight.insert(story_id) {
+            return;
+        }
 
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
@@ -890,14 +888,11 @@ impl App {
     /// locally. For URL stories, validates the http(s) scheme and then
     /// spawns a fetch + readability extraction task.
     fn open_article_reader(&mut self) {
-        let story = match self.focus {
+        let Some(story) = (match self.focus {
             Pane::Stories => self.story_state.selected_story().cloned(),
             Pane::Comments => self.comment_state.story.clone(),
-        };
-
-        let story = match story {
-            Some(s) => s,
-            None => return,
+        }) else {
+            return;
         };
 
         let title = story.title.clone().unwrap_or_default();

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -87,22 +87,11 @@ impl LinkRegistry {
 
     /// Looks up `prefix` against every link's label. See [`MatchResult`].
     pub fn match_prefix(&self, prefix: &str) -> MatchResult<'_> {
-        let mut found: Option<&LinkRef> = None;
-        let mut count = 0usize;
-        for link in &self.links {
-            if link.label.starts_with(prefix) {
-                count += 1;
-                if count == 1 {
-                    found = Some(link);
-                } else {
-                    return MatchResult::Multiple;
-                }
-            }
-        }
-        match (count, found) {
-            (0, _) => MatchResult::None,
-            (1, Some(link)) => MatchResult::Unique(link),
-            _ => MatchResult::None,
+        let mut iter = self.links.iter().filter(|l| l.label.starts_with(prefix));
+        match (iter.next(), iter.next()) {
+            (None, _) => MatchResult::None,
+            (Some(link), None) => MatchResult::Unique(link),
+            (Some(_), Some(_)) => MatchResult::Multiple,
         }
     }
 }


### PR DESCRIPTION
## Summary

Generated by `/idiom-check`. Six pure-refactor cleanups to control-flow idioms in `App::dispatch`, `App::process_messages`, `App::open_article_reader`, `App::spawn_prior_discussions`, and `LinkRegistry::match_prefix`. No behavior changes.

- **[I9]** `App::dispatch` hint-mode prefilter: drop the leading \`&action\` borrow so the arms move directly, eliminating the \`*c\` / \`*hint_action\` deref-copies. (\`src/app.rs:351-365\`)
- **[I10]** \`App::process_messages\`: extract \`apply_loaded_stories\` for the common housekeeping shared by \`StoriesLoaded\` and \`SearchResultsLoaded\` arms (install/clear-loading/clear-error). (\`src/app.rs:230-329\`)
- **[I11]** \`LinkRegistry::match_prefix\`: replace the manual count-loop with \`(iter.next(), iter.next())\` tri-state match. Hot path — runs on every keystroke in hint mode. (\`src/state/link_registry.rs:89-107\`)
- **[I25]/[I30]** \`App::open_article_reader\`: collapse two-stage \`match\` then \`match\` into a single \`let-else\`, matching the file's existing convention at \`app.rs:577-583\`. (\`src/app.rs:893-901\`)
- **[I26]** \`App::spawn_prior_discussions\`: replace \`contains\` + \`insert\` with \`HashSet::insert -> bool\` single-lookup membership-and-insert (mirrors the existing pattern at \`comment_state.rs:228-231\`). (\`src/app.rs:785\`)

## Test plan

- [x] \`cargo check\` — clean
- [x] \`cargo test\` — 216 passing, 0 failed
- [ ] Manual smoke: hint-mode entry/exit, story scroll, refresh, search, prior discussions overlay