### PR TITLE
Drop dead offset field, use BoxFuture, get over remove

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -7,7 +7,9 @@
 
 use super::types::{CommentWithDepth, FeedKind, Item, SearchResponse};
 use anyhow::Result;
+use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt};
+use futures::FutureExt;
 use lru::LruCache;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -103,14 +105,16 @@ impl HnClient {
             .await;
 
         // buffer_unordered doesn't preserve order, so re-order by input IDs.
-        let mut result_map: HashMap<u64, Arc<Item>> = results
+        // Callers don't pass duplicate IDs, so a non-consuming `get` lookup
+        // suffices — no need to invalidate the map slot per hit.
+        let result_map: HashMap<u64, Arc<Item>> = results
             .into_iter()
             .flatten()
             .map(|arc| (arc.id, arc))
             .collect();
 
         ids.iter()
-            .map(|id| result_map.remove(id).map(|arc| (*arc).clone()))
+            .map(|id| result_map.get(id).map(|arc| (**arc).clone()))
             .collect()
     }
 
@@ -212,16 +216,17 @@ impl HnClient {
 
     /// Walks a comment subtree depth-first, appending [`CommentWithDepth`]
     /// records into `result` for every live descendant up to `max_depth`.
-    /// Dead/deleted comments are skipped. Returns a boxed future so the
-    /// recursion can cross `async` boundaries.
+    /// Dead/deleted comments are skipped. Returns a [`BoxFuture`] so the
+    /// recursion can cross `async` boundaries — `BoxFuture<'a, ()>` is the
+    /// idiomatic alias for the hand-pinned `Pin<Box<dyn Future + Send + 'a>>`.
     pub fn fetch_children_recursive<'a>(
         &'a self,
         ids: &'a [u64],
         depth: usize,
         max_depth: usize,
         result: &'a mut Vec<CommentWithDepth>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
-        Box::pin(async move {
+    ) -> BoxFuture<'a, ()> {
+        async move {
             if depth > max_depth || ids.is_empty() {
                 return;
             }
@@ -244,7 +249,8 @@ impl HnClient {
                     }
                 }
             }
-        })
+        }
+        .boxed()
     }
 }
 

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -17,7 +17,6 @@ pub struct StoryListState {
     pub stories: Vec<Item>,
     pub all_ids: Vec<u64>,
     pub selected: usize,
-    pub offset: usize,
     pub loading: bool,
 }
 
@@ -77,7 +76,6 @@ impl StoryListState {
         self.stories.clear();
         self.all_ids.clear();
         self.selected = 0;
-        self.offset = 0;
         self.loading = false;
     }
 }
@@ -117,7 +115,6 @@ mod tests {
         assert!(s.stories.is_empty());
         assert!(s.all_ids.is_empty());
         assert_eq!(s.selected, 0);
-        assert_eq!(s.offset, 0);
         assert!(!s.loading);
     }
 
@@ -272,13 +269,11 @@ mod tests {
         let mut s = state_with_stories(5);
         s.all_ids = vec![1, 2, 3];
         s.selected = 3;
-        s.offset = 10;
         s.loading = true;
         s.reset();
         assert!(s.stories.is_empty());
         assert!(s.all_ids.is_empty());
         assert_eq!(s.selected, 0);
-        assert_eq!(s.offset, 0);
         assert!(!s.loading);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -54,7 +54,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         story_list::StoryList {
             stories: &app.story_state.stories,
             selected: app.story_state.selected,
-            offset: 0,
             focused: app.focus == crate::app::Pane::Stories,
             loading: app.story_state.loading,
             search_query: if search_active { search_query } else { None },

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -20,7 +20,6 @@ use ratatui::{
 pub struct StoryList<'a> {
     pub stories: &'a [Item],
     pub selected: usize,
-    pub offset: usize,
     pub focused: bool,
     pub loading: bool,
     pub search_query: Option<&'a str>,
@@ -76,13 +75,11 @@ impl<'a> Widget for StoryList<'a> {
 
         let visible_height = inner.height as usize;
 
-        // Calculate scroll offset to keep selected visible
-        let scroll = if self.selected >= self.offset + visible_height {
+        // Calculate scroll offset to keep selected visible.
+        let scroll = if self.selected >= visible_height {
             self.selected - visible_height + 1
-        } else if self.selected < self.offset {
-            self.selected
         } else {
-            self.offset
+            0
         };
 
         for (i, story) in self


### PR DESCRIPTION
## Summary

Generated by `/idiom-check`. Three small cleanups in adjacent code.

- **[I22]** `HnClient::fetch_children_recursive`: replace the hand-pinned `Pin<Box<dyn Future + Send + 'a>>` return with `BoxFuture<'a, ()>` from `futures` (already a dep), via `.boxed()` on the inner `async move` block. Same behavior, less ceremony. (`src/api/client.rs:217-244`)
- **[I23]** Drop dead `StoryListState::offset` (and the matching `StoryList::offset` widget field). The field was hardwired to `0` at every call site; the scroll-keep-visible logic in `ui/story_list.rs` collapses to a 4-line computation on `selected` and `visible_height`. (`src/state/story_state.rs:19`, `src/ui/mod.rs:57`, `src/ui/story_list.rs:23,80,82,86`)
- **[I33]** `HnClient::fetch_items`: swap `result_map.remove(id)` for `result_map.get(id)`. Callers don't pass duplicate IDs, so a non-consuming lookup is enough (also drops the `mut` on the local map). Pairs with [I12] (Arc propagation, deferred to a separate PR). (`src/api/client.rs:106-115`)

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 216 passing, 0 failed (two `offset` test asserts pruned alongside the field)