### PR TITLE
Bump version to 0.3.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Closes #112

## Summary
- Bumps `Cargo.toml` from `0.3.11` → `0.3.12`
- Refreshes the `hnt` entry in `Cargo.lock` to match
- Triggers the `Release` workflow to build the four target binaries and publish `v0.3.12`

## What's in this release

Seven idiom-audit PRs merged via `/idiom-check`:

- **#105** Drop deep clones in comment-load spawn path
- **#106** Eliminate per-frame string allocations on render path
- **#107** Idiomatic control flow in dispatch and link registry
- **#108** Tighten public APIs with `#[non_exhaustive]` / `#[must_use]`
- **#109** Default-derive state constructors and consolidate keymap
- **#110** Align article module on `anyhow::Result`
- **#111** Drop dead `StoryListState::offset` and use `BoxFuture` alias

Zero test regressions — 216 tests passing throughout the series.

## Test plan
- [ ] CI green on this PR (`cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`, build matrix)
- [ ] Merge → `release.yml` kicks off
- [ ] All four target builds succeed (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`)
- [ ] `v0.3.12` appears under [Releases](https://github.com/thijsvos/hnt/releases) with 5 assets (4 binaries + `checksums.txt`)