### PR TITLE
Add 'What's New' comment filter (n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Browse stories, read threaded comments, and open links — all from your termina
 - **Quickjump link hints** — In reader mode, press `f` and every hyperlink gets a 1- or 2-character home-row label. Type the label to open it (`f` browser, `F` HNT reader, `y` copy URL via OSC 52 — works through SSH)
 - **Prior discussions** — Press `h` to see past HN submissions of the same URL with their scores and dates
 - **Read-state tracking** — Visited stories render dimmed; stories with new comments since your last visit get a `+N` badge. Persisted to `$XDG_DATA_HOME/hnt/read.json`
+- **What's New filter** — In the comments pane, press `n` to cycle through "all → new since last visit → recent 24h → all". Shows only comments newer than the threshold, with their parent comments preserved so the thread still reads in context. Turns the `+N` badge into something you can act on without scrolling through 500 comments to find the new ones.
 - **Open in browser** — Press `o` to open the story URL
 - **Progressive loading** — Root comments appear instantly, children load in the background
 - **Lazy pagination** — Stories load automatically as you scroll
@@ -75,6 +76,7 @@ cargo build --release
 | `Tab` | Switch pane focus |
 | `1`-`6` | Switch feed (Top/New/Best/Ask/Show/Jobs) |
 | `r` | Refresh |
+| `n` | Cycle "What's New" filter (comments pane) |
 | `g` / `G` | Jump to top / bottom |
 | `Ctrl+d` / `Ctrl+u` | Page down / up |
 | `q` | Quit |

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::api::types::{CommentId, CommentWithDepth, FeedKind, Item, StoryId};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::clipboard;
 use crate::keys::{Action, InputMode};
-use crate::state::comment_state::CommentTreeState;
+use crate::state::comment_state::{CommentFilter, CommentTreeState};
 use crate::state::hint_state::{HintAction, HintContext, HintState};
 use crate::state::link_registry::{LinkRegistry, MatchResult};
 use crate::state::prior_state::PriorDiscussionsState;
@@ -394,6 +394,7 @@ impl App {
                 | Action::EnterSearch
                 | Action::ToggleHelp
                 | Action::TogglePriorDiscussions
+                | Action::CycleCommentFilter
                 | Action::None => {}
                 Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
                     unreachable!("hint actions handled above")
@@ -436,6 +437,7 @@ impl App {
                 | Action::EnterSearch
                 | Action::ToggleHelp
                 | Action::TogglePriorDiscussions
+                | Action::CycleCommentFilter
                 | Action::PageDown
                 | Action::PageUp
                 | Action::None => {}
@@ -539,10 +541,38 @@ impl App {
             },
             Action::ToggleHelp => self.show_help = !self.show_help,
             Action::TogglePriorDiscussions => self.toggle_prior_discussions(),
+            Action::CycleCommentFilter => self.cycle_comment_filter(),
             Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
                 unreachable!("hint actions handled above")
             }
             Action::None => {}
+        }
+    }
+
+    /// Cycles the comment-pane filter: All → New since last visit →
+    /// Recent 24h → All. Stories never visited skip `NewSince` (no
+    /// timestamp to anchor it to) and go All → Recent → All. No-op when
+    /// no story is loaded. Clamps the selection to the new visible
+    /// length so the cursor stays in range.
+    fn cycle_comment_filter(&mut self) {
+        let Some(story) = self.comment_state.story.as_ref() else {
+            return;
+        };
+        let last_seen = self.read_store.last_seen_at(StoryId(story.id));
+        let now = chrono::Utc::now().timestamp();
+        let recent = CommentFilter::Recent(now - 86_400);
+        self.comment_state.filter = match (self.comment_state.filter, last_seen) {
+            (CommentFilter::All, Some(t)) => CommentFilter::NewSince(t),
+            (CommentFilter::All, None) => recent,
+            (CommentFilter::NewSince(_), _) => recent,
+            (CommentFilter::Recent(_), _) => CommentFilter::All,
+        };
+        // Clamp selection to whatever is visible under the new filter.
+        let visible = self.comment_state.visible_len();
+        if visible == 0 {
+            self.comment_state.selected = 0;
+        } else if self.comment_state.selected >= visible {
+            self.comment_state.selected = visible - 1;
         }
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -45,6 +45,10 @@ pub enum Action {
     ToggleHelp,
     TogglePriorDiscussions,
     EnterSearch,
+    /// Cycle the comment-pane "what's new" filter: All → New since last
+    /// visit → Recent 24h → All. Falls through to All when the story has
+    /// never been visited (no `last_seen_at` to anchor `NewSince` to).
+    CycleCommentFilter,
     /// Quickjump: enter hint-label mode; the `HintAction` decides what
     /// fires on a unique label match (open in browser / open in reader /
     /// copy URL to clipboard via OSC 52).
@@ -130,6 +134,7 @@ pub fn map_key(
         KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => Action::SwitchPane,
         KeyCode::Char(c @ '1'..='6') => Action::SwitchFeed(c as usize - '1' as usize),
         KeyCode::Char('r') => Action::Refresh,
+        KeyCode::Char('n') => Action::CycleCommentFilter,
         KeyCode::Char('g') => Action::JumpTop,
         KeyCode::Char('G') => Action::JumpBottom,
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -11,6 +11,22 @@ use crate::api::types::ItemType;
 use crate::api::types::{CommentId, CommentWithDepth, Item};
 use std::collections::HashSet;
 
+/// Comment-pane visibility filter. Composes with the collapse state so the
+/// user can fold subtrees and narrow to "what's new" simultaneously.
+///
+/// `NewSince(t)` and `Recent(t)` differ only in how `t` is chosen — the
+/// former from `read_store.last_seen_at(story_id)`, the latter from a
+/// rolling clock window — but their semantics are identical: keep every
+/// comment whose `time > t`, plus every ancestor of such a comment so the
+/// thread reads coherently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CommentFilter {
+    #[default]
+    All,
+    NewSince(i64),
+    Recent(i64),
+}
+
 /// One comment in the flattened, depth-tagged comment tree.
 ///
 /// `depth == 0` is a root-level comment; children have strictly greater
@@ -70,6 +86,9 @@ pub struct CommentTreeState {
     /// Maps screen row (relative to inner area top) → visible comment index.
     /// Populated during render for mouse click handling.
     pub row_map: Vec<Option<usize>>,
+    /// "What's new" filter — composes with collapse to narrow the visible
+    /// set. Reset to [`CommentFilter::All`] on every [`Self::set_comments`].
+    pub filter: CommentFilter,
     /// Cached plain-text rendering of the current story's text (id, width, text).
     /// Invalidated automatically when story id or width changes.
     story_text_cache: Option<(u64, usize, String)>,
@@ -99,6 +118,8 @@ impl CommentTreeState {
 
     /// Replaces the flat list and resets selection/scroll to the top.
     /// `items` must be in pre-order (parents before their descendants).
+    /// Also clears any active "what's new" filter — switching stories
+    /// should always start with the full thread visible.
     pub fn set_comments(&mut self, items: Vec<CommentWithDepth>) {
         self.comments = items
             .into_iter()
@@ -106,6 +127,7 @@ impl CommentTreeState {
             .collect();
         self.scroll = 0;
         self.selected = 0;
+        self.filter = CommentFilter::All;
     }
 
     /// Insert child comments right after their parent in the flattened list.
@@ -126,11 +148,52 @@ impl CommentTreeState {
         }
     }
 
+    /// Returns the set of comment indices that pass `self.filter`,
+    /// including every ancestor of a passing comment so the thread reads
+    /// coherently. Returns `None` for [`CommentFilter::All`] — callers
+    /// treat that as "everything passes."
+    ///
+    /// O(comments) for the matching scan plus O(matches × tree_depth) for
+    /// the ancestor walk. The flat list is in pre-order, so each ancestor
+    /// is found by walking backwards over strictly-decreasing depths.
+    fn filter_visible_set(&self) -> Option<HashSet<usize>> {
+        let threshold = match self.filter {
+            CommentFilter::All => return None,
+            CommentFilter::NewSince(t) | CommentFilter::Recent(t) => t,
+        };
+        let mut keep = HashSet::new();
+        for (i, c) in self.comments.iter().enumerate() {
+            if c.item.time.is_none_or(|t| t <= threshold) {
+                continue;
+            }
+            keep.insert(i);
+            let mut wanted_depth = c.depth;
+            if wanted_depth == 0 {
+                continue;
+            }
+            for j in (0..i).rev() {
+                let d = self.comments[j].depth;
+                if d < wanted_depth {
+                    keep.insert(j);
+                    wanted_depth = d;
+                    if d == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        Some(keep)
+    }
+
     /// Walks the comment tree, skipping subtrees rooted at a collapsed
-    /// comment, and yields the indices (into `self.comments`) that should
-    /// be shown. Allocation-free — prefer this for `.count()` /
+    /// comment and (when `self.filter` is non-default) any comment that
+    /// neither matches the filter nor is an ancestor of a match. Yields
+    /// the indices (into `self.comments`) that should be shown.
+    /// Allocation-free for the common [`CommentFilter::All`] case; one
+    /// `HashSet` allocation otherwise. Prefer this for `.count()` /
     /// `.nth(...)` over the `Vec`-returning [`Self::visible_indices`].
     pub fn visible_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
+        let filter_set = self.filter_visible_set();
         let mut skip_depth: Option<usize> = None;
         self.comments
             .iter()
@@ -144,6 +207,11 @@ impl CommentTreeState {
                 }
                 if self.collapsed.contains(&CommentId(comment.item.id)) {
                     skip_depth = Some(comment.depth);
+                }
+                if let Some(set) = filter_set.as_ref() {
+                    if !set.contains(&i) {
+                        return None;
+                    }
                 }
                 Some(i)
             })
@@ -233,6 +301,7 @@ impl CommentTreeState {
         self.story = None;
         self.pending_root_ids.clear();
         self.row_map.clear();
+        self.filter = CommentFilter::All;
     }
 }
 
@@ -563,5 +632,125 @@ mod tests {
         // CommentsDone → clear remaining
         state.pending_root_ids.clear();
         assert!(state.pending_root_ids.is_empty());
+    }
+
+    fn cwd_at(id: u64, depth: usize, time: i64) -> CommentWithDepth {
+        let mut item = make_item(id);
+        item.time = Some(time);
+        CommentWithDepth { item, depth }
+    }
+
+    #[test]
+    fn filter_default_is_all() {
+        let state = CommentTreeState::new();
+        assert_eq!(state.filter, CommentFilter::All);
+    }
+
+    #[test]
+    fn filter_all_keeps_everything() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![cwd_at(1, 0, 100), cwd_at(2, 1, 200), cwd_at(3, 0, 50)]);
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn filter_new_since_keeps_match_and_ancestors() {
+        let mut state = CommentTreeState::new();
+        // root(1)@100 -> child(2)@150 -> grandchild(3)@500, sibling(4)@110
+        // threshold = 200 → only id=3 passes; ancestors 1, 2 must be kept;
+        // sibling 4 is filtered out.
+        state.set_comments(vec![
+            cwd_at(1, 0, 100),
+            cwd_at(2, 1, 150),
+            cwd_at(3, 2, 500),
+            cwd_at(4, 0, 110),
+        ]);
+        state.filter = CommentFilter::NewSince(200);
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn filter_new_since_keeps_unrelated_new_root() {
+        let mut state = CommentTreeState::new();
+        // root(1)@100 -> child(2)@150, root(3)@500
+        // threshold = 200 → root(3) passes. No ancestors needed (depth 0).
+        state.set_comments(vec![
+            cwd_at(1, 0, 100),
+            cwd_at(2, 1, 150),
+            cwd_at(3, 0, 500),
+        ]);
+        state.filter = CommentFilter::NewSince(200);
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![3]);
+    }
+
+    #[test]
+    fn filter_new_since_no_matches_yields_empty() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![cwd_at(1, 0, 100), cwd_at(2, 1, 150)]);
+        state.filter = CommentFilter::NewSince(1_000);
+        assert!(state.visible_comments().is_empty());
+    }
+
+    #[test]
+    fn filter_skips_comments_without_time() {
+        let mut state = CommentTreeState::new();
+        // make_item leaves time = None — those should never pass the filter
+        state.set_comments(sample_tree());
+        state.filter = CommentFilter::NewSince(0);
+        assert!(state.visible_comments().is_empty());
+    }
+
+    #[test]
+    fn filter_recent_uses_threshold_directly() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![
+            cwd_at(1, 0, 100),
+            cwd_at(2, 0, 1000),
+            cwd_at(3, 0, 2000),
+        ]);
+        state.filter = CommentFilter::Recent(500);
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[test]
+    fn filter_walks_ancestors_with_skipped_intermediate_depths() {
+        let mut state = CommentTreeState::new();
+        // root(1)@100 at depth 0 -> deep(2)@500 at depth 3
+        // The ancestor walk only requires *strictly decreasing* depths;
+        // a single direct parent at depth 0 is enough.
+        state.set_comments(vec![cwd_at(1, 0, 100), cwd_at(2, 3, 500)]);
+        state.filter = CommentFilter::NewSince(200);
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn filter_composes_with_collapse() {
+        let mut state = CommentTreeState::new();
+        // root(1)@100 -> child(2)@500 -> grandchild(3)@600, sibling(4)@500
+        state.set_comments(vec![
+            cwd_at(1, 0, 100),
+            cwd_at(2, 1, 500),
+            cwd_at(3, 2, 600),
+            cwd_at(4, 0, 500),
+        ]);
+        state.filter = CommentFilter::NewSince(200);
+        // Without collapse: 1 (ancestor), 2 (match + ancestor), 3 (match), 4 (match)
+        // Collapse 2 → its descendants (3) hidden by collapse rule, 2 still shown
+        state.collapsed.insert(cid(2));
+        let ids: Vec<u64> = state.visible_comments().iter().map(|c| c.item.id).collect();
+        assert_eq!(ids, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn set_comments_resets_filter() {
+        let mut state = CommentTreeState::new();
+        state.filter = CommentFilter::NewSince(123);
+        state.set_comments(sample_tree());
+        assert_eq!(state.filter, CommentFilter::All);
     }
 }

--- a/src/state/read_store.rs
+++ b/src/state/read_store.rs
@@ -158,6 +158,14 @@ impl ReadStore {
         self.entries.contains_key(&id)
     }
 
+    /// Wall-clock timestamp (Unix seconds) of the last visit to `id`, if
+    /// any. Used by the "what's new" comment filter to mark comments
+    /// older than the user's previous visit as already-seen.
+    #[must_use]
+    pub fn last_seen_at(&self, id: StoryId) -> Option<i64> {
+        self.entries.get(&id).map(|e| e.last_seen_at)
+    }
+
     /// Persisted entry for `id`, if any.
     #[cfg(test)]
     pub fn entry(&self, id: StoryId) -> Option<&ReadEntry> {

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -7,7 +7,7 @@
 //! back to comment indices.
 
 use crate::api::types::CommentId;
-use crate::state::comment_state::{CommentTreeState, FlatComment};
+use crate::state::comment_state::{CommentFilter, CommentTreeState, FlatComment};
 use crate::ui::spinner;
 use crate::ui::story_list::format_time_ago;
 use crate::ui::theme;
@@ -76,6 +76,16 @@ impl<'a> Widget for CommentTree<'a> {
                 format!("· {} prior (h) ", self.prior_count),
                 theme::dim_style(),
             ));
+        }
+        match self.state.filter {
+            CommentFilter::All => {}
+            CommentFilter::NewSince(_) => title_spans.push(Span::styled(
+                "· New since last visit (n) ",
+                theme::accent_style(),
+            )),
+            CommentFilter::Recent(_) => {
+                title_spans.push(Span::styled("· Recent 24h (n) ", theme::accent_style()));
+            }
         }
 
         let block = Block::default()


### PR DESCRIPTION
Closes #114

## Summary
- New `n` keybind in the comments pane cycles **All → New since last visit → Recent 24h → All**
- Filtered comments include every ancestor of a matching comment so threads stay readable
- Stories never visited skip `NewSince` (no `last_seen_at` to anchor to) and cycle `All → Recent → All` instead
- Title-bar chip surfaces the active filter (`· New since last visit (n)` / `· Recent 24h (n)`)
- Filter resets on `set_comments` / `reset` so switching stories starts with a fresh view
- Composes with existing collapse logic — fold subtrees and narrow to "what's new" simultaneously

## What's behind this

The story-list `+N` badge has been telling users "12 new comments since last time" for a while, but the comment pane gave no way to act on the signal. This makes the badge actionable.

`ReadStore.entries[story_id].last_seen_at` was already populated, and `Item::time` carries per-comment timestamps from both Firebase and Algolia, so nothing new had to be persisted or fetched. The marginal code is one enum, one field on `CommentTreeState`, one accessor on `ReadStore`, one dispatch arm, and a title chip.

## Implementation

- **`src/state/comment_state.rs`** — new `CommentFilter` enum (`All` / `NewSince(i64)` / `Recent(i64)`); `filter` field on `CommentTreeState`; `filter_visible_set()` returns `Some(HashSet<usize>)` for non-default filters and `None` for the common `All` case (the iter stays allocation-free in the default path); `visible_indices_iter` composes filter and collapse in one pass. The ancestor walk scans backwards over strictly-decreasing depths since the flat list is pre-order.
- **`src/state/read_store.rs`** — `pub fn last_seen_at(&self, id: StoryId) -> Option<i64>` accessor over the existing `entries` map.
- **`src/keys.rs`** — `KeyCode::Char('n')` → new `Action::CycleCommentFilter` variant in the normal-mode keymap. Added to the reader and prior-overlay no-op lists so overlay routing stays exhaustive.
- **`src/app.rs`** — `cycle_comment_filter` reads `last_seen_at` for the active story, advances the mode, then clamps `selected` to the new visible length so the cursor stays in range when the filter shrinks the view.
- **`src/ui/comment_tree.rs`** — title-bar chip mirroring the existing `· N prior (h)` chip pattern.
- **`README.md`** — keybinding row + Features bullet.

## Test plan
- [x] 10 new unit tests in `comment_state::tests` (default filter, ancestor preservation including skipped depths, no-`time` items skipped, `Recent` threshold, filter+collapse composition, `set_comments` resets filter)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 226 passing (up from 216)
- [x] Manual TUI smoke: open a recently-visited story, press `n`, verify count shrinks and ancestor context is preserved; press `n` again for 24h; press `n` to clear; verify chip appears and disappears; switch stories and confirm filter resets