### PR TITLE
Add Pinned feed with resume position (b/7)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -60,9 +60,15 @@ impl HnClient {
         self.cache().clear();
     }
 
-    /// Fetches the list of story IDs for a given feed.
+    /// Fetches the list of story IDs for a given feed. Returns an empty
+    /// list for virtual feeds (those whose [`FeedKind::endpoint`] is
+    /// `None`) — the caller is responsible for sourcing those IDs from
+    /// local state instead.
     pub async fn fetch_story_ids(&self, feed: FeedKind) -> Result<Vec<u64>> {
-        let url = format!("{}/{}.json", BASE_URL, feed.endpoint());
+        let Some(endpoint) = feed.endpoint() else {
+            return Ok(Vec::new());
+        };
+        let url = format!("{}/{}.json", BASE_URL, endpoint);
         let ids: Vec<u64> = self.client.get(&url).send().await?.json().await?;
         Ok(ids)
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -218,8 +218,14 @@ fn url_domain(raw: &str) -> Option<String> {
     Some(host.strip_prefix("www.").unwrap_or(host).to_string())
 }
 
-/// The six Hacker News feeds the app can display; mirrors the Firebase
-/// endpoints exposed via [`FeedKind::endpoint`].
+/// The Hacker News feeds the app can display.
+///
+/// The first six mirror Firebase endpoints (Top/New/Best/Ask/Show/Jobs) —
+/// see [`FeedKind::endpoint`]. [`FeedKind::Pinned`] is a virtual feed
+/// backed by the local [`crate::state::pin_store::PinStore`] rather than
+/// a remote endpoint, so its [`endpoint`](FeedKind::endpoint) returns
+/// `None` and callers must branch to load IDs from the pin store instead
+/// of issuing a Firebase request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FeedKind {
@@ -229,29 +235,38 @@ pub enum FeedKind {
     Ask,
     Show,
     Jobs,
+    /// Locally-curated stories saved by the user (`b` to toggle). Aggregated
+    /// by [`crate::state::pin_store::PinStore`], not fetched over HTTP.
+    Pinned,
 }
 
 impl FeedKind {
-    /// Every [`FeedKind`] in display order — indexed by the 1–6 number keys
-    /// and iterated to build the header tab bar.
-    pub const ALL: [FeedKind; 6] = [
+    /// Every [`FeedKind`] in display order — indexed by the 1–7 number keys
+    /// and iterated to build the header tab bar. The trailing `Pinned`
+    /// entry is the local virtual feed.
+    pub const ALL: [FeedKind; 7] = [
         FeedKind::Top,
         FeedKind::New,
         FeedKind::Best,
         FeedKind::Ask,
         FeedKind::Show,
         FeedKind::Jobs,
+        FeedKind::Pinned,
     ];
 
-    /// Firebase path segment (e.g. `"topstories"`) for this feed.
-    pub fn endpoint(&self) -> &'static str {
+    /// Firebase path segment (e.g. `"topstories"`) for this feed, or
+    /// `None` for virtual feeds backed by local state. Callers must
+    /// branch on `None` to source IDs from the appropriate store rather
+    /// than issuing a Firebase request.
+    pub fn endpoint(&self) -> Option<&'static str> {
         match self {
-            FeedKind::Top => "topstories",
-            FeedKind::New => "newstories",
-            FeedKind::Best => "beststories",
-            FeedKind::Ask => "askstories",
-            FeedKind::Show => "showstories",
-            FeedKind::Jobs => "jobstories",
+            FeedKind::Top => Some("topstories"),
+            FeedKind::New => Some("newstories"),
+            FeedKind::Best => Some("beststories"),
+            FeedKind::Ask => Some("askstories"),
+            FeedKind::Show => Some("showstories"),
+            FeedKind::Jobs => Some("jobstories"),
+            FeedKind::Pinned => None,
         }
     }
 }
@@ -265,6 +280,7 @@ impl fmt::Display for FeedKind {
             FeedKind::Ask => write!(f, "Ask"),
             FeedKind::Show => write!(f, "Show"),
             FeedKind::Jobs => write!(f, "Jobs"),
+            FeedKind::Pinned => write!(f, "Pinned"),
         }
     }
 }
@@ -518,12 +534,25 @@ mod tests {
 
     #[test]
     fn feed_kind_endpoints() {
-        assert_eq!(FeedKind::Top.endpoint(), "topstories");
-        assert_eq!(FeedKind::New.endpoint(), "newstories");
-        assert_eq!(FeedKind::Best.endpoint(), "beststories");
-        assert_eq!(FeedKind::Ask.endpoint(), "askstories");
-        assert_eq!(FeedKind::Show.endpoint(), "showstories");
-        assert_eq!(FeedKind::Jobs.endpoint(), "jobstories");
+        assert_eq!(FeedKind::Top.endpoint(), Some("topstories"));
+        assert_eq!(FeedKind::New.endpoint(), Some("newstories"));
+        assert_eq!(FeedKind::Best.endpoint(), Some("beststories"));
+        assert_eq!(FeedKind::Ask.endpoint(), Some("askstories"));
+        assert_eq!(FeedKind::Show.endpoint(), Some("showstories"));
+        assert_eq!(FeedKind::Jobs.endpoint(), Some("jobstories"));
+    }
+
+    #[test]
+    fn feed_kind_pinned_has_no_endpoint() {
+        // Pinned is a virtual feed backed by local state — callers must
+        // branch on None to source IDs from the pin store.
+        assert_eq!(FeedKind::Pinned.endpoint(), None);
+    }
+
+    #[test]
+    fn feed_kind_all_includes_pinned_last() {
+        assert_eq!(FeedKind::ALL.len(), 7);
+        assert_eq!(FeedKind::ALL[6], FeedKind::Pinned);
     }
 
     #[test]
@@ -534,6 +563,7 @@ mod tests {
         assert_eq!(format!("{}", FeedKind::Ask), "Ask");
         assert_eq!(format!("{}", FeedKind::Show), "Show");
         assert_eq!(format!("{}", FeedKind::Jobs), "Jobs");
+        assert_eq!(format!("{}", FeedKind::Pinned), "Pinned");
     }
 
     // --- TryFrom<SearchHit> for Item ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use crate::keys::{Action, InputMode};
 use crate::state::comment_state::{CommentFilter, CommentTreeState};
 use crate::state::hint_state::{HintAction, HintContext, HintState};
 use crate::state::link_registry::{LinkRegistry, MatchResult};
+use crate::state::pin_store::PinStore;
 use crate::state::prior_state::PriorDiscussionsState;
 use crate::state::read_store::ReadStore;
 use crate::state::reader_state::{ReaderState, StyledFragment};
@@ -54,6 +55,19 @@ enum HintResolve {
     Cancel,
     /// Exactly one label matches — fire the action against this URL.
     Fire(String),
+}
+
+/// A reading-position the app is trying to restore for a pinned story.
+///
+/// Set on `CommentsLoaded` for pinned stories; cleared on a successful
+/// apply, on `CommentsDone`, or on the first user navigation in the
+/// comments pane (so resume never overrides intentional user motion).
+/// Selected indices that exceed the currently-visible length are kept
+/// pending and re-tried as `CommentsAppended` grows the tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingResume {
+    story_id: StoryId,
+    target_selected: usize,
 }
 
 /// Messages sent from async tasks back to the main loop.
@@ -159,6 +173,20 @@ pub struct App {
     /// flushed via [`App::persist`] on shutdown.
     pub read_store: ReadStore,
 
+    /// Persisted pinned-store — stories the user has explicitly pinned
+    /// via `b`, plus their reading-position snapshot. Backs the
+    /// [`FeedKind::Pinned`] virtual feed and the `★` badge in the story
+    /// list. Loaded from disk at startup and flushed via [`App::persist`]
+    /// on shutdown.
+    pub pin_store: PinStore,
+
+    /// In-progress resume application: when a pinned story is opened, this
+    /// holds the saved selected-comment target until the comments tree
+    /// has loaded enough rows to position the cursor there. Cleared on
+    /// successful apply, on `CommentsDone`, or on any user navigation in
+    /// the comments pane.
+    pending_pinned_resume: Option<PendingResume>,
+
     /// Quickjump hint-mode state — `Some` while the user is selecting a
     /// label, `None` otherwise. Created by [`Action::EnterHintMode`]
     /// and torn down by [`Action::ExitHintMode`] or a unique-match dispatch.
@@ -194,6 +222,8 @@ impl App {
             prior_results: HashMap::new(),
             prior_in_flight: HashSet::new(),
             read_store: ReadStore::load(),
+            pin_store: PinStore::load(),
+            pending_pinned_resume: None,
             hint_state: None,
             last_comment_click: None,
             client: HnClient::new(),
@@ -215,11 +245,63 @@ impl App {
         self.terminal_height = h;
     }
 
-    /// Flushes any in-memory persistent state (read-store) to disk. Call
-    /// once at shutdown after the main loop exits. Silently swallows I/O
-    /// errors — read-state is non-critical.
+    /// Flushes any in-memory persistent state (read-store, pin-store) to
+    /// disk. Call once at shutdown after the main loop exits. Silently
+    /// swallows I/O errors — both stores are non-critical. Snapshots
+    /// any in-flight pinned-story reading position before saving so a
+    /// quit-while-reading round-trips correctly.
     pub fn persist(&mut self) {
+        self.snapshot_pinned_resume_if_any();
         self.read_store.save();
+        self.pin_store.save();
+    }
+
+    /// If the currently-loaded story is pinned, capture its current
+    /// reading position (selected comment index, collapsed-subtree IDs)
+    /// into the pin store. Called before tearing down comment_state for
+    /// any reason (Back, SwitchFeed, Refresh, opening a different story,
+    /// quit) so the next reopen lands the user where they left off.
+    fn snapshot_pinned_resume_if_any(&mut self) {
+        let Some(story) = self.comment_state.story.as_ref() else {
+            return;
+        };
+        let id = StoryId(story.id);
+        if !self.pin_store.is_pinned(id) {
+            return;
+        }
+        let collapsed: Vec<u64> = self.comment_state.collapsed.iter().map(|c| c.0).collect();
+        self.pin_store
+            .update_resume(id, self.comment_state.selected, collapsed);
+    }
+
+    /// Best-effort apply of [`Self::pending_pinned_resume`]: if the saved
+    /// `target_selected` is within the currently-visible comment range,
+    /// place the cursor there and clear the pending state. Otherwise
+    /// leave it pending so the next [`AppMessage::CommentsAppended`] can
+    /// retry once more rows are loaded.
+    ///
+    /// Also clears pending if the loaded story has changed underneath us
+    /// (the user moved on while comments were still streaming in).
+    fn try_advance_resume(&mut self) {
+        let Some(target) = self.pending_pinned_resume else {
+            return;
+        };
+        let Some(ref story) = self.comment_state.story else {
+            self.pending_pinned_resume = None;
+            return;
+        };
+        if StoryId(story.id) != target.story_id {
+            self.pending_pinned_resume = None;
+            return;
+        }
+        let visible_len = self.comment_state.visible_len();
+        if visible_len == 0 {
+            return; // no rows yet — try again on the next batch
+        }
+        if target.target_selected < visible_len {
+            self.comment_state.selected = target.target_selected;
+            self.pending_pinned_resume = None;
+        }
     }
 
     /// Spawns a background fetch for the first page of the current feed.
@@ -286,11 +368,29 @@ impl App {
                     comments,
                     pending_roots,
                 } => {
+                    let story_id = StoryId(story.id);
                     self.comment_state.story = Some(*story);
                     self.comment_state.set_comments(comments);
                     self.comment_state.pending_root_ids = pending_roots;
-                    // Still loading children in background
                     self.error = None;
+
+                    // If this is a pinned story, restore collapse + queue the
+                    // selected-cursor target. Collapsed IDs apply immediately —
+                    // CommentId values that aren't in the loaded tree yet are
+                    // harmlessly retained. Selected restoration is best-effort:
+                    // if the saved index lies past currently-visible rows, we
+                    // wait for `CommentsAppended` to grow the tree.
+                    if let Some(entry) = self.pin_store.resume_for(story_id) {
+                        self.comment_state.collapsed =
+                            entry.collapsed.iter().map(|&id| CommentId(id)).collect();
+                        self.pending_pinned_resume = Some(PendingResume {
+                            story_id,
+                            target_selected: entry.selected,
+                        });
+                        self.try_advance_resume();
+                    } else {
+                        self.pending_pinned_resume = None;
+                    }
                 }
                 AppMessage::CommentsAppended {
                     parent_id,
@@ -298,10 +398,25 @@ impl App {
                 } => {
                     self.comment_state.insert_children(parent_id, children);
                     self.comment_state.pending_root_ids.remove(&parent_id);
+                    // The freshly-spliced rows may now have made the resume
+                    // target reachable.
+                    self.try_advance_resume();
                 }
                 AppMessage::CommentsDone => {
                     self.comment_state.loading = false;
                     self.comment_state.pending_root_ids.clear();
+                    // Final attempt — clamp to the now-complete tree.
+                    if let Some(target) = self.pending_pinned_resume.take() {
+                        if let Some(ref story) = self.comment_state.story {
+                            if StoryId(story.id) == target.story_id {
+                                let visible_len = self.comment_state.visible_len();
+                                if visible_len > 0 {
+                                    self.comment_state.selected =
+                                        target.target_selected.min(visible_len - 1);
+                                }
+                            }
+                        }
+                    }
                 }
                 AppMessage::ArticleLoaded { lines, links } => {
                     if let Some(ref mut reader) = self.reader_state {
@@ -395,6 +510,7 @@ impl App {
                 | Action::ToggleHelp
                 | Action::TogglePriorDiscussions
                 | Action::CycleCommentFilter
+                | Action::TogglePin
                 | Action::None => {}
                 Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
                     unreachable!("hint actions handled above")
@@ -438,6 +554,7 @@ impl App {
                 | Action::ToggleHelp
                 | Action::TogglePriorDiscussions
                 | Action::CycleCommentFilter
+                | Action::TogglePin
                 | Action::PageDown
                 | Action::PageUp
                 | Action::None => {}
@@ -453,7 +570,9 @@ impl App {
             Action::Quit => self.running = false,
             Action::Back => {
                 if self.focus == Pane::Comments && self.comment_state.story.is_some() {
+                    self.snapshot_pinned_resume_if_any();
                     self.comment_state.reset();
+                    self.pending_pinned_resume = None;
                     self.focus = Pane::Stories;
                 } else if self.search_state.is_some() {
                     self.cancel_search();
@@ -466,15 +585,24 @@ impl App {
                     self.story_state.select_next();
                     self.check_lazy_load();
                 }
-                Pane::Comments => self.comment_state.select_next(),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.select_next();
+                }
             },
             Action::MoveUp => match self.focus {
                 Pane::Stories => self.story_state.select_prev(),
-                Pane::Comments => self.comment_state.select_prev(),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.select_prev();
+                }
             },
             Action::Select => match self.focus {
                 Pane::Stories => self.load_selected_comments(),
-                Pane::Comments => self.comment_state.toggle_collapse(),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.toggle_collapse();
+                }
             },
             Action::OpenInBrowser => self.open_in_browser(),
             Action::OpenReader => self.open_article_reader(),
@@ -488,11 +616,13 @@ impl App {
                 if idx < FeedKind::ALL.len() {
                     let feed = FeedKind::ALL[idx];
                     if feed != self.current_feed || self.search_state.is_some() {
+                        self.snapshot_pinned_resume_if_any();
                         self.search_state = None;
                         self.input_mode = InputMode::Normal;
                         self.current_feed = feed;
                         self.story_state.reset();
                         self.comment_state.reset();
+                        self.pending_pinned_resume = None;
                         self.client.clear_cache();
                         self.focus = Pane::Stories;
                         self.spawn_load_stories(LoadMode::Replace);
@@ -503,13 +633,17 @@ impl App {
                 if let Some(ref ss) = self.search_state {
                     let query = ss.query.clone();
                     if !query.is_empty() {
+                        self.snapshot_pinned_resume_if_any();
                         self.story_state.reset();
                         self.comment_state.reset();
+                        self.pending_pinned_resume = None;
                         self.spawn_search(query, 0, LoadMode::Replace);
                     }
                 } else {
+                    self.snapshot_pinned_resume_if_any();
                     self.story_state.reset();
                     self.comment_state.reset();
+                    self.pending_pinned_resume = None;
                     self.client.clear_cache();
                     self.spawn_load_stories(LoadMode::Replace);
                 }
@@ -519,33 +653,74 @@ impl App {
             }
             Action::JumpTop => match self.focus {
                 Pane::Stories => self.story_state.jump_top(),
-                Pane::Comments => self.comment_state.jump_top(),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.jump_top();
+                }
             },
             Action::JumpBottom => match self.focus {
                 Pane::Stories => {
                     self.story_state.jump_bottom();
                     self.check_lazy_load();
                 }
-                Pane::Comments => self.comment_state.jump_bottom(),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.jump_bottom();
+                }
             },
             Action::PageDown => match self.focus {
                 Pane::Stories => {
                     self.story_state.page_down(SCROLL_PAGE);
                     self.check_lazy_load();
                 }
-                Pane::Comments => self.comment_state.page_down(SCROLL_PAGE),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.page_down(SCROLL_PAGE);
+                }
             },
             Action::PageUp => match self.focus {
                 Pane::Stories => self.story_state.page_up(SCROLL_PAGE),
-                Pane::Comments => self.comment_state.page_up(SCROLL_PAGE),
+                Pane::Comments => {
+                    self.pending_pinned_resume = None;
+                    self.comment_state.page_up(SCROLL_PAGE);
+                }
             },
             Action::ToggleHelp => self.show_help = !self.show_help,
             Action::TogglePriorDiscussions => self.toggle_prior_discussions(),
             Action::CycleCommentFilter => self.cycle_comment_filter(),
+            Action::TogglePin => self.toggle_pin_focused_story(),
             Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
                 unreachable!("hint actions handled above")
             }
             Action::None => {}
+        }
+    }
+
+    /// Pins or unpins the story under focus.
+    ///
+    /// In the stories pane, targets the highlighted row; in the comments
+    /// pane, targets the currently-loaded story. Unpinning a story whose
+    /// thread is currently loaded snapshots its position one last time —
+    /// so the resume metadata survives a brief pin/unpin/re-pin without
+    /// losing the user's place. Re-pinning preserves an existing entry's
+    /// `pinned_at` (see [`PinStore::pin`]).
+    fn toggle_pin_focused_story(&mut self) {
+        let target_id = match self.focus {
+            Pane::Stories => self.story_state.selected_story().map(|s| StoryId(s.id)),
+            Pane::Comments => self.comment_state.story.as_ref().map(|s| StoryId(s.id)),
+        };
+        let Some(id) = target_id else {
+            return;
+        };
+        if self.pin_store.is_pinned(id) {
+            self.snapshot_pinned_resume_if_any();
+            self.pin_store.unpin(id);
+        } else {
+            self.pin_store.pin(id);
+            // Capture the current reading position immediately so that a
+            // pin-then-quit (without further navigation) still records
+            // where the user was.
+            self.snapshot_pinned_resume_if_any();
         }
     }
 
@@ -610,6 +785,11 @@ impl App {
         else {
             return;
         };
+        // Snapshot the outgoing pinned story's reading position before
+        // we overwrite `comment_state` with the prior-submission load.
+        self.snapshot_pinned_resume_if_any();
+        self.pending_pinned_resume = None;
+
         self.read_store
             .mark(StoryId(item.id), item.descendants.unwrap_or(0));
         self.prior_state = None;
@@ -709,10 +889,12 @@ impl App {
 
     /// Exits search mode, clears the cache, and reloads the current feed.
     pub fn cancel_search(&mut self) {
+        self.snapshot_pinned_resume_if_any();
         self.search_state = None;
         self.input_mode = InputMode::Normal;
         self.story_state.reset();
         self.comment_state.reset();
+        self.pending_pinned_resume = None;
         self.client.clear_cache();
         self.spawn_load_stories(LoadMode::Replace);
     }
@@ -761,6 +943,10 @@ impl App {
     /// Kicks off an async feed-page load. [`LoadMode::Append`] reuses the
     /// cached ID list to compute a stable offset (so newly posted stories
     /// don't shift the page); [`LoadMode::Replace`] fetches a fresh ID list.
+    ///
+    /// Branches on [`FeedKind::endpoint`] to source IDs: feeds with a
+    /// remote endpoint hit Firebase; the [`FeedKind::Pinned`] virtual
+    /// feed reads from [`Self::pin_store`] directly.
     fn spawn_load_stories(&self, mode: LoadMode) {
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
@@ -786,6 +972,24 @@ impl App {
                     Err(e) => {
                         let _ =
                             tx.send(AppMessage::Error(format!("Failed to load stories: {}", e)));
+                    }
+                }
+            });
+        } else if matches!(self.current_feed, FeedKind::Pinned) {
+            // Virtual feed: source IDs locally, then page through them with
+            // the same `fetch_items_page` path the remote feeds use.
+            let pinned_ids = self.pin_store.pinned_ids_newest_first();
+            tokio::spawn(async move {
+                match client.fetch_items_page(&pinned_ids, 0, page_size).await {
+                    Ok(stories) => {
+                        let _ = tx.send(AppMessage::StoriesLoaded {
+                            stories,
+                            all_ids: Some(pinned_ids),
+                            mode: LoadMode::Replace,
+                        });
+                    }
+                    Err(e) => {
+                        let _ = tx.send(AppMessage::Error(format!("Failed to load pinned: {}", e)));
                     }
                 }
             });
@@ -845,6 +1049,12 @@ impl App {
     /// For search results (kids missing), fetches the full item first.
     fn load_selected_comments(&mut self) {
         if let Some(story) = self.story_state.selected_story().cloned() {
+            // Snapshot the outgoing pinned story's reading position before
+            // we overwrite `comment_state` with the new selection. No-op
+            // when the previous story wasn't pinned (or was the same one).
+            self.snapshot_pinned_resume_if_any();
+            self.pending_pinned_resume = None;
+
             self.read_store
                 .mark(StoryId(story.id), story.descendants.unwrap_or(0));
             self.comment_state.loading = true;
@@ -1097,6 +1307,10 @@ impl App {
             if let Some(vi) = visual_index {
                 let visible_len = self.comment_state.visible_len();
                 if vi < visible_len {
+                    // Mouse interaction in the comments pane is intentional
+                    // navigation — drop any pending resume target so we don't
+                    // jump the cursor away from where the user clicked.
+                    self.pending_pinned_resume = None;
                     // Check for double-click to toggle collapse
                     let now = std::time::Instant::now();
                     if let Some((last_time, last_vi)) = self.last_comment_click {
@@ -1296,9 +1510,11 @@ impl App {
                     self.story_state.select_prev();
                 }
                 (Pane::Comments, true) => {
+                    self.pending_pinned_resume = None;
                     self.comment_state.select_next();
                 }
                 (Pane::Comments, false) => {
+                    self.pending_pinned_resume = None;
                     self.comment_state.select_prev();
                 }
             }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -49,6 +49,10 @@ pub enum Action {
     /// visit → Recent 24h → All. Falls through to All when the story has
     /// never been visited (no `last_seen_at` to anchor `NewSince` to).
     CycleCommentFilter,
+    /// Toggle the pinned state of the focused story (pin if not pinned,
+    /// unpin if pinned). Pinned stories surface in the
+    /// [`crate::api::types::FeedKind::Pinned`] virtual feed.
+    TogglePin,
     /// Quickjump: enter hint-label mode; the `HintAction` decides what
     /// fires on a unique label match (open in browser / open in reader /
     /// copy URL to clipboard via OSC 52).
@@ -132,9 +136,11 @@ pub fn map_key(
         KeyCode::Char('p') => Action::OpenReader,
         KeyCode::Char('h') => Action::TogglePriorDiscussions,
         KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => Action::SwitchPane,
-        KeyCode::Char(c @ '1'..='6') => Action::SwitchFeed(c as usize - '1' as usize),
+        // 1–7: Top, New, Best, Ask, Show, Jobs, Pinned (matches FeedKind::ALL order).
+        KeyCode::Char(c @ '1'..='7') => Action::SwitchFeed(c as usize - '1' as usize),
         KeyCode::Char('r') => Action::Refresh,
         KeyCode::Char('n') => Action::CycleCommentFilter,
+        KeyCode::Char('b') => Action::TogglePin,
         KeyCode::Char('g') => Action::JumpTop,
         KeyCode::Char('G') => Action::JumpBottom,
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,
@@ -310,9 +316,53 @@ mod tests {
                 InputMode::Normal,
             )
         };
-        for (c, idx) in [('1', 0), ('2', 1), ('3', 2), ('4', 3), ('5', 4), ('6', 5)] {
+        for (c, idx) in [
+            ('1', 0),
+            ('2', 1),
+            ('3', 2),
+            ('4', 3),
+            ('5', 4),
+            ('6', 5),
+            ('7', 6), // Pinned virtual feed
+        ] {
             assert_eq!(n(c), Action::SwitchFeed(idx));
         }
+    }
+
+    #[test]
+    fn normal_b_toggles_pin() {
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char('b')), Action::TogglePin);
+    }
+
+    #[test]
+    fn reader_overlay_does_not_consume_b() {
+        // Pin toggle is a story-level action; the reader overlay should
+        // not emit it (the reader's focused story is already known to the
+        // user — pinning belongs in the underlying pane).
+        let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
+        assert_eq!(r(KeyCode::Char('b')), Action::None);
+    }
+
+    #[test]
+    fn prior_overlay_does_not_consume_b() {
+        let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
+        assert_eq!(p(KeyCode::Char('b')), Action::None);
+    }
+
+    #[test]
+    fn search_input_does_not_emit_toggle_pin() {
+        // `b` must be a query character when typing a search.
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('b')),
+                false,
+                false,
+                false,
+                InputMode::SearchInput
+            ),
+            Action::None
+        );
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -7,12 +7,14 @@
 //! overlay, [`search_state::SearchState`] for the Algolia search flow,
 //! [`prior_state::PriorDiscussionsState`] for the prior-submissions
 //! overlay, [`read_store::ReadStore`] for persisted read-state tracking,
-//! and [`link_registry::LinkRegistry`] + [`hint_state::HintState`] for the
-//! Quickjump label-hint mode.
+//! [`pin_store::PinStore`] for persisted pinned stories with
+//! resume-position snapshots, and [`link_registry::LinkRegistry`] +
+//! [`hint_state::HintState`] for the Quickjump label-hint mode.
 
 pub mod comment_state;
 pub mod hint_state;
 pub mod link_registry;
+pub mod pin_store;
 pub mod prior_state;
 pub mod read_store;
 pub mod reader_state;

--- a/src/state/pin_store.rs
+++ b/src/state/pin_store.rs
@@ -1,0 +1,472 @@
+//! Persistent pinned-story store.
+//!
+//! Tracks stories the user has explicitly pinned via `b`, plus the
+//! reading-position snapshot (selected comment index, collapsed-subtree
+//! IDs) at the time they last left the story. The Pinned feed
+//! ([`crate::api::types::FeedKind::Pinned`]) reads from this store, and
+//! [`crate::ui::story_list::StoryList`] renders a `★` glyph for any story
+//! present here.
+//!
+//! Backed by a JSON file at `$XDG_DATA_HOME/hnt/pinned.json` (or
+//! `$HOME/.local/share/hnt/pinned.json` as a fallback). Failures to
+//! resolve the path or read the file leave the store in-memory only —
+//! the feature still works within the session but is not persisted across
+//! restarts. Mirrors [`crate::state::read_store::ReadStore`]'s atomic
+//! tmp+rename write, version field, and corrupt-file recovery.
+
+use crate::api::types::StoryId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Soft cap on stored pins. Oldest (lowest `pinned_at`) entries are
+/// evicted on overflow so the file stays bounded. Set lower than
+/// [`crate::state::read_store`]'s cap because pinning is a deliberate
+/// user action, not a side effect of every visit.
+const MAX_ENTRIES: usize = 1000;
+
+/// On-disk schema version. Bumped only on incompatible format changes.
+const SCHEMA_VERSION: u32 = 1;
+
+/// One pinned story's persisted state, including the reading-position
+/// snapshot used to resume the user mid-thread when they reopen it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PinEntry {
+    /// Wall-clock timestamp (Unix seconds) at which the story was first
+    /// pinned. Used for newest-first ordering in the Pinned feed and as
+    /// the LRU eviction key. Re-pinning an existing entry leaves this
+    /// untouched — the position in the list is stable.
+    pub pinned_at: i64,
+    /// Selected comment index into `visible_comments()` at the moment of
+    /// the last snapshot. Clamped to the visible length on restore so a
+    /// shrinking thread (rare — moderation deletions) can't strand the
+    /// cursor past the end.
+    #[serde(default)]
+    pub selected: usize,
+    /// Comment IDs the user collapsed before leaving. Restored as the
+    /// initial collapse set when reopening. IDs that no longer exist in
+    /// the loaded tree are harmlessly retained — the visibility check
+    /// just never matches them.
+    #[serde(default)]
+    pub collapsed: Vec<u64>,
+}
+
+/// In-memory pinned-store with JSON-file persistence.
+///
+/// Constructed via [`PinStore::load`] at startup. Add a pin with
+/// [`PinStore::pin`], remove with [`PinStore::unpin`], snapshot reading
+/// position with [`PinStore::update_resume`], flush with
+/// [`PinStore::save`]. Reads ([`PinStore::is_pinned`],
+/// [`PinStore::resume_for`], [`PinStore::pinned_ids_newest_first`]) are
+/// cheap.
+pub struct PinStore {
+    entries: HashMap<StoryId, PinEntry>,
+    path: Option<PathBuf>,
+    dirty: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DiskStore {
+    version: u32,
+    #[serde(default)]
+    entries: HashMap<String, PinEntry>,
+}
+
+impl PinStore {
+    /// In-memory-only store with no persistence path. Used when the
+    /// default XDG path can't be resolved.
+    pub fn empty() -> Self {
+        Self {
+            entries: HashMap::new(),
+            path: None,
+            dirty: false,
+        }
+    }
+
+    /// Loads from `$XDG_DATA_HOME/hnt/pinned.json` (or the
+    /// `$HOME/.local/share/hnt/pinned.json` fallback). Returns an empty
+    /// in-memory store if the path can't be resolved or the file is
+    /// missing/corrupt.
+    pub fn load() -> Self {
+        match default_path() {
+            Some(path) => Self::load_from(path),
+            None => Self::empty(),
+        }
+    }
+
+    /// Loads or creates a store at `path`. A missing or corrupt file
+    /// produces an empty store with `path` still set as the save target —
+    /// the next [`PinStore::save`] will replace it.
+    pub fn load_from(path: PathBuf) -> Self {
+        let entries = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<DiskStore>(&raw).ok())
+            .map(|disk| {
+                disk.entries
+                    .into_iter()
+                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (StoryId(id), v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            entries,
+            path: Some(path),
+            dirty: false,
+        }
+    }
+
+    /// Writes the store to its configured path if dirty. No-op for
+    /// in-memory-only stores and for clean stores. Uses an atomic
+    /// `tmp → rename` to avoid leaving half-written files on crash.
+    /// Failures (permissions, missing parent, disk full) are silently
+    /// swallowed — pin-state is non-critical.
+    pub fn save(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        let disk = DiskStore {
+            version: SCHEMA_VERSION,
+            entries: self
+                .entries
+                .iter()
+                .map(|(&id, entry)| (id.0.to_string(), entry.clone()))
+                .collect(),
+        };
+        let Ok(json) = serde_json::to_string(&disk) else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let tmp = path.with_extension("json.tmp");
+        if std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
+            self.dirty = false;
+        }
+    }
+
+    /// Pins `id` with the current wall-clock timestamp and a default
+    /// (top-of-thread) resume state. No-op if already pinned — re-pinning
+    /// must not bump `pinned_at`, otherwise the Pinned-feed ordering
+    /// would shuffle when the user opens an existing pin.
+    pub fn pin(&mut self, id: StoryId) {
+        self.pin_at(id, chrono::Utc::now().timestamp());
+    }
+
+    /// Variant of [`PinStore::pin`] that uses an explicit timestamp —
+    /// used by tests to keep behavior deterministic.
+    pub fn pin_at(&mut self, id: StoryId, now: i64) {
+        if self.entries.contains_key(&id) {
+            return;
+        }
+        self.entries.insert(
+            id,
+            PinEntry {
+                pinned_at: now,
+                selected: 0,
+                collapsed: Vec::new(),
+            },
+        );
+        if self.entries.len() > MAX_ENTRIES {
+            self.evict_oldest();
+        }
+        self.dirty = true;
+    }
+
+    /// Unpins `id`. No-op if not pinned. Returns whether anything was
+    /// removed (useful for callers that want to flag the store dirty
+    /// only on a real change).
+    pub fn unpin(&mut self, id: StoryId) -> bool {
+        if self.entries.remove(&id).is_some() {
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether `id` is currently pinned.
+    #[must_use]
+    pub fn is_pinned(&self, id: StoryId) -> bool {
+        self.entries.contains_key(&id)
+    }
+
+    /// Snapshot the user's reading position for `id`. No-op if `id` isn't
+    /// pinned — only deliberately-curated stories get their position
+    /// remembered.
+    pub fn update_resume(&mut self, id: StoryId, selected: usize, collapsed: Vec<u64>) {
+        let Some(entry) = self.entries.get_mut(&id) else {
+            return;
+        };
+        // Skip a write (and `dirty`) when nothing actually changed —
+        // typical idle-then-quit shouldn't re-flush the file.
+        if entry.selected == selected && entry.collapsed == collapsed {
+            return;
+        }
+        entry.selected = selected;
+        entry.collapsed = collapsed;
+        self.dirty = true;
+    }
+
+    /// Persisted entry for `id`, if any. Used by the comment-load path to
+    /// restore reading position once the thread has finished loading.
+    #[must_use]
+    pub fn resume_for(&self, id: StoryId) -> Option<&PinEntry> {
+        self.entries.get(&id)
+    }
+
+    /// Pinned story IDs in newest-first order — the listing the Pinned
+    /// virtual feed renders. Returns owned `u64`s (matching
+    /// [`crate::state::story_state::StoryListState::all_ids`]) so the
+    /// caller can stash the slice for stable pagination without holding a
+    /// borrow into the store.
+    #[must_use]
+    pub fn pinned_ids_newest_first(&self) -> Vec<u64> {
+        let mut entries: Vec<(i64, StoryId)> = self
+            .entries
+            .iter()
+            .map(|(&id, e)| (e.pinned_at, id))
+            .collect();
+        // Newest first → descending by timestamp, with ID as tiebreaker
+        // for determinism when two pins land in the same second.
+        entries.sort_unstable_by(|a, b| b.cmp(a));
+        entries.into_iter().map(|(_, id)| id.0).collect()
+    }
+
+    /// Drops entries with the lowest `pinned_at` until the store is
+    /// back within [`MAX_ENTRIES`].
+    fn evict_oldest(&mut self) {
+        let mut ages: Vec<(i64, StoryId)> = self
+            .entries
+            .iter()
+            .map(|(&id, e)| (e.pinned_at, id))
+            .collect();
+        ages.sort_unstable();
+        let excess = self.entries.len().saturating_sub(MAX_ENTRIES);
+        for (_, id) in ages.into_iter().take(excess) {
+            self.entries.remove(&id);
+        }
+    }
+
+    /// Number of pinned entries. Exposed for tests and diagnostics.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Resolves the default persistence path: `$XDG_DATA_HOME/hnt/pinned.json`,
+/// falling back to `$HOME/.local/share/hnt/pinned.json`. Returns `None` if
+/// neither variable is set (rare — containers with no `HOME`).
+fn default_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("hnt").join("pinned.json"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(
+        PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("hnt")
+            .join("pinned.json"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "hnt_pin_store_test_{}_{}.json",
+            name,
+            std::process::id()
+        ))
+    }
+
+    fn fresh_store(name: &str) -> PinStore {
+        let p = tmp_path(name);
+        let _ = std::fs::remove_file(&p);
+        PinStore::load_from(p)
+    }
+
+    fn sid(n: u64) -> StoryId {
+        StoryId(n)
+    }
+
+    #[test]
+    fn empty_store_has_no_pins() {
+        let s = PinStore::empty();
+        assert!(!s.is_pinned(sid(42)));
+        assert!(s.resume_for(sid(42)).is_none());
+        assert!(s.pinned_ids_newest_first().is_empty());
+    }
+
+    #[test]
+    fn pin_then_is_pinned() {
+        let mut s = fresh_store("pin_then_is_pinned");
+        s.pin_at(sid(42), 1_700_000_000);
+        assert!(s.is_pinned(sid(42)));
+        assert!(!s.is_pinned(sid(99)));
+    }
+
+    #[test]
+    fn unpin_removes_entry() {
+        let mut s = fresh_store("unpin_removes");
+        s.pin_at(sid(42), 1_700_000_000);
+        assert!(s.unpin(sid(42)));
+        assert!(!s.is_pinned(sid(42)));
+    }
+
+    #[test]
+    fn unpin_unknown_returns_false() {
+        let mut s = fresh_store("unpin_unknown");
+        assert!(!s.unpin(sid(42)));
+    }
+
+    #[test]
+    fn re_pinning_is_idempotent_and_does_not_bump_timestamp() {
+        let mut s = fresh_store("idempotent_pin");
+        s.pin_at(sid(42), 1_700_000_000);
+        s.pin_at(sid(42), 1_700_000_500);
+        assert_eq!(s.resume_for(sid(42)).unwrap().pinned_at, 1_700_000_000);
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn pinned_ids_newest_first_orders_by_timestamp_descending() {
+        let mut s = fresh_store("newest_first");
+        s.pin_at(sid(1), 1_700_000_100);
+        s.pin_at(sid(2), 1_700_000_300);
+        s.pin_at(sid(3), 1_700_000_200);
+        assert_eq!(s.pinned_ids_newest_first(), vec![2, 3, 1]);
+    }
+
+    #[test]
+    fn pinned_ids_newest_first_tiebreak_is_deterministic() {
+        let mut s = fresh_store("tiebreak");
+        // Two pins land in the same second — order must still be stable
+        // across runs (HashMap iteration is not).
+        s.pin_at(sid(5), 1_700_000_000);
+        s.pin_at(sid(7), 1_700_000_000);
+        s.pin_at(sid(3), 1_700_000_000);
+        let ids = s.pinned_ids_newest_first();
+        assert_eq!(ids, vec![7, 5, 3]);
+    }
+
+    #[test]
+    fn update_resume_only_applies_to_pinned() {
+        let mut s = fresh_store("update_unpinned");
+        s.update_resume(sid(42), 5, vec![1, 2, 3]);
+        assert!(s.resume_for(sid(42)).is_none());
+    }
+
+    #[test]
+    fn update_resume_stores_position() {
+        let mut s = fresh_store("update_resume");
+        s.pin_at(sid(42), 1_700_000_000);
+        s.update_resume(sid(42), 17, vec![10, 20, 30]);
+        let entry = s.resume_for(sid(42)).unwrap();
+        assert_eq!(entry.selected, 17);
+        assert_eq!(entry.collapsed, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn update_resume_no_change_does_not_dirty() {
+        let mut s = fresh_store("no_change");
+        s.pin_at(sid(42), 1_700_000_000);
+        s.dirty = false; // simulate "just saved"
+        s.update_resume(sid(42), 0, Vec::new());
+        assert!(
+            !s.dirty,
+            "equal-value resume update must not dirty the store"
+        );
+    }
+
+    #[test]
+    fn save_and_reload_roundtrip() {
+        let p = tmp_path("roundtrip");
+        let _ = std::fs::remove_file(&p);
+        {
+            let mut s = PinStore::load_from(p.clone());
+            s.pin_at(sid(1), 1_700_000_000);
+            s.pin_at(sid(2), 1_700_000_100);
+            s.update_resume(sid(2), 7, vec![100, 200]);
+            s.save();
+        }
+        let s2 = PinStore::load_from(p.clone());
+        assert!(s2.is_pinned(sid(1)));
+        assert!(s2.is_pinned(sid(2)));
+        let e2 = s2.resume_for(sid(2)).unwrap();
+        assert_eq!(e2.selected, 7);
+        assert_eq!(e2.collapsed, vec![100, 200]);
+        assert_eq!(e2.pinned_at, 1_700_000_100);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn save_is_noop_when_not_dirty() {
+        let p = tmp_path("save_noop");
+        let _ = std::fs::remove_file(&p);
+        let mut s = PinStore::load_from(p.clone());
+        s.save();
+        assert!(!p.exists());
+    }
+
+    #[test]
+    fn corrupt_file_loads_as_empty() {
+        let p = tmp_path("corrupt");
+        std::fs::write(&p, "{not valid json").unwrap();
+        let s = PinStore::load_from(p.clone());
+        assert_eq!(s.len(), 0);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn version_mismatch_is_tolerated_via_default_path_field() {
+        // We don't currently reject on version mismatch — instead the
+        // shape of `entries` is what matters. A future v2 could add an
+        // explicit check here. Ensure today's behavior for v=99 is "load
+        // anyway" so a forward-compat downgrade doesn't lose data.
+        let p = tmp_path("version_99");
+        std::fs::write(
+            &p,
+            r#"{"version": 99, "entries": {"42": {"pinned_at": 1, "selected": 0, "collapsed": []}}}"#,
+        )
+        .unwrap();
+        let s = PinStore::load_from(p.clone());
+        assert!(s.is_pinned(sid(42)));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn in_memory_only_store_silently_drops_save() {
+        let mut s = PinStore::empty();
+        s.pin_at(sid(1), 1000);
+        s.save();
+        assert!(s.is_pinned(sid(1)));
+    }
+
+    #[test]
+    fn eviction_bounds_size_at_max_and_removes_oldest() {
+        let mut s = PinStore::empty();
+        for i in 0..(MAX_ENTRIES as u64 + 5) {
+            s.pin_at(sid(i), i as i64);
+        }
+        assert_eq!(s.len(), MAX_ENTRIES);
+        for oldest in 0..5u64 {
+            assert!(
+                !s.is_pinned(sid(oldest)),
+                "oldest id {oldest} should be evicted"
+            );
+        }
+        assert!(s.is_pinned(sid(MAX_ENTRIES as u64 + 4)));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -58,6 +58,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             loading: app.story_state.loading,
             search_query: if search_active { search_query } else { None },
             read_store: &app.read_store,
+            pin_store: &app.pin_store,
         },
         layout.stories,
     );
@@ -192,11 +193,15 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
             Span::styled("Switch pane focus", theme::base_style()),
         ]),
         Line::from(vec![
-            Span::styled("  1-6          ", theme::accent_style()),
+            Span::styled("  1-7          ", theme::accent_style()),
             Span::styled(
-                "Switch feed (Top/New/Best/Ask/Show/Jobs)",
+                "Switch feed (Top/New/Best/Ask/Show/Jobs/Pinned)",
                 theme::base_style(),
             ),
+        ]),
+        Line::from(vec![
+            Span::styled("  b            ", theme::accent_style()),
+            Span::styled("Pin/unpin focused story (\u{2605})", theme::base_style()),
         ]),
         Line::from(vec![
             Span::styled("  /            ", theme::accent_style()),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -92,7 +92,7 @@ impl<'a> Widget for StatusBar<'a> {
                 ));
             } else {
                 spans.push(Span::styled(
-                    "j/k:nav tab:switch enter:open 1-6:feed /:search o:browser p:read h:prior r:refresh ?:help q:quit ",
+                    "j/k:nav tab:switch enter:open 1-7:feed b:pin /:search o:browser p:read h:prior r:refresh ?:help q:quit ",
                     theme::status_style(),
                 ));
             }

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -6,6 +6,7 @@
 //! timestamps.
 
 use crate::api::types::{Item, StoryId};
+use crate::state::pin_store::PinStore;
 use crate::state::read_store::ReadStore;
 use crate::ui::theme;
 use ratatui::{
@@ -26,6 +27,9 @@ pub struct StoryList<'a> {
     /// Persisted read-state: stories present here render dimmed, and those
     /// whose comment count has grown since the last visit get a `+N` badge.
     pub read_store: &'a ReadStore,
+    /// Persisted pin-store: stories present here render with a leading
+    /// `★` glyph in any feed.
+    pub pin_store: &'a PinStore,
 }
 
 impl<'a> Widget for StoryList<'a> {
@@ -93,6 +97,7 @@ impl<'a> Widget for StoryList<'a> {
             let is_selected = i == self.selected;
             let sid = StoryId(story.id);
             let is_read = self.read_store.is_read(sid);
+            let is_pinned = self.pin_store.is_pinned(sid);
             let new_comments = self
                 .read_store
                 .new_comments_since(sid, story.descendants.unwrap_or(0));
@@ -109,8 +114,12 @@ impl<'a> Widget for StoryList<'a> {
             let badge_text = badge.map(|b| format!("[{}] ", b.label()));
             let badge_width = badge_text.as_ref().map_or(0, |t| t.len());
             let new_badge_width = new_badge_text.as_ref().map_or(0, |t| t.len());
-            let max_title_width = (inner.width as usize)
-                .saturating_sub(num.len() + badge_width + new_badge_width + domain.len() + 2);
+            // ★ + space = 2 visual columns. Reserved before the badge so a
+            // pinned Ask HN story stays aligned: "  1. ★ [Ask HN] Title".
+            let pin_width = if is_pinned { 2 } else { 0 };
+            let max_title_width = (inner.width as usize).saturating_sub(
+                num.len() + pin_width + badge_width + new_badge_width + domain.len() + 2,
+            );
             let truncated_title: String = if title.chars().count() > max_title_width {
                 let truncated: String = title
                     .chars()
@@ -156,6 +165,16 @@ impl<'a> Widget for StoryList<'a> {
                     theme::dim_style()
                 },
             )];
+            if is_pinned {
+                spans.push(Span::styled(
+                    "\u{2605} ",
+                    if is_selected {
+                        theme::pinned_style().bg(theme::SURFACE)
+                    } else {
+                        theme::pinned_style()
+                    },
+                ));
+            }
             if let Some((text, b)) = badge_text.zip(badge) {
                 spans.push(Span::styled(text, theme::badge_style(b)));
             }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -109,6 +109,17 @@ pub const fn hint_dim_style() -> Style {
     Style::new().fg(DIM).bg(SURFACE)
 }
 
+/// Bold HN-orange "pin" glyph for stories present in
+/// [`crate::state::pin_store::PinStore`]. Matches the brand-accent
+/// palette used for badges and active tabs so the marker reads as
+/// "important to you" rather than as another classification badge.
+pub const fn pinned_style() -> Style {
+    Style::new()
+        .fg(HN_ORANGE)
+        .bg(BG)
+        .add_modifier(Modifier::BOLD)
+}
+
 /// Bold badge color on the surface background — one color per
 /// [`StoryBadge`](crate::api::types::StoryBadge) variant.
 pub const fn badge_style(badge: crate::api::types::StoryBadge) -> Style {


### PR DESCRIPTION
Closes #118

## Summary

- New `b` key pins/unpins the focused story; pinned stories show `★` in any feed and aggregate into a new Pinned virtual feed (key `7`).
- Reopening a pinned story restores the comment-pane cursor and collapse state — survives feed switches, refresh, and quit. User navigation in the comments pane clears the pending resume so it never overrides intentional motion.
- Backed by `PinStore` at `$XDG_DATA_HOME/hnt/pinned.json`, mirroring `ReadStore`'s atomic-write/version/eviction template (1000-entry LRU cap, schema v1). No new dependencies.
- 9 modified files, 1 new file (`src/state/pin_store.rs`); +380/-41. 16 new unit tests; 248 total pass.

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — all green
- [ ] Pin three stories from different feeds; verify `★` appears in each
- [ ] Press `7`, confirm pinned stories listed newest-first
- [ ] Open a pinned story, scroll/select comment, switch feeds, return — cursor lands at saved position
- [ ] Quit and relaunch — pins and resume positions persist
- [ ] Corrupt `~/.local/share/hnt/pinned.json` — app launches and treats as empty