### PR TITLE
Bump version to 0.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Closes #116

## Summary
- Bumps `Cargo.toml` from `0.3.12` → `0.3.13`
- Refreshes the `hnt` entry in `Cargo.lock` to match
- Triggers the `Release` workflow to build the four target binaries and publish `v0.3.13`

## What's in this release

One feature PR on top of v0.3.12:

- **#115** Add "What's New" comment filter (`n`) — cycles `All → New since last visit → Recent 24h → All` in the comments pane, with parent comments preserved so threads still read coherently. Turns the existing `+N` story-list badge into something actionable.

## Test plan
- [ ] CI green on this PR (`cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`, build matrix)
- [ ] Merge → `release.yml` kicks off
- [ ] All four target builds succeed (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`)
- [ ] `v0.3.13` appears under [Releases](https://github.com/thijsvos/hnt/releases) with 5 assets (4 binaries + `checksums.txt`)