### PR TITLE
Align article module on anyhow::Result

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -504,7 +504,7 @@ impl App {
                     if !query.is_empty() {
                         self.story_state.reset();
                         self.comment_state.reset();
-                        self.spawn_search(&query, 0, LoadMode::Replace);
+                        self.spawn_search(query, 0, LoadMode::Replace);
                     }
                 } else {
                     self.story_state.reset();
@@ -673,7 +673,7 @@ impl App {
         self.input_mode = InputMode::Normal;
         self.story_state.reset();
         self.comment_state.reset();
-        self.spawn_search(&query, 0, LoadMode::Replace);
+        self.spawn_search(query, 0, LoadMode::Replace);
     }
 
     /// Exits search mode, clears the cache, and reloads the current feed.
@@ -702,11 +702,12 @@ impl App {
 
     /// Kicks off an async Algolia search. [`LoadMode::Append`] extends the
     /// current result list (lazy pagination); [`LoadMode::Replace`] replaces it.
-    fn spawn_search(&mut self, query: &str, page: usize, mode: LoadMode) {
+    /// Takes `query: String` by value so callers can hand ownership in once
+    /// instead of cloning at the call site and again inside this function.
+    fn spawn_search(&mut self, query: String, page: usize, mode: LoadMode) {
         self.story_state.loading = true;
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
-        let query = query.to_string();
         let page_size = self.page_size();
 
         tokio::spawn(async move {
@@ -934,7 +935,7 @@ impl App {
                     let _ = tx.send(AppMessage::ArticleLoaded { lines, links });
                 }
                 Err(e) => {
-                    let _ = tx.send(AppMessage::ArticleError(e));
+                    let _ = tx.send(AppMessage::ArticleError(format!("{e:#}")));
                 }
             }
         });
@@ -983,7 +984,7 @@ impl App {
                 ss.current_page += 1;
                 let query = ss.query.clone();
                 let page = ss.current_page;
-                self.spawn_search(&query, page, LoadMode::Append);
+                self.spawn_search(query, page, LoadMode::Append);
             }
         } else if self.story_state.needs_more() {
             self.story_state.loading = true;
@@ -1206,7 +1207,7 @@ impl App {
                     let _ = tx.send(AppMessage::ArticleLoaded { lines, links });
                 }
                 Err(e) => {
-                    let _ = tx.send(AppMessage::ArticleError(e));
+                    let _ = tx.send(AppMessage::ArticleError(format!("{e:#}")));
                 }
             }
         });

--- a/src/article.rs
+++ b/src/article.rs
@@ -200,7 +200,9 @@ fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>
 pub async fn fetch_and_extract_article(
     url: &str,
     width: usize,
-) -> Result<(Vec<Vec<StyledFragment>>, LinkRegistry), String> {
+) -> anyhow::Result<(Vec<Vec<StyledFragment>>, LinkRegistry)> {
+    use anyhow::{anyhow, bail, Context};
+
     let client = reqwest::Client::builder()
         .user_agent(concat!(
             "Mozilla/5.0 (compatible; hnt/",
@@ -208,8 +210,7 @@ pub async fn fetch_and_extract_article(
             ")"
         ))
         .timeout(std::time::Duration::from_secs(15))
-        .build()
-        .map_err(|e| format!("HTTP client error: {}", e))?;
+        .build()?;
 
     // For GitHub/GitLab repo pages, try fetching the README directly
     if let Some((readme_text, is_markdown)) = try_fetch_readme(&client, url).await {
@@ -237,15 +238,15 @@ pub async fn fetch_and_extract_article(
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("Failed to fetch: {}", e))?;
+        .context("Failed to fetch")?;
 
     if !resp.status().is_success() {
-        return Err(format!("HTTP {}", resp.status()));
+        bail!("HTTP {}", resp.status());
     }
 
     if let Some(len) = resp.content_length() {
         if len > MAX_RESPONSE_BYTES as u64 {
-            return Err("Article too large (>5MB)".to_string());
+            bail!("Article too large (>5MB)");
         }
     }
 
@@ -262,19 +263,16 @@ pub async fn fetch_and_extract_article(
         && !content_type.contains("text/plain")
         && !content_type.contains("application/xhtml")
     {
-        return Err(format!(
+        bail!(
             "Not an article (content-type: {})",
             content_type.split(';').next().unwrap_or(&content_type)
-        ));
+        );
     }
 
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to read response: {}", e))?;
+    let bytes = resp.bytes().await.context("Failed to read response")?;
 
     if bytes.len() > MAX_RESPONSE_BYTES {
-        return Err("Article too large (>5MB)".to_string());
+        bail!("Article too large (>5MB)");
     }
 
     // Run readability extraction in a blocking task (CPU-bound)
@@ -282,7 +280,7 @@ pub async fn fetch_and_extract_article(
     let width_copy = width;
     tokio::task::spawn_blocking(move || extract_article_content(&bytes, &url_string, width_copy))
         .await
-        .map_err(|e| format!("Processing error: {}", e))?
+        .map_err(|e| anyhow!("Processing error: {}", e))?
 }
 
 /// Runs readability extraction + html2text rich rendering
@@ -292,8 +290,9 @@ fn extract_article_content(
     html_bytes: &[u8],
     url_str: &str,
     width: usize,
-) -> Result<(Vec<Vec<StyledFragment>>, LinkRegistry), String> {
-    let parsed_url = url::Url::parse(url_str).map_err(|e| format!("Invalid URL: {}", e))?;
+) -> anyhow::Result<(Vec<Vec<StyledFragment>>, LinkRegistry)> {
+    use anyhow::Context;
+    let parsed_url = url::Url::parse(url_str).context("Invalid URL")?;
 
     // Try readability extraction first, fall back to full HTML if it produces no content
     let tagged_lines = {

--- a/src/article.rs
+++ b/src/article.rs
@@ -234,11 +234,7 @@ pub async fn fetch_and_extract_article(
         };
     }
 
-    let resp = client
-        .get(url)
-        .send()
-        .await
-        .context("Failed to fetch")?;
+    let resp = client.get(url).send().await.context("Failed to fetch")?;
 
     if !resp.status().is_success() {
         bail!("HTTP {}", resp.status());


### PR DESCRIPTION
## Summary

Generated by `/idiom-check`. Two findings around error propagation and clone elimination on the article-load path.

- **[I7]** `article::fetch_and_extract_article` and `extract_article_content`: switch from `Result<_, String>` to `anyhow::Result<_>`. Replaces ~10 `.map_err(|e| format!(\"...: {e}\"))` calls with bare `?` and `.context(...)`, aligning the article module with `HnClient` (`api/client.rs`) and `event.rs:73-78`, which already use `anyhow::Result`. Literal-`Err(...)` returns become `anyhow::bail!`. The article-error send sites format with `{e:#}` so the chained error renders as `\"context: source\"`. (`src/article.rs:200-203, 291-295`, `src/app.rs:937, 1210`)
- **[I31]** `App::spawn_search`: take `query: String` by value instead of `&str` + an internal `to_string()`. Removes a redundant clone in the Refresh and `check_lazy_load` paths where the caller already had an owned `String`. (`src/app.rs:502-507, 705-727, 983-986`)

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 216 passing, 0 failed
- [ ] Manual smoke: trigger an article fetch error (404 URL) — verify the error message in the reader overlay still reads as before; trigger a search and a refresh