### PR TITLE
Multi-pillar refactor across src/ tree

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -35,13 +35,29 @@ pub struct HnClient {
     cache: Arc<Mutex<LruCache<u64, Arc<Item>>>>,
 }
 
+impl Default for HnClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HnClient {
     /// Builds a fresh client with an empty LRU cache of up to
     /// `CACHE_CAPACITY` items.
     pub fn new() -> Self {
         let capacity = NonZeroUsize::new(CACHE_CAPACITY).expect("cache capacity > 0");
+        // Timeouts prevent a stalled HN endpoint from leaving spawned
+        // tasks hung forever (no progress, just a spinning UI). 15s body
+        // timeout is enough for a /topstories list (usually ~20KB);
+        // connect_timeout catches DNS/handshake stalls fast.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .user_agent(concat!("hnt/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("hn client builder");
         Self {
-            client: reqwest::Client::new(),
+            client,
             cache: Arc::new(Mutex::new(LruCache::new(capacity))),
         }
     }
@@ -89,7 +105,12 @@ impl HnClient {
 
         Ok(item.map(|item| {
             let arc = Arc::new(item);
-            self.cache().put(id, Arc::clone(&arc));
+            // Skip caching dead/deleted items — the rest of the app filters
+            // them out anyway and a moderation reversal (rare but real)
+            // shouldn't be masked by a session-long stale cache entry.
+            if !arc.is_dead_or_deleted() {
+                self.cache().put(id, Arc::clone(&arc));
+            }
             arc
         }))
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -20,7 +20,11 @@ pub struct Item {
     pub id: u64,
     #[serde(default)]
     pub title: Option<String>,
-    #[serde(default)]
+    /// Story URL — only populated for `http`/`https` schemes. Other
+    /// schemes are dropped to `None` at deserialization so downstream
+    /// open/fetch helpers don't need to re-validate; see
+    /// [`validate_http_url`].
+    #[serde(default, deserialize_with = "deserialize_http_url")]
     pub url: Option<String>,
     #[serde(default)]
     pub text: Option<String>,
@@ -195,7 +199,11 @@ impl TryFrom<SearchHit> for Item {
         Ok(Item {
             id: hit.object_id.parse::<u64>()?,
             title: hit.title,
-            url: hit.url,
+            // Drop non-`http(s)` schemes — `mailto:`, `data:`, `javascript:`
+            // could otherwise reach `open::that` or be rendered as a clickable
+            // hint target. The Firebase decode path applies the same guard
+            // via `deserialize_http_url`.
+            url: hit.url.as_deref().and_then(validate_http_url),
             text: hit.story_text,
             by: hit.author,
             score: hit.points,
@@ -207,6 +215,27 @@ impl TryFrom<SearchHit> for Item {
             deleted: None,
         })
     }
+}
+
+/// Returns `Some(url.to_owned())` only when the input parses as an
+/// `http`/`https` URL. Used at the API boundary so the rest of the app
+/// can trust that any `Some(url)` on an [`Item`] is safe to open or
+/// render. Empty strings, non-http schemes, and malformed URLs all
+/// collapse to `None`.
+pub fn validate_http_url(raw: &str) -> Option<String> {
+    let parsed = url::Url::parse(raw).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    Some(raw.to_string())
+}
+
+fn deserialize_http_url<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    Ok(opt.as_deref().and_then(validate_http_url))
 }
 
 fn url_domain(raw: &str) -> Option<String> {
@@ -588,6 +617,82 @@ mod tests {
         assert_eq!(item.descendants, Some(10));
         assert_eq!(item.text.as_deref(), Some("body"));
         assert_eq!(item.item_type, Some(ItemType::Story));
+    }
+
+    // --- validate_http_url ---
+
+    #[test]
+    fn validate_http_url_accepts_https() {
+        assert_eq!(
+            validate_http_url("https://example.com/x"),
+            Some("https://example.com/x".into())
+        );
+    }
+
+    #[test]
+    fn validate_http_url_accepts_http() {
+        assert_eq!(
+            validate_http_url("http://example.com/x"),
+            Some("http://example.com/x".into())
+        );
+    }
+
+    #[test]
+    fn validate_http_url_rejects_javascript() {
+        assert_eq!(validate_http_url("javascript:alert(1)"), None);
+    }
+
+    #[test]
+    fn validate_http_url_rejects_data() {
+        assert_eq!(validate_http_url("data:text/html,<script>"), None);
+    }
+
+    #[test]
+    fn validate_http_url_rejects_mailto() {
+        assert_eq!(validate_http_url("mailto:foo@example.com"), None);
+    }
+
+    #[test]
+    fn validate_http_url_rejects_file() {
+        assert_eq!(validate_http_url("file:///etc/passwd"), None);
+    }
+
+    #[test]
+    fn validate_http_url_rejects_garbage() {
+        assert_eq!(validate_http_url("not a url"), None);
+        assert_eq!(validate_http_url(""), None);
+    }
+
+    #[test]
+    fn item_deserialize_drops_non_http_url() {
+        // Firebase returns whatever the submitter put in. Verify a
+        // mailto: URL is normalised to None at decode time.
+        let json = r#"{"id":1,"url":"mailto:a@b.com"}"#;
+        let item: Item = serde_json::from_str(json).unwrap();
+        assert_eq!(item.url, None);
+    }
+
+    #[test]
+    fn item_deserialize_keeps_http_url() {
+        let json = r#"{"id":1,"url":"https://example.com/foo"}"#;
+        let item: Item = serde_json::from_str(json).unwrap();
+        assert_eq!(item.url.as_deref(), Some("https://example.com/foo"));
+    }
+
+    #[test]
+    fn search_hit_drops_non_http_url() {
+        let hit = SearchHit {
+            object_id: "1".into(),
+            title: None,
+            url: Some("javascript:alert(1)".into()),
+            author: None,
+            points: None,
+            num_comments: None,
+            created_at_i: None,
+            story_text: None,
+        };
+        let item = Item::try_from(hit).unwrap();
+        assert_eq!(item.url, None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1475,10 +1475,7 @@ async fn run_comment_load(
             Ok(Some(full_item)) => full_item.kids.as_deref().unwrap_or(&[]).to_vec(),
             Ok(None) => Vec::new(),
             Err(e) => {
-                let _ = tx.send(AppMessage::Error(format!(
-                    "Failed to load comments: {}",
-                    e
-                )));
+                let _ = tx.send(AppMessage::Error(format!("Failed to load comments: {}", e)));
                 return;
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -640,18 +640,17 @@ impl App {
                     Pane::Comments => Pane::Stories,
                 };
             }
-            Action::SwitchFeed(idx) => {
-                if idx < FeedKind::ALL.len() {
-                    let feed = FeedKind::ALL[idx];
-                    if feed != self.current_feed || self.search_state.is_some() {
-                        self.search_state = None;
-                        self.input_mode = InputMode::Normal;
-                        self.current_feed = feed;
-                        self.focus = Pane::Stories;
-                        self.reset_panes_and_reload();
-                    }
+            Action::SwitchFeed(idx) if idx < FeedKind::ALL.len() => {
+                let feed = FeedKind::ALL[idx];
+                if feed != self.current_feed || self.search_state.is_some() {
+                    self.search_state = None;
+                    self.input_mode = InputMode::Normal;
+                    self.current_feed = feed;
+                    self.focus = Pane::Stories;
+                    self.reset_panes_and_reload();
                 }
             }
+            Action::SwitchFeed(_) => {}
             Action::Refresh => {
                 if let Some(ref ss) = self.search_state {
                     let query = ss.query.clone();

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,12 +20,19 @@ use crate::state::read_store::ReadStore;
 use crate::state::reader_state::{ReaderState, StyledFragment};
 use crate::state::search_state::SearchState;
 use crate::state::story_state::StoryListState;
-use std::collections::{HashMap, HashSet};
+use lru::LruCache;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
 const MIN_PAGE_SIZE: usize = 30;
 const SCROLL_PAGE: usize = 10;
 const MAX_COMMENT_DEPTH: usize = 10;
+/// Maximum prior-discussions results retained across a session. Long
+/// browse sessions otherwise grow this cache unboundedly (one entry per
+/// distinct visited story URL).
+const PRIOR_RESULTS_CACHE: usize = 200;
 
 /// Which content pane currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -160,11 +167,18 @@ pub struct App {
     /// when the user presses `h`.
     pub prior_state: Option<PriorDiscussionsState>,
     /// Prior-submissions query results, keyed by the story ID that was
-    /// queried. Keeps each result around for the rest of the session so
-    /// reopening the [`PriorDiscussionsState`] overlay doesn't trigger a refetch.
-    pub prior_results: HashMap<StoryId, Vec<Item>>,
-    /// Story IDs whose URL queries are in flight. Prevents duplicate spawns.
-    prior_in_flight: HashSet<StoryId>,
+    /// queried. Keeps each result around for reopening the
+    /// [`PriorDiscussionsState`] overlay without a refetch. Bounded by
+    /// [`PRIOR_RESULTS_CACHE`] entries so a long browse session doesn't
+    /// grow the cache unboundedly. LRU eviction order means the most
+    /// recently visited stories stay warm.
+    pub prior_results: LruCache<StoryId, Vec<Item>>,
+    /// Story IDs whose URL queries are in flight. Prevents duplicate
+    /// spawns. Wrapped in `Arc<Mutex<...>>` so the spawned task can hold
+    /// a [`PriorInFlightGuard`] that clears the entry on `Drop` — that
+    /// way a task panic doesn't leak the ID and lock the user out of
+    /// reopening prior-discussions for that story.
+    prior_in_flight: Arc<Mutex<HashSet<StoryId>>>,
 
     /// Persisted read-state — records which stories have been opened and
     /// how many comments each had at the time. Rendered by
@@ -219,8 +233,10 @@ impl App {
             terminal_width,
             tick_count: 0,
             prior_state: None,
-            prior_results: HashMap::new(),
-            prior_in_flight: HashSet::new(),
+            prior_results: LruCache::new(
+                NonZeroUsize::new(PRIOR_RESULTS_CACHE).expect("PRIOR_RESULTS_CACHE > 0"),
+            ),
+            prior_in_flight: Arc::new(Mutex::new(HashSet::new())),
             read_store: ReadStore::load(),
             pin_store: PinStore::load(),
             pending_pinned_resume: None,
@@ -283,6 +299,23 @@ impl App {
     /// Also clears pending if the loaded story has changed underneath us
     /// (the user moved on while comments were still streaming in).
     fn try_advance_resume(&mut self) {
+        self.apply_pending_resume(false);
+    }
+
+    /// Final-pass clamp invoked from `CommentsDone`: if a saved target
+    /// still lies past the now-complete visible range (rare — heavy
+    /// moderation since the last visit), pin the cursor to the last
+    /// visible row instead of leaving the resume permanently pending.
+    fn finalize_pending_resume(&mut self) {
+        self.apply_pending_resume(true);
+    }
+
+    /// Shared body for [`Self::try_advance_resume`] (in-progress) and
+    /// [`Self::finalize_pending_resume`] (final pass after `CommentsDone`).
+    /// Returns silently with the resume still pending when the loaded
+    /// tree hasn't grown enough yet — except in the final pass, where
+    /// past-end targets clamp to `visible_len - 1` and the resume clears.
+    fn apply_pending_resume(&mut self, clamp_to_end: bool) {
         let Some(target) = self.pending_pinned_resume else {
             return;
         };
@@ -296,12 +329,39 @@ impl App {
         }
         let visible_len = self.comment_state.visible_len();
         if visible_len == 0 {
-            return; // no rows yet — try again on the next batch
+            if clamp_to_end {
+                self.pending_pinned_resume = None;
+            }
+            return;
         }
         if target.target_selected < visible_len {
             self.comment_state.selected = target.target_selected;
             self.pending_pinned_resume = None;
+        } else if clamp_to_end {
+            self.comment_state.selected = visible_len - 1;
+            self.pending_pinned_resume = None;
         }
+    }
+
+    /// Records that the user just navigated within the comments pane.
+    /// Drops any pending pinned-resume target so we don't override their
+    /// intentional cursor motion. Called from every comments-pane
+    /// navigation arm in `dispatch`, plus the click and scroll handlers.
+    fn user_navigated_comments(&mut self) {
+        self.pending_pinned_resume = None;
+    }
+
+    /// Snapshot the outgoing pinned story's reading position, blow away
+    /// both panes' state plus the HN client cache, drop any pending
+    /// resume target, and kick off a fresh feed fetch. Used by
+    /// `Action::SwitchFeed`, `Action::Refresh`, and [`Self::cancel_search`].
+    fn reset_panes_and_reload(&mut self) {
+        self.snapshot_pinned_resume_if_any();
+        self.story_state.reset();
+        self.comment_state.reset();
+        self.pending_pinned_resume = None;
+        self.client.clear_cache();
+        self.spawn_load_stories(LoadMode::Replace);
     }
 
     /// Spawns a background fetch for the first page of the current feed.
@@ -318,8 +378,8 @@ impl App {
     /// caller-specific and stay at the call sites.
     fn apply_loaded_stories(&mut self, stories: Vec<Item>, mode: LoadMode) {
         match mode {
-            LoadMode::Append => self.story_state.stories.extend(stories),
-            LoadMode::Replace => self.story_state.stories = stories,
+            LoadMode::Append => self.story_state.append_stories(stories),
+            LoadMode::Replace => self.story_state.replace_stories(stories),
         }
         self.story_state.loading = false;
         self.error = None;
@@ -405,18 +465,9 @@ impl App {
                 AppMessage::CommentsDone => {
                     self.comment_state.loading = false;
                     self.comment_state.pending_root_ids.clear();
-                    // Final attempt — clamp to the now-complete tree.
-                    if let Some(target) = self.pending_pinned_resume.take() {
-                        if let Some(ref story) = self.comment_state.story {
-                            if StoryId(story.id) == target.story_id {
-                                let visible_len = self.comment_state.visible_len();
-                                if visible_len > 0 {
-                                    self.comment_state.selected =
-                                        target.target_selected.min(visible_len - 1);
-                                }
-                            }
-                        }
-                    }
+                    // Final attempt — clamp past-end targets to the last
+                    // visible row of the now-complete tree.
+                    self.finalize_pending_resume();
                 }
                 AppMessage::ArticleLoaded { lines, links } => {
                     if let Some(ref mut reader) = self.reader_state {
@@ -437,7 +488,8 @@ impl App {
                     story_id,
                     submissions,
                 } => {
-                    self.prior_in_flight.remove(&story_id);
+                    // The spawned task's `PriorInFlightGuard` clears the
+                    // in-flight entry on Drop, so no explicit removal here.
                     // If the user has already opened the overlay for this
                     // same story, backfill its contents now that we have data.
                     if let Some(ref mut ps) = self.prior_state {
@@ -446,7 +498,7 @@ impl App {
                             ps.selected = 0;
                         }
                     }
-                    self.prior_results.insert(story_id, submissions);
+                    self.prior_results.put(story_id, submissions);
                 }
             }
         }
@@ -478,94 +530,70 @@ impl App {
             _ => {}
         }
 
-        // When reader is open, route actions to reader.
         if self.reader_state.is_some() {
-            // Back mutates the Option itself, so handle it before borrowing
-            // the inner state.
-            if matches!(action, Action::Back) {
-                self.reader_state = None;
-                return;
-            }
-            let Some(r) = self.reader_state.as_mut() else {
-                return;
-            };
-            match action {
-                Action::MoveDown => r.scroll_down(1),
-                Action::MoveUp => r.scroll_up(1),
-                Action::PageDown => r.page_down(SCROLL_PAGE),
-                Action::PageUp => r.page_up(SCROLL_PAGE),
-                Action::JumpTop => r.jump_top(),
-                Action::JumpBottom => r.jump_bottom(),
-                Action::OpenInBrowser => open_http_url(r.url.as_deref()),
-                // Exhaustive no-op list — when new Action variants are added
-                // they'll provoke a compile error here so the overlay's
-                // handling is a deliberate choice, not an accident.
-                Action::Quit
-                | Action::Select
-                | Action::OpenReader
-                | Action::SwitchPane
-                | Action::SwitchFeed(_)
-                | Action::Refresh
-                | Action::EnterSearch
-                | Action::ToggleHelp
-                | Action::TogglePriorDiscussions
-                | Action::CycleCommentFilter
-                | Action::TogglePin
-                | Action::None => {}
-                Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
-                    unreachable!("hint actions handled above")
-                }
-                Action::Back => unreachable!("Back is handled above"),
-            }
-            return;
+            return self.dispatch_reader(action);
         }
-
-        // When the prior-discussions overlay is open, route a reduced action
-        // set and consume everything else.
         if self.prior_state.is_some() {
-            // Actions that mutate App itself (not just the overlay's inner
-            // state) go first so the subsequent borrow of `p` is clean.
-            if matches!(action, Action::Back) {
-                self.prior_state = None;
-                return;
-            }
-            if matches!(action, Action::Select) {
-                self.open_selected_prior_discussion();
-                return;
-            }
-            let Some(p) = self.prior_state.as_mut() else {
-                return;
-            };
-            match action {
-                Action::MoveDown => p.select_next(),
-                Action::MoveUp => p.select_prev(),
-                Action::JumpTop => p.jump_top(),
-                Action::JumpBottom => p.jump_bottom(),
-                Action::OpenInBrowser => {
-                    open_http_url(p.selected_submission().and_then(|i| i.url.as_deref()));
-                }
-                // Exhaustive no-op list — see note in reader block above.
-                Action::Quit
-                | Action::OpenReader
-                | Action::SwitchPane
-                | Action::SwitchFeed(_)
-                | Action::Refresh
-                | Action::EnterSearch
-                | Action::ToggleHelp
-                | Action::TogglePriorDiscussions
-                | Action::CycleCommentFilter
-                | Action::TogglePin
-                | Action::PageDown
-                | Action::PageUp
-                | Action::None => {}
-                Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
-                    unreachable!("hint actions handled above")
-                }
-                Action::Back | Action::Select => unreachable!("handled above"),
-            }
+            return self.dispatch_prior(action);
+        }
+        self.dispatch_normal(action);
+    }
+
+    /// Dispatch arm for the article-reader overlay. Assumes
+    /// `reader_state.is_some()`. Hint actions are filtered upstream by
+    /// [`Self::dispatch`]. Unmapped actions are silently consumed.
+    fn dispatch_reader(&mut self, action: Action) {
+        // Back mutates the Option itself, so handle it before borrowing
+        // the inner state.
+        if matches!(action, Action::Back) {
+            self.reader_state = None;
             return;
         }
+        let Some(r) = self.reader_state.as_mut() else {
+            return;
+        };
+        match action {
+            Action::MoveDown => r.scroll_down(1),
+            Action::MoveUp => r.scroll_up(1),
+            Action::PageDown => r.page_down(SCROLL_PAGE),
+            Action::PageUp => r.page_up(SCROLL_PAGE),
+            Action::JumpTop => r.jump_top(),
+            Action::JumpBottom => r.jump_bottom(),
+            Action::OpenInBrowser => open_http_url(r.url.as_deref()),
+            _ => {}
+        }
+    }
 
+    /// Dispatch arm for the prior-discussions overlay. Assumes
+    /// `prior_state.is_some()`. Unmapped actions are silently consumed.
+    fn dispatch_prior(&mut self, action: Action) {
+        // Actions that mutate App itself (not just the overlay's inner
+        // state) go first so the subsequent borrow of `p` is clean.
+        if matches!(action, Action::Back) {
+            self.prior_state = None;
+            return;
+        }
+        if matches!(action, Action::Select) {
+            self.open_selected_prior_discussion();
+            return;
+        }
+        let Some(p) = self.prior_state.as_mut() else {
+            return;
+        };
+        match action {
+            Action::MoveDown => p.select_next(),
+            Action::MoveUp => p.select_prev(),
+            Action::JumpTop => p.jump_top(),
+            Action::JumpBottom => p.jump_bottom(),
+            Action::OpenInBrowser => {
+                open_http_url(p.selected_submission().and_then(|i| i.url.as_deref()));
+            }
+            _ => {}
+        }
+    }
+
+    /// Dispatch arm for the normal two-pane state (no overlay open).
+    fn dispatch_normal(&mut self, action: Action) {
         match action {
             Action::Quit => self.running = false,
             Action::Back => {
@@ -586,21 +614,21 @@ impl App {
                     self.check_lazy_load();
                 }
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.select_next();
                 }
             },
             Action::MoveUp => match self.focus {
                 Pane::Stories => self.story_state.select_prev(),
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.select_prev();
                 }
             },
             Action::Select => match self.focus {
                 Pane::Stories => self.load_selected_comments(),
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.toggle_collapse();
                 }
             },
@@ -616,16 +644,11 @@ impl App {
                 if idx < FeedKind::ALL.len() {
                     let feed = FeedKind::ALL[idx];
                     if feed != self.current_feed || self.search_state.is_some() {
-                        self.snapshot_pinned_resume_if_any();
                         self.search_state = None;
                         self.input_mode = InputMode::Normal;
                         self.current_feed = feed;
-                        self.story_state.reset();
-                        self.comment_state.reset();
-                        self.pending_pinned_resume = None;
-                        self.client.clear_cache();
                         self.focus = Pane::Stories;
-                        self.spawn_load_stories(LoadMode::Replace);
+                        self.reset_panes_and_reload();
                     }
                 }
             }
@@ -640,12 +663,7 @@ impl App {
                         self.spawn_search(query, 0, LoadMode::Replace);
                     }
                 } else {
-                    self.snapshot_pinned_resume_if_any();
-                    self.story_state.reset();
-                    self.comment_state.reset();
-                    self.pending_pinned_resume = None;
-                    self.client.clear_cache();
-                    self.spawn_load_stories(LoadMode::Replace);
+                    self.reset_panes_and_reload();
                 }
             }
             Action::EnterSearch => {
@@ -654,7 +672,7 @@ impl App {
             Action::JumpTop => match self.focus {
                 Pane::Stories => self.story_state.jump_top(),
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.jump_top();
                 }
             },
@@ -664,7 +682,7 @@ impl App {
                     self.check_lazy_load();
                 }
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.jump_bottom();
                 }
             },
@@ -674,14 +692,14 @@ impl App {
                     self.check_lazy_load();
                 }
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.page_down(SCROLL_PAGE);
                 }
             },
             Action::PageUp => match self.focus {
                 Pane::Stories => self.story_state.page_up(SCROLL_PAGE),
                 Pane::Comments => {
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     self.comment_state.page_up(SCROLL_PAGE);
                 }
             },
@@ -689,10 +707,9 @@ impl App {
             Action::TogglePriorDiscussions => self.toggle_prior_discussions(),
             Action::CycleCommentFilter => self.cycle_comment_filter(),
             Action::TogglePin => self.toggle_pin_focused_story(),
-            Action::EnterHintMode(_) | Action::HintKey(_) | Action::ExitHintMode => {
-                unreachable!("hint actions handled above")
-            }
-            Action::None => {}
+            // Hint-mode actions are already handled in `dispatch`; any
+            // unmapped Action variant is silently consumed.
+            _ => {}
         }
     }
 
@@ -734,8 +751,11 @@ impl App {
             return;
         };
         let last_seen = self.read_store.last_seen_at(StoryId(story.id));
+        // Subtract a 60s skew tolerance so users whose system clock is
+        // slightly ahead of HN's wall clock don't see legitimately-recent
+        // comments filtered out as "older than now − 24h".
         let now = chrono::Utc::now().timestamp();
-        let recent = CommentFilter::Recent(now - 86_400);
+        let recent = CommentFilter::Recent(now - 86_400 - 60);
         self.comment_state.filter = match (self.comment_state.filter, last_seen) {
             (CommentFilter::All, Some(t)) => CommentFilter::NewSince(t),
             (CommentFilter::All, None) => recent,
@@ -765,6 +785,8 @@ impl App {
         };
         let story_id = StoryId(story.id);
         if let Some(submissions) = self.prior_results.get(&story_id) {
+            // `LruCache::get` bumps recency — the most-recently-opened
+            // overlay stays warm even under cache pressure.
             self.prior_state = Some(PriorDiscussionsState::new(story_id, submissions.clone()));
         } else if let Some(url) = story.url.clone() {
             // No result yet — fire the query (if not already in flight) and
@@ -796,63 +818,13 @@ impl App {
         self.focus = Pane::Comments;
         self.comment_state.loading = true;
 
-        let client = self.client.clone();
-        let tx = self.msg_tx.clone();
         let needs_full_fetch = item.kids.is_none();
-        let kids = item.kids.as_deref().unwrap_or(&[]).to_vec();
-        let story = item;
-
-        tokio::spawn(async move {
-            // Search results arrive with kids == None — fetch the full item to
-            // populate them. TryFrom<SearchHit> filters out id=0 upstream, so
-            // no sentinel guard is needed. `fetch_item` returns Arc<Item>,
-            // so we copy the kids slice into an owned Vec.
-            let kids = if needs_full_fetch {
-                match client.fetch_item(story.id).await {
-                    Ok(Some(full_item)) => full_item.kids.as_deref().unwrap_or(&[]).to_vec(),
-                    _ => kids,
-                }
-            } else {
-                kids
-            };
-            let root_items = client.fetch_items(&kids).await;
-            let root_comments: Vec<CommentWithDepth> = root_items
-                .into_iter()
-                .flatten()
-                .filter(|item| !item.is_dead_or_deleted())
-                .map(|item| CommentWithDepth { item, depth: 0 })
-                .collect();
-            let pending_roots: HashSet<CommentId> = root_comments
-                .iter()
-                .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                .map(|c| CommentId(c.item.id))
-                .collect();
-            let child_specs: Vec<(CommentId, Vec<u64>)> = root_comments
-                .iter()
-                .filter_map(|c| {
-                    let kids = c.item.kids.as_deref()?;
-                    (!kids.is_empty()).then(|| (CommentId(c.item.id), kids.to_vec()))
-                })
-                .collect();
-            let _ = tx.send(AppMessage::CommentsLoaded {
-                story: Box::new(story),
-                comments: root_comments,
-                pending_roots,
-            });
-            for (parent_id, child_ids) in child_specs {
-                let mut children = Vec::new();
-                client
-                    .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
-                    .await;
-                if !children.is_empty() {
-                    let _ = tx.send(AppMessage::CommentsAppended {
-                        parent_id,
-                        children,
-                    });
-                }
-            }
-            let _ = tx.send(AppMessage::CommentsDone);
-        });
+        tokio::spawn(run_comment_load(
+            self.client.clone(),
+            self.msg_tx.clone(),
+            item,
+            needs_full_fetch,
+        ));
     }
 
     /// Transitions into search-input mode, showing an empty search prompt.
@@ -889,14 +861,9 @@ impl App {
 
     /// Exits search mode, clears the cache, and reloads the current feed.
     pub fn cancel_search(&mut self) {
-        self.snapshot_pinned_resume_if_any();
         self.search_state = None;
         self.input_mode = InputMode::Normal;
-        self.story_state.reset();
-        self.comment_state.reset();
-        self.pending_pinned_resume = None;
-        self.client.clear_cache();
-        self.spawn_load_stories(LoadMode::Replace);
+        self.reset_panes_and_reload();
     }
 
     /// Appends a typed character to the in-progress search input.
@@ -1018,19 +985,36 @@ impl App {
     /// query is already in flight. Failures silently no-op — prior-discussions
     /// is optional UX, not critical-path.
     fn spawn_prior_discussions(&mut self, story_id: StoryId, url: &str) {
-        if self.prior_results.contains_key(&story_id) {
+        if self.prior_results.contains(&story_id) {
             return;
         }
         // HashSet::insert returns false if the value was already present —
-        // single-lookup membership-check + insert.
-        if !self.prior_in_flight.insert(story_id) {
-            return;
+        // single-lookup membership-check + insert. Recover from a poisoned
+        // mutex by taking the inner guard rather than panicking; the
+        // in-flight set is non-essential.
+        {
+            let mut g = match self.prior_in_flight.lock() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            if !g.insert(story_id) {
+                return;
+            }
         }
 
         let client = self.client.clone();
         let tx = self.msg_tx.clone();
         let url = url.to_string();
+        let in_flight = Arc::clone(&self.prior_in_flight);
         tokio::spawn(async move {
+            // Guard removes `story_id` from the in-flight set when the
+            // task finishes — including the panic path. Without it, a
+            // panic before `tx.send(...)` would leak the entry and lock
+            // the user out of reopening prior-discussions for that story.
+            let _guard = PriorInFlightGuard {
+                set: in_flight,
+                id: story_id,
+            };
             let submissions = match client.search_by_url(&url).await {
                 Ok(items) => items.into_iter().filter(|i| i.id != story_id.0).collect(),
                 Err(_) => Vec::new(),
@@ -1066,72 +1050,13 @@ impl App {
                 self.spawn_prior_discussions(StoryId(story.id), url);
             }
 
-            let client = self.client.clone();
-            let tx = self.msg_tx.clone();
             let needs_full_fetch = story.kids.is_none();
-            let kids = story.kids.as_deref().unwrap_or(&[]).to_vec();
-
-            tokio::spawn(async move {
-                // For search results, kids is None — fetch the full item first.
-                // TryFrom<SearchHit> filters out id=0 upstream. `fetch_item`
-                // returns Arc<Item>, so we copy the kids slice into an owned Vec.
-                let kids = if needs_full_fetch {
-                    match client.fetch_item(story.id).await {
-                        Ok(Some(full_item)) => full_item.kids.as_deref().unwrap_or(&[]).to_vec(),
-                        _ => kids,
-                    }
-                } else {
-                    kids
-                };
-
-                // Step 1: Fetch root-level comments and show them immediately
-                let root_items = client.fetch_items(&kids).await;
-                let root_comments: Vec<CommentWithDepth> = root_items
-                    .into_iter()
-                    .flatten()
-                    .filter(|item| !item.is_dead_or_deleted())
-                    .map(|item| CommentWithDepth { item, depth: 0 })
-                    .collect();
-
-                let pending_roots: HashSet<CommentId> = root_comments
-                    .iter()
-                    .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
-                    .map(|c| CommentId(c.item.id))
-                    .collect();
-
-                // Extract (parent, child_ids) pairs before moving root_comments
-                // into the message — avoids cloning the full Vec just to keep
-                // the iterator alive.
-                let child_specs: Vec<(CommentId, Vec<u64>)> = root_comments
-                    .iter()
-                    .filter_map(|c| {
-                        let kids = c.item.kids.as_deref()?;
-                        (!kids.is_empty()).then(|| (CommentId(c.item.id), kids.to_vec()))
-                    })
-                    .collect();
-
-                let _ = tx.send(AppMessage::CommentsLoaded {
-                    story: Box::new(story),
-                    comments: root_comments,
-                    pending_roots,
-                });
-
-                // Step 2: For each root comment, fetch its children progressively
-                for (parent_id, child_ids) in child_specs {
-                    let mut children = Vec::new();
-                    client
-                        .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
-                        .await;
-                    if !children.is_empty() {
-                        let _ = tx.send(AppMessage::CommentsAppended {
-                            parent_id,
-                            children,
-                        });
-                    }
-                }
-
-                let _ = tx.send(AppMessage::CommentsDone);
-            });
+            tokio::spawn(run_comment_load(
+                self.client.clone(),
+                self.msg_tx.clone(),
+                story,
+                needs_full_fetch,
+            ));
         }
     }
 
@@ -1239,6 +1164,32 @@ impl App {
         }
     }
 
+    /// Maps a terminal cell to the pane under it plus that pane's inner
+    /// (post-border) rect. Returns `None` when the cell falls inside a
+    /// pane border or outside both panes. Shared by [`Self::handle_click`]
+    /// and [`Self::handle_scroll`] so the layout/contains math lives in
+    /// one place.
+    fn pane_at(&self, column: u16, row: u16) -> Option<(Pane, ratatui::layout::Rect)> {
+        use crate::ui::layout::build_layout;
+        use ratatui::layout::{Position, Rect};
+        use ratatui::widgets::{Block, Borders};
+
+        let area = Rect::new(0, 0, self.terminal_width, self.terminal_height);
+        let layout = build_layout(area);
+        let pos = Position::new(column, row);
+
+        for (pane_rect, pane) in [
+            (layout.stories, Pane::Stories),
+            (layout.comments, Pane::Comments),
+        ] {
+            if pane_rect.contains(pos) {
+                let inner = Block::default().borders(Borders::ALL).inner(pane_rect);
+                return inner.contains(pos).then_some((pane, inner));
+            }
+        }
+        None
+    }
+
     /// Handles a mouse left-click at the given terminal cell.
     ///
     /// Maps the cell to a pane via `build_layout`: in the stories pane,
@@ -1252,22 +1203,11 @@ impl App {
             return;
         }
 
-        use crate::ui::layout::build_layout;
-        use ratatui::layout::Rect;
-        use ratatui::widgets::{Block, Borders};
+        let Some((pane, inner)) = self.pane_at(column, row) else {
+            return;
+        };
 
-        let area = Rect::new(0, 0, self.terminal_width, self.terminal_height);
-        let layout = build_layout(area);
-
-        if layout
-            .stories
-            .contains(ratatui::layout::Position::new(column, row))
-        {
-            let inner = Block::default().borders(Borders::ALL).inner(layout.stories);
-            if !inner.contains(ratatui::layout::Position::new(column, row)) {
-                return;
-            }
-
+        if pane == Pane::Stories {
             let visible_height = inner.height as usize;
             let selected = self.story_state.selected;
             let scroll = if selected >= visible_height {
@@ -1283,17 +1223,7 @@ impl App {
                 // Auto-load comments for the clicked story
                 self.load_selected_comments();
             }
-        } else if layout
-            .comments
-            .contains(ratatui::layout::Position::new(column, row))
-        {
-            let inner = Block::default()
-                .borders(Borders::ALL)
-                .inner(layout.comments);
-            if !inner.contains(ratatui::layout::Position::new(column, row)) {
-                return;
-            }
-
+        } else {
             self.focus = Pane::Comments;
 
             let screen_row = (row - inner.y) as usize;
@@ -1310,7 +1240,7 @@ impl App {
                     // Mouse interaction in the comments pane is intentional
                     // navigation — drop any pending resume target so we don't
                     // jump the cursor away from where the user clicked.
-                    self.pending_pinned_resume = None;
+                    self.user_navigated_comments();
                     // Check for double-click to toggle collapse
                     let now = std::time::Instant::now();
                     if let Some((last_time, last_vi)) = self.last_comment_click {
@@ -1467,7 +1397,7 @@ impl App {
     /// Handles a mouse wheel event in the pane under the cursor. When the
     /// reader overlay is open, scrolls the reader (3 lines per tick);
     /// otherwise moves the selected item in the hit pane.
-    pub fn handle_scroll(&mut self, _column: u16, _row: u16, down: bool) {
+    pub fn handle_scroll(&mut self, column: u16, row: u16, down: bool) {
         // When reader is open, scroll reader
         if self.reader_state.is_some() {
             if let Some(ref mut reader) = self.reader_state {
@@ -1480,46 +1410,136 @@ impl App {
             return;
         }
 
-        use crate::ui::layout::build_layout;
-        use ratatui::layout::Rect;
-
-        let area = Rect::new(0, 0, self.terminal_width, self.terminal_height);
-        let layout = build_layout(area);
-
-        let pane = if layout
-            .stories
-            .contains(ratatui::layout::Position::new(_column, _row))
-        {
-            Some(Pane::Stories)
-        } else if layout
-            .comments
-            .contains(ratatui::layout::Position::new(_column, _row))
-        {
-            Some(Pane::Comments)
-        } else {
-            None
+        let Some((pane, _inner)) = self.pane_at(column, row) else {
+            return;
         };
 
-        if let Some(pane) = pane {
-            match (pane, down) {
-                (Pane::Stories, true) => {
-                    self.story_state.select_next();
-                    self.check_lazy_load();
-                }
-                (Pane::Stories, false) => {
-                    self.story_state.select_prev();
-                }
-                (Pane::Comments, true) => {
-                    self.pending_pinned_resume = None;
-                    self.comment_state.select_next();
-                }
-                (Pane::Comments, false) => {
-                    self.pending_pinned_resume = None;
-                    self.comment_state.select_prev();
-                }
+        match (pane, down) {
+            (Pane::Stories, true) => {
+                self.story_state.select_next();
+                self.check_lazy_load();
+            }
+            (Pane::Stories, false) => {
+                self.story_state.select_prev();
+            }
+            (Pane::Comments, true) => {
+                self.user_navigated_comments();
+                self.comment_state.select_next();
+            }
+            (Pane::Comments, false) => {
+                self.user_navigated_comments();
+                self.comment_state.select_prev();
             }
         }
     }
+}
+
+/// Removes a `story_id` from `App::prior_in_flight` on `Drop` so a
+/// panicking spawned task doesn't leave the entry stranded — without
+/// this guard, the user would be unable to reopen prior-discussions for
+/// that story for the rest of the session.
+struct PriorInFlightGuard {
+    set: Arc<Mutex<HashSet<StoryId>>>,
+    id: StoryId,
+}
+
+impl Drop for PriorInFlightGuard {
+    fn drop(&mut self) {
+        // Recover from a poisoned mutex — same rationale as the
+        // `HnClient::cache` guard: a transient task panic shouldn't
+        // tear down the rest of the TUI.
+        let mut g = match self.set.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        g.remove(&self.id);
+    }
+}
+
+/// Two-phase comment load shared by `load_selected_comments` and
+/// `open_selected_prior_discussion`. Resolves the kids list (fetching the
+/// full item when search results arrive without one), sends
+/// `CommentsLoaded`, drives subtree walks concurrently, then sends
+/// `CommentsDone`. A failed `fetch_item` surfaces as `AppMessage::Error`
+/// instead of silently rendering an empty thread.
+async fn run_comment_load(
+    client: HnClient,
+    tx: mpsc::UnboundedSender<AppMessage>,
+    story: Item,
+    needs_full_fetch: bool,
+) {
+    use futures::stream::{self, StreamExt};
+
+    let kids: Vec<u64> = if needs_full_fetch {
+        match client.fetch_item(story.id).await {
+            Ok(Some(full_item)) => full_item.kids.as_deref().unwrap_or(&[]).to_vec(),
+            Ok(None) => Vec::new(),
+            Err(e) => {
+                let _ = tx.send(AppMessage::Error(format!(
+                    "Failed to load comments: {}",
+                    e
+                )));
+                return;
+            }
+        }
+    } else {
+        story.kids.as_deref().unwrap_or(&[]).to_vec()
+    };
+
+    let root_items = client.fetch_items(&kids).await;
+    let root_comments: Vec<CommentWithDepth> = root_items
+        .into_iter()
+        .flatten()
+        .filter(|item| !item.is_dead_or_deleted())
+        .map(|item| CommentWithDepth { item, depth: 0 })
+        .collect();
+
+    let pending_roots: HashSet<CommentId> = root_comments
+        .iter()
+        .filter(|c| c.item.kids.as_ref().is_some_and(|k| !k.is_empty()))
+        .map(|c| CommentId(c.item.id))
+        .collect();
+
+    // Extract (parent, child_ids) pairs before moving root_comments into
+    // the message — avoids cloning the full Vec just to keep the iterator
+    // alive.
+    let child_specs: Vec<(CommentId, Vec<u64>)> = root_comments
+        .iter()
+        .filter_map(|c| {
+            let kids = c.item.kids.as_deref()?;
+            (!kids.is_empty()).then(|| (CommentId(c.item.id), kids.to_vec()))
+        })
+        .collect();
+
+    let _ = tx.send(AppMessage::CommentsLoaded {
+        story: Box::new(story),
+        comments: root_comments,
+        pending_roots,
+    });
+
+    // Step 2: drive each root subtree concurrently. `fetch_children_recursive`
+    // already does buffer_unordered(20) inside; capping outer concurrency at
+    // 4 keeps total in-flight requests bounded (~80 worst case).
+    stream::iter(child_specs)
+        .for_each_concurrent(Some(4), |(parent_id, child_ids)| {
+            let client = client.clone();
+            let tx = tx.clone();
+            async move {
+                let mut children = Vec::new();
+                client
+                    .fetch_children_recursive(&child_ids, 1, MAX_COMMENT_DEPTH, &mut children)
+                    .await;
+                if !children.is_empty() {
+                    let _ = tx.send(AppMessage::CommentsAppended {
+                        parent_id,
+                        children,
+                    });
+                }
+            }
+        })
+        .await;
+
+    let _ = tx.send(AppMessage::CommentsDone);
 }
 
 /// Opens `url` in the system browser — but only when it parses as an

--- a/src/article.rs
+++ b/src/article.rs
@@ -5,13 +5,73 @@
 //! and GitLab repo roots it short-circuits to the raw README. HN-native
 //! text posts (Ask HN, etc.) go through [`html_to_styled_lines`] directly.
 
+use crate::sanitize::sanitize_terminal;
 use crate::state::link_registry::LinkRegistry;
 use crate::state::reader_state::StyledFragment;
 use crate::ui::theme;
 use html2text::render::RichAnnotation;
 use ratatui::style::{Modifier, Style};
+use std::sync::OnceLock;
 
 const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024; // 5MB
+
+/// Shared HTTP client for article fetches. Built once on first use so
+/// connection pools are reused across reader opens (multiple GH README
+/// clicks in a row share keep-alive). The redirect policy rejects
+/// non-`http(s)` schemes and IP literals in private/loopback ranges,
+/// closing the SSRF redirect path that would otherwise let a HN story
+/// `302` to `http://169.254.169.254/` or `http://localhost:6379/`.
+fn article_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent(concat!(
+                "Mozilla/5.0 (compatible; hnt/",
+                env!("CARGO_PKG_VERSION"),
+                ")"
+            ))
+            .timeout(std::time::Duration::from_secs(15))
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                if attempt.previous().len() >= 5 {
+                    return attempt.error("too many redirects");
+                }
+                let url = attempt.url();
+                if !matches!(url.scheme(), "http" | "https") {
+                    return attempt.error("non-http redirect");
+                }
+                if let Some(host) = url.host_str() {
+                    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+                        if is_private_ip(ip) {
+                            return attempt.error("redirect to private/loopback host");
+                        }
+                    }
+                }
+                attempt.follow()
+            }))
+            .build()
+            .expect("article client builder")
+    })
+}
+
+/// Whether `ip` falls inside an address range we won't follow redirects
+/// to. Covers loopback, link-local, unspecified, RFC1918 private (v4),
+/// and unique-local + loopback (v6).
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    if ip.is_loopback() || ip.is_unspecified() {
+        return true;
+    }
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        // v6 unique-local (fc00::/7) doesn't have a stable .is_unique_local()
+        // on stable Rust yet; check manually.
+        IpAddr::V6(v6) => {
+            let seg0 = v6.segments()[0];
+            (seg0 & 0xfe00) == 0xfc00 // ULA
+                || (seg0 & 0xffc0) == 0xfe80 // link-local
+        }
+    }
+}
 
 /// For GitHub/GitLab repo pages, tries to fetch the raw README instead of
 /// the JS-heavy HTML shell (the README content is loaded dynamically by JS).
@@ -60,28 +120,36 @@ async fn try_fetch_readme(client: &reqwest::Client, url: &str) -> Option<(String
         return None;
     };
 
-    for readme_url in readme_urls {
-        if let Ok(resp) = client.get(&readme_url).send().await {
-            if resp.status().is_success() {
+    // Fire all candidate URLs in parallel and return the first one that
+    // produces a non-empty, size-bounded response. Saves ~3× RTT on the
+    // common case where the first 1-3 candidates 404. `select_ok`
+    // cancels the remaining futures as soon as one succeeds.
+    use futures::future::{select_ok, BoxFuture};
+    let futs: Vec<BoxFuture<'_, Result<(String, bool), ()>>> = readme_urls
+        .into_iter()
+        .map(|readme_url| {
+            let client = client.clone();
+            Box::pin(async move {
+                let resp = client.get(&readme_url).send().await.map_err(|_| ())?;
+                if !resp.status().is_success() {
+                    return Err(());
+                }
                 if let Some(len) = resp.content_length() {
                     if len > MAX_RESPONSE_BYTES as u64 {
-                        continue;
+                        return Err(());
                     }
                 }
-                if let Ok(text) = resp.text().await {
-                    if text.len() > MAX_RESPONSE_BYTES {
-                        continue;
-                    }
-                    if !text.trim().is_empty() {
-                        let is_markdown = readme_url.ends_with(".md");
-                        return Some((text, is_markdown));
-                    }
+                let text = resp.text().await.map_err(|_| ())?;
+                if text.len() > MAX_RESPONSE_BYTES || text.trim().is_empty() {
+                    return Err(());
                 }
-            }
-        }
-    }
+                let is_markdown = readme_url.ends_with(".md");
+                Ok((text, is_markdown))
+            }) as BoxFuture<'_, _>
+        })
+        .collect();
 
-    None
+    select_ok(futs).await.ok().map(|(value, _rest)| value)
 }
 
 /// Converts markdown text to styled lines with basic formatting.
@@ -203,17 +271,10 @@ pub async fn fetch_and_extract_article(
 ) -> anyhow::Result<(Vec<Vec<StyledFragment>>, LinkRegistry)> {
     use anyhow::{anyhow, bail, Context};
 
-    let client = reqwest::Client::builder()
-        .user_agent(concat!(
-            "Mozilla/5.0 (compatible; hnt/",
-            env!("CARGO_PKG_VERSION"),
-            ")"
-        ))
-        .timeout(std::time::Duration::from_secs(15))
-        .build()?;
+    let client = article_client();
 
     // For GitHub/GitLab repo pages, try fetching the README directly
-    if let Some((readme_text, is_markdown)) = try_fetch_readme(&client, url).await {
+    if let Some((readme_text, is_markdown)) = try_fetch_readme(client, url).await {
         return if is_markdown {
             Ok((
                 markdown_to_styled_lines(&readme_text, width),
@@ -332,6 +393,11 @@ fn tagged_lines_to_styled_with_links(
         .enumerate()
         .map(|(line_idx, tagged_line)| {
             let mut fragments: Vec<StyledFragment> = Vec::new();
+            // Running column offset on this line, in chars. Updated as
+            // each fragment is appended so the link's `col` field is
+            // captured once at registry-build time — the hint paint then
+            // reads it directly without re-summing fragment widths.
+            let mut cur_col: usize = 0;
             for ts in tagged_line.tagged_strings() {
                 let style = annotations_to_style(&ts.tag);
                 let url = ts.tag.iter().find_map(|ann| {
@@ -343,18 +409,25 @@ fn tagged_lines_to_styled_with_links(
                 });
                 let fragment_idx = fragments.len();
                 let text_is_visible = !ts.s.trim().is_empty();
+                let safe_text = sanitize_terminal(&ts.s).into_owned();
+                let text_cols = safe_text.chars().count();
                 fragments.push(StyledFragment {
-                    text: ts.s.clone(),
+                    text: safe_text,
                     style,
                 });
                 if let Some(url) = url {
+                    let safe_url = sanitize_terminal(&url).into_owned();
                     if text_is_visible {
-                        links.push(url.clone(), line_idx, fragment_idx);
+                        links.push(safe_url.clone(), line_idx, fragment_idx, cur_col);
                     }
+                    let suffix = format!(" [{}]", safe_url);
+                    cur_col += text_cols + suffix.chars().count();
                     fragments.push(StyledFragment {
-                        text: format!(" [{}]", url),
+                        text: suffix,
                         style: Style::default().fg(theme::DIM),
                     });
+                } else {
+                    cur_col += text_cols;
                 }
             }
             fragments
@@ -407,6 +480,63 @@ pub fn html_to_styled_lines(html: &[u8], width: usize) -> (Vec<Vec<StyledFragmen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    // --- is_private_ip ---
+
+    #[test]
+    fn private_ip_blocks_loopback_ipv4() {
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn private_ip_blocks_loopback_ipv6() {
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn private_ip_blocks_unspecified() {
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED)));
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+    }
+
+    #[test]
+    fn private_ip_blocks_rfc1918() {
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+    }
+
+    #[test]
+    fn private_ip_blocks_link_local_v4() {
+        // AWS IMDS — 169.254.169.254 is the canonical SSRF target.
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))));
+    }
+
+    #[test]
+    fn private_ip_blocks_unique_local_v6() {
+        // fc00::/7
+        let ula: Ipv6Addr = "fd00::1".parse().unwrap();
+        assert!(is_private_ip(IpAddr::V6(ula)));
+    }
+
+    #[test]
+    fn private_ip_blocks_link_local_v6() {
+        let lla: Ipv6Addr = "fe80::1".parse().unwrap();
+        assert!(is_private_ip(IpAddr::V6(lla)));
+    }
+
+    #[test]
+    fn private_ip_allows_public_v4() {
+        assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    #[test]
+    fn private_ip_allows_public_v6() {
+        let public: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+        assert!(!is_private_ip(IpAddr::V6(public)));
+    }
 
     // --- markdown_to_styled_lines ---
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 pub enum Event {
     Key(KeyEvent),
     Mouse(MouseEvent),
-    Resize(#[allow(dead_code)] u16, u16),
+    Resize { width: u16, height: u16 },
     Tick,
 }
 
@@ -26,7 +26,6 @@ pub enum Event {
 /// [`EventHandler::next`] to `.await` the next [`Event`].
 pub struct EventHandler {
     rx: mpsc::UnboundedReceiver<Event>,
-    _tx: mpsc::UnboundedSender<Event>,
 }
 
 impl EventHandler {
@@ -36,7 +35,6 @@ impl EventHandler {
     /// errors/ends. Ticks fire every `tick_rate`.
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        let _tx = tx.clone();
 
         tokio::spawn(async move {
             let mut reader = EventStream::new();
@@ -53,7 +51,9 @@ impl EventHandler {
                         let send_result = match event {
                             Some(Ok(CrosstermEvent::Key(key))) => tx.send(Event::Key(key)),
                             Some(Ok(CrosstermEvent::Mouse(mouse))) => tx.send(Event::Mouse(mouse)),
-                            Some(Ok(CrosstermEvent::Resize(w, h))) => tx.send(Event::Resize(w, h)),
+                            Some(Ok(CrosstermEvent::Resize(w, h))) => {
+                                tx.send(Event::Resize { width: w, height: h })
+                            }
                             Some(Err(_)) | None => break,
                             _ => continue,
                         };
@@ -65,7 +65,7 @@ impl EventHandler {
             }
         });
 
-        Self { rx, _tx }
+        Self { rx }
     }
 
     /// Awaits the next [`Event`]. Returns an error if the channel closes,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -25,7 +25,8 @@ pub enum InputMode {
 /// A keybinding-independent operation the app may perform.
 ///
 /// Produced by [`map_key`] from raw [`KeyEvent`]s, consumed by
-/// [`crate::app::App::dispatch`]. `Action::None` means "unmapped — ignore."
+/// [`crate::app::App::dispatch`]. Unmapped keys yield `None` from
+/// [`map_key`] — there is no in-band sentinel variant.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Action {
@@ -63,50 +64,53 @@ pub enum Action {
     /// Cancel hint-label selection and return to the prior input mode.
     ExitHintMode,
     Back,
-    None,
 }
 
 /// Translates a [`KeyEvent`] into an [`Action`] for the current UI
 /// context.
 ///
 /// Priority order: search-input + hint-mode suppress normal keys (return
-/// [`Action::None`] so `main.rs` can handle raw characters); a visible
-/// help overlay consumes any key as [`Action::ToggleHelp`]; a visible
-/// reader overlay uses its own reduced keymap; a visible
-/// prior-discussions overlay likewise uses a reduced keymap; otherwise
-/// the standard navigation keymap applies.
+/// `None` so `main.rs` can handle raw characters); a visible help
+/// overlay consumes any key as [`Action::ToggleHelp`]; a visible reader
+/// overlay uses its own reduced keymap; a visible prior-discussions
+/// overlay likewise uses a reduced keymap; otherwise the standard
+/// navigation keymap applies. Unmapped keys yield `None`.
 pub fn map_key(
     key: KeyEvent,
     help_visible: bool,
     reader_visible: bool,
     prior_visible: bool,
     input_mode: InputMode,
-) -> Action {
+) -> Option<Action> {
     // SearchInput and HintMode both consume raw chars in main.rs.
     if matches!(input_mode, InputMode::SearchInput | InputMode::HintMode) {
-        return Action::None;
+        return None;
     }
 
     // If help overlay is open, any key closes it
     if help_visible {
-        return Action::ToggleHelp;
+        return Some(Action::ToggleHelp);
     }
 
     // Reader overlay has its own limited key set
     if reader_visible {
         return match key.code {
-            KeyCode::Char('j') | KeyCode::Down => Action::MoveDown,
-            KeyCode::Char('k') | KeyCode::Up => Action::MoveUp,
-            KeyCode::Char('g') => Action::JumpTop,
-            KeyCode::Char('G') => Action::JumpBottom,
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageUp,
-            KeyCode::Char('o') => Action::OpenInBrowser,
-            KeyCode::Char('f') => Action::EnterHintMode(HintAction::Open),
-            KeyCode::Char('F') => Action::EnterHintMode(HintAction::OpenInReader),
-            KeyCode::Char('y') => Action::EnterHintMode(HintAction::CopyUrl),
-            KeyCode::Esc | KeyCode::Char('q') => Action::Back,
-            _ => Action::None,
+            KeyCode::Char('j') | KeyCode::Down => Some(Action::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Action::MoveUp),
+            KeyCode::Char('g') => Some(Action::JumpTop),
+            KeyCode::Char('G') => Some(Action::JumpBottom),
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(Action::PageDown)
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(Action::PageUp)
+            }
+            KeyCode::Char('o') => Some(Action::OpenInBrowser),
+            KeyCode::Char('f') => Some(Action::EnterHintMode(HintAction::Open)),
+            KeyCode::Char('F') => Some(Action::EnterHintMode(HintAction::OpenInReader)),
+            KeyCode::Char('y') => Some(Action::EnterHintMode(HintAction::CopyUrl)),
+            KeyCode::Esc | KeyCode::Char('q') => Some(Action::Back),
+            _ => None,
         };
     }
 
@@ -115,44 +119,48 @@ pub fn map_key(
     // global toggle in normal mode (below) without ambiguity.
     if prior_visible {
         return match key.code {
-            KeyCode::Char('j') | KeyCode::Down => Action::MoveDown,
-            KeyCode::Char('k') | KeyCode::Up => Action::MoveUp,
-            KeyCode::Char('g') => Action::JumpTop,
-            KeyCode::Char('G') => Action::JumpBottom,
-            KeyCode::Enter => Action::Select,
-            KeyCode::Char('o') => Action::OpenInBrowser,
-            KeyCode::Esc | KeyCode::Char('q') => Action::Back,
-            _ => Action::None,
+            KeyCode::Char('j') | KeyCode::Down => Some(Action::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Action::MoveUp),
+            KeyCode::Char('g') => Some(Action::JumpTop),
+            KeyCode::Char('G') => Some(Action::JumpBottom),
+            KeyCode::Enter => Some(Action::Select),
+            KeyCode::Char('o') => Some(Action::OpenInBrowser),
+            KeyCode::Esc | KeyCode::Char('q') => Some(Action::Back),
+            _ => None,
         };
     }
 
     match key.code {
-        KeyCode::Char('q') => Action::Quit,
-        KeyCode::Esc => Action::Back,
-        KeyCode::Char('j') | KeyCode::Down => Action::MoveDown,
-        KeyCode::Char('k') | KeyCode::Up => Action::MoveUp,
-        KeyCode::Enter => Action::Select,
-        KeyCode::Char('o') => Action::OpenInBrowser,
-        KeyCode::Char('p') => Action::OpenReader,
-        KeyCode::Char('h') => Action::TogglePriorDiscussions,
-        KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => Action::SwitchPane,
+        KeyCode::Char('q') => Some(Action::Quit),
+        KeyCode::Esc => Some(Action::Back),
+        KeyCode::Char('j') | KeyCode::Down => Some(Action::MoveDown),
+        KeyCode::Char('k') | KeyCode::Up => Some(Action::MoveUp),
+        KeyCode::Enter => Some(Action::Select),
+        KeyCode::Char('o') => Some(Action::OpenInBrowser),
+        KeyCode::Char('p') => Some(Action::OpenReader),
+        KeyCode::Char('h') => Some(Action::TogglePriorDiscussions),
+        KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => {
+            Some(Action::SwitchPane)
+        }
         // 1–7: Top, New, Best, Ask, Show, Jobs, Pinned (matches FeedKind::ALL order).
-        KeyCode::Char(c @ '1'..='7') => Action::SwitchFeed(c as usize - '1' as usize),
-        KeyCode::Char('r') => Action::Refresh,
-        KeyCode::Char('n') => Action::CycleCommentFilter,
-        KeyCode::Char('b') => Action::TogglePin,
-        KeyCode::Char('g') => Action::JumpTop,
-        KeyCode::Char('G') => Action::JumpBottom,
-        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageDown,
-        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::PageUp,
-        KeyCode::Char('/') => Action::EnterSearch,
-        KeyCode::Char('?') => Action::ToggleHelp,
+        KeyCode::Char(c @ '1'..='7') => Some(Action::SwitchFeed(c as usize - '1' as usize)),
+        KeyCode::Char('r') => Some(Action::Refresh),
+        KeyCode::Char('n') => Some(Action::CycleCommentFilter),
+        KeyCode::Char('b') => Some(Action::TogglePin),
+        KeyCode::Char('g') => Some(Action::JumpTop),
+        KeyCode::Char('G') => Some(Action::JumpBottom),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(Action::PageDown)
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageUp),
+        KeyCode::Char('/') => Some(Action::EnterSearch),
+        KeyCode::Char('?') => Some(Action::ToggleHelp),
         // Quickjump entry — comments-pane variant. Reader-overlay variant
         // is handled in the reader_visible block above.
-        KeyCode::Char('f') => Action::EnterHintMode(HintAction::Open),
-        KeyCode::Char('F') => Action::EnterHintMode(HintAction::OpenInReader),
-        KeyCode::Char('y') => Action::EnterHintMode(HintAction::CopyUrl),
-        _ => Action::None,
+        KeyCode::Char('f') => Some(Action::EnterHintMode(HintAction::Open)),
+        KeyCode::Char('F') => Some(Action::EnterHintMode(HintAction::OpenInReader)),
+        KeyCode::Char('y') => Some(Action::EnterHintMode(HintAction::CopyUrl)),
+        _ => None,
     }
 }
 
@@ -180,7 +188,7 @@ mod tests {
                 false,
                 InputMode::SearchInput
             ),
-            Action::None
+            None
         );
         assert_eq!(
             map_key(
@@ -190,7 +198,7 @@ mod tests {
                 false,
                 InputMode::SearchInput
             ),
-            Action::None
+            None
         );
     }
 
@@ -204,11 +212,11 @@ mod tests {
                 false,
                 InputMode::Normal
             ),
-            Action::ToggleHelp
+            Some(Action::ToggleHelp)
         );
         assert_eq!(
             map_key(key(KeyCode::Enter), true, false, false, InputMode::Normal),
-            Action::ToggleHelp
+            Some(Action::ToggleHelp)
         );
     }
 
@@ -222,7 +230,7 @@ mod tests {
                 false,
                 InputMode::Normal
             ),
-            Action::ToggleHelp
+            Some(Action::ToggleHelp)
         );
     }
 
@@ -231,26 +239,26 @@ mod tests {
     #[test]
     fn reader_navigation() {
         let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
-        assert_eq!(r(KeyCode::Char('j')), Action::MoveDown);
-        assert_eq!(r(KeyCode::Down), Action::MoveDown);
-        assert_eq!(r(KeyCode::Char('k')), Action::MoveUp);
-        assert_eq!(r(KeyCode::Up), Action::MoveUp);
-        assert_eq!(r(KeyCode::Char('g')), Action::JumpTop);
-        assert_eq!(r(KeyCode::Char('G')), Action::JumpBottom);
-        assert_eq!(r(KeyCode::Char('o')), Action::OpenInBrowser);
-        assert_eq!(r(KeyCode::Esc), Action::Back);
-        assert_eq!(r(KeyCode::Char('q')), Action::Back);
+        assert_eq!(r(KeyCode::Char('j')), Some(Action::MoveDown));
+        assert_eq!(r(KeyCode::Down), Some(Action::MoveDown));
+        assert_eq!(r(KeyCode::Char('k')), Some(Action::MoveUp));
+        assert_eq!(r(KeyCode::Up), Some(Action::MoveUp));
+        assert_eq!(r(KeyCode::Char('g')), Some(Action::JumpTop));
+        assert_eq!(r(KeyCode::Char('G')), Some(Action::JumpBottom));
+        assert_eq!(r(KeyCode::Char('o')), Some(Action::OpenInBrowser));
+        assert_eq!(r(KeyCode::Esc), Some(Action::Back));
+        assert_eq!(r(KeyCode::Char('q')), Some(Action::Back));
     }
 
     #[test]
     fn reader_ctrl_keys() {
         assert_eq!(
             map_key(ctrl('d'), false, true, false, InputMode::Normal),
-            Action::PageDown
+            Some(Action::PageDown)
         );
         assert_eq!(
             map_key(ctrl('u'), false, true, false, InputMode::Normal),
-            Action::PageUp
+            Some(Action::PageUp)
         );
     }
 
@@ -264,11 +272,11 @@ mod tests {
                 false,
                 InputMode::Normal
             ),
-            Action::None
+            None
         );
         assert_eq!(
             map_key(key(KeyCode::Enter), false, true, false, InputMode::Normal),
-            Action::None
+            None
         );
     }
 
@@ -277,31 +285,31 @@ mod tests {
     #[test]
     fn normal_quit_and_back() {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
-        assert_eq!(n(KeyCode::Char('q')), Action::Quit);
-        assert_eq!(n(KeyCode::Esc), Action::Back);
+        assert_eq!(n(KeyCode::Char('q')), Some(Action::Quit));
+        assert_eq!(n(KeyCode::Esc), Some(Action::Back));
     }
 
     #[test]
     fn normal_navigation() {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
-        assert_eq!(n(KeyCode::Char('j')), Action::MoveDown);
-        assert_eq!(n(KeyCode::Down), Action::MoveDown);
-        assert_eq!(n(KeyCode::Char('k')), Action::MoveUp);
-        assert_eq!(n(KeyCode::Up), Action::MoveUp);
-        assert_eq!(n(KeyCode::Enter), Action::Select);
-        assert_eq!(n(KeyCode::Char('g')), Action::JumpTop);
-        assert_eq!(n(KeyCode::Char('G')), Action::JumpBottom);
+        assert_eq!(n(KeyCode::Char('j')), Some(Action::MoveDown));
+        assert_eq!(n(KeyCode::Down), Some(Action::MoveDown));
+        assert_eq!(n(KeyCode::Char('k')), Some(Action::MoveUp));
+        assert_eq!(n(KeyCode::Up), Some(Action::MoveUp));
+        assert_eq!(n(KeyCode::Enter), Some(Action::Select));
+        assert_eq!(n(KeyCode::Char('g')), Some(Action::JumpTop));
+        assert_eq!(n(KeyCode::Char('G')), Some(Action::JumpBottom));
     }
 
     #[test]
     fn normal_ctrl_keys() {
         assert_eq!(
             map_key(ctrl('d'), false, false, false, InputMode::Normal),
-            Action::PageDown
+            Some(Action::PageDown)
         );
         assert_eq!(
             map_key(ctrl('u'), false, false, false, InputMode::Normal),
-            Action::PageUp
+            Some(Action::PageUp)
         );
     }
 
@@ -325,14 +333,14 @@ mod tests {
             ('6', 5),
             ('7', 6), // Pinned virtual feed
         ] {
-            assert_eq!(n(c), Action::SwitchFeed(idx));
+            assert_eq!(n(c), Some(Action::SwitchFeed(idx)));
         }
     }
 
     #[test]
     fn normal_b_toggles_pin() {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
-        assert_eq!(n(KeyCode::Char('b')), Action::TogglePin);
+        assert_eq!(n(KeyCode::Char('b')), Some(Action::TogglePin));
     }
 
     #[test]
@@ -341,13 +349,13 @@ mod tests {
         // not emit it (the reader's focused story is already known to the
         // user — pinning belongs in the underlying pane).
         let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
-        assert_eq!(r(KeyCode::Char('b')), Action::None);
+        assert_eq!(r(KeyCode::Char('b')), None);
     }
 
     #[test]
     fn prior_overlay_does_not_consume_b() {
         let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
-        assert_eq!(p(KeyCode::Char('b')), Action::None);
+        assert_eq!(p(KeyCode::Char('b')), None);
     }
 
     #[test]
@@ -361,23 +369,23 @@ mod tests {
                 false,
                 InputMode::SearchInput
             ),
-            Action::None
+            None
         );
     }
 
     #[test]
     fn normal_actions() {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
-        assert_eq!(n(KeyCode::Char('o')), Action::OpenInBrowser);
-        assert_eq!(n(KeyCode::Char('p')), Action::OpenReader);
-        assert_eq!(n(KeyCode::Char('h')), Action::TogglePriorDiscussions);
-        assert_eq!(n(KeyCode::Tab), Action::SwitchPane);
-        assert_eq!(n(KeyCode::BackTab), Action::SwitchPane);
-        assert_eq!(n(KeyCode::Left), Action::SwitchPane);
-        assert_eq!(n(KeyCode::Right), Action::SwitchPane);
-        assert_eq!(n(KeyCode::Char('r')), Action::Refresh);
-        assert_eq!(n(KeyCode::Char('/')), Action::EnterSearch);
-        assert_eq!(n(KeyCode::Char('?')), Action::ToggleHelp);
+        assert_eq!(n(KeyCode::Char('o')), Some(Action::OpenInBrowser));
+        assert_eq!(n(KeyCode::Char('p')), Some(Action::OpenReader));
+        assert_eq!(n(KeyCode::Char('h')), Some(Action::TogglePriorDiscussions));
+        assert_eq!(n(KeyCode::Tab), Some(Action::SwitchPane));
+        assert_eq!(n(KeyCode::BackTab), Some(Action::SwitchPane));
+        assert_eq!(n(KeyCode::Left), Some(Action::SwitchPane));
+        assert_eq!(n(KeyCode::Right), Some(Action::SwitchPane));
+        assert_eq!(n(KeyCode::Char('r')), Some(Action::Refresh));
+        assert_eq!(n(KeyCode::Char('/')), Some(Action::EnterSearch));
+        assert_eq!(n(KeyCode::Char('?')), Some(Action::ToggleHelp));
     }
 
     #[test]
@@ -390,7 +398,7 @@ mod tests {
                 false,
                 InputMode::Normal
             ),
-            Action::None
+            None
         );
     }
 
@@ -399,16 +407,16 @@ mod tests {
     #[test]
     fn prior_overlay_keymap() {
         let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
-        assert_eq!(p(KeyCode::Char('j')), Action::MoveDown);
-        assert_eq!(p(KeyCode::Down), Action::MoveDown);
-        assert_eq!(p(KeyCode::Char('k')), Action::MoveUp);
-        assert_eq!(p(KeyCode::Up), Action::MoveUp);
-        assert_eq!(p(KeyCode::Char('g')), Action::JumpTop);
-        assert_eq!(p(KeyCode::Char('G')), Action::JumpBottom);
-        assert_eq!(p(KeyCode::Enter), Action::Select);
-        assert_eq!(p(KeyCode::Char('o')), Action::OpenInBrowser);
-        assert_eq!(p(KeyCode::Esc), Action::Back);
-        assert_eq!(p(KeyCode::Char('q')), Action::Back);
+        assert_eq!(p(KeyCode::Char('j')), Some(Action::MoveDown));
+        assert_eq!(p(KeyCode::Down), Some(Action::MoveDown));
+        assert_eq!(p(KeyCode::Char('k')), Some(Action::MoveUp));
+        assert_eq!(p(KeyCode::Up), Some(Action::MoveUp));
+        assert_eq!(p(KeyCode::Char('g')), Some(Action::JumpTop));
+        assert_eq!(p(KeyCode::Char('G')), Some(Action::JumpBottom));
+        assert_eq!(p(KeyCode::Enter), Some(Action::Select));
+        assert_eq!(p(KeyCode::Char('o')), Some(Action::OpenInBrowser));
+        assert_eq!(p(KeyCode::Esc), Some(Action::Back));
+        assert_eq!(p(KeyCode::Char('q')), Some(Action::Back));
     }
 
     #[test]
@@ -416,10 +424,10 @@ mod tests {
         // Keys that would otherwise dispatch in normal mode — the overlay
         // should swallow them so e.g. `/` doesn't enter search underneath.
         let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
-        assert_eq!(p(KeyCode::Char('/')), Action::None);
-        assert_eq!(p(KeyCode::Char('1')), Action::None);
-        assert_eq!(p(KeyCode::Char('p')), Action::None);
-        assert_eq!(p(KeyCode::Char('h')), Action::None);
+        assert_eq!(p(KeyCode::Char('/')), None);
+        assert_eq!(p(KeyCode::Char('1')), None);
+        assert_eq!(p(KeyCode::Char('p')), None);
+        assert_eq!(p(KeyCode::Char('h')), None);
     }
 
     #[test]
@@ -434,7 +442,7 @@ mod tests {
                 true,
                 InputMode::Normal
             ),
-            Action::OpenInBrowser
+            Some(Action::OpenInBrowser)
         );
     }
 
@@ -448,7 +456,7 @@ mod tests {
                 true,
                 InputMode::Normal
             ),
-            Action::ToggleHelp
+            Some(Action::ToggleHelp)
         );
     }
 
@@ -456,8 +464,8 @@ mod tests {
 
     #[test]
     fn hint_mode_suppresses_all_keys() {
-        // Every key returns Action::None so main.rs can route raw chars
-        // to HintKey via the input-mode shortcut.
+        // Every key returns None so main.rs can route raw chars to
+        // HintKey via the input-mode shortcut.
         assert_eq!(
             map_key(
                 key(KeyCode::Char('a')),
@@ -466,11 +474,11 @@ mod tests {
                 false,
                 InputMode::HintMode
             ),
-            Action::None
+            None
         );
         assert_eq!(
             map_key(key(KeyCode::Esc), false, false, false, InputMode::HintMode),
-            Action::None
+            None
         );
         assert_eq!(
             map_key(
@@ -480,7 +488,7 @@ mod tests {
                 false,
                 InputMode::HintMode
             ),
-            Action::None
+            None
         );
         // Even with overlays and help flagged, HintMode wins.
         assert_eq!(
@@ -491,7 +499,7 @@ mod tests {
                 true,
                 InputMode::HintMode
             ),
-            Action::None
+            None
         );
     }
 
@@ -500,7 +508,7 @@ mod tests {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(
             n(KeyCode::Char('f')),
-            Action::EnterHintMode(HintAction::Open)
+            Some(Action::EnterHintMode(HintAction::Open))
         );
     }
 
@@ -509,7 +517,7 @@ mod tests {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(
             n(KeyCode::Char('F')),
-            Action::EnterHintMode(HintAction::OpenInReader)
+            Some(Action::EnterHintMode(HintAction::OpenInReader))
         );
     }
 
@@ -518,7 +526,7 @@ mod tests {
         let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
         assert_eq!(
             n(KeyCode::Char('y')),
-            Action::EnterHintMode(HintAction::CopyUrl)
+            Some(Action::EnterHintMode(HintAction::CopyUrl))
         );
     }
 
@@ -527,15 +535,15 @@ mod tests {
         let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
         assert_eq!(
             r(KeyCode::Char('f')),
-            Action::EnterHintMode(HintAction::Open)
+            Some(Action::EnterHintMode(HintAction::Open))
         );
         assert_eq!(
             r(KeyCode::Char('F')),
-            Action::EnterHintMode(HintAction::OpenInReader)
+            Some(Action::EnterHintMode(HintAction::OpenInReader))
         );
         assert_eq!(
             r(KeyCode::Char('y')),
-            Action::EnterHintMode(HintAction::CopyUrl)
+            Some(Action::EnterHintMode(HintAction::CopyUrl))
         );
     }
 
@@ -544,9 +552,9 @@ mod tests {
         // Prior overlay's keymap should still consume f/F/y as None — those
         // keys only make sense in reader/comments contexts.
         let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
-        assert_eq!(p(KeyCode::Char('f')), Action::None);
-        assert_eq!(p(KeyCode::Char('F')), Action::None);
-        assert_eq!(p(KeyCode::Char('y')), Action::None);
+        assert_eq!(p(KeyCode::Char('f')), None);
+        assert_eq!(p(KeyCode::Char('F')), None);
+        assert_eq!(p(KeyCode::Char('y')), None);
     }
 
     #[test]
@@ -562,8 +570,8 @@ mod tests {
                 InputMode::SearchInput,
             )
         };
-        assert_eq!(s('f'), Action::None);
-        assert_eq!(s('F'), Action::None);
-        assert_eq!(s('y'), Action::None);
+        assert_eq!(s('f'), None);
+        assert_eq!(s('F'), None);
+        assert_eq!(s('y'), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod article;
 mod clipboard;
 mod event;
 mod keys;
+mod sanitize;
 mod state;
 mod tui;
 mod ui;
@@ -75,14 +76,15 @@ async fn main() -> Result<()> {
                     _ => {}
                 },
                 InputMode::Normal => {
-                    let action = keys::map_key(
+                    if let Some(action) = keys::map_key(
                         key,
                         app.show_help,
                         app.reader_state.is_some(),
                         app.prior_state.is_some(),
                         app.input_mode,
-                    );
-                    app.dispatch(action);
+                    ) {
+                        app.dispatch(action);
+                    }
                 }
             },
             Event::Mouse(mouse) => {
@@ -100,8 +102,8 @@ async fn main() -> Result<()> {
                     _ => {}
                 }
             }
-            Event::Resize(w, h) => {
-                app.set_terminal_size(w, h);
+            Event::Resize { width, height } => {
+                app.set_terminal_size(width, height);
             }
             Event::Tick => {
                 app.tick_count = app.tick_count.wrapping_add(1);

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -24,7 +24,13 @@ pub fn sanitize_terminal(s: &str) -> Cow<'_, str> {
     }
     Cow::Owned(
         s.chars()
-            .map(|c| if is_control_to_strip(c) { '\u{FFFD}' } else { c })
+            .map(|c| {
+                if is_control_to_strip(c) {
+                    '\u{FFFD}'
+                } else {
+                    c
+                }
+            })
             .collect(),
     )
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,99 @@
+//! Strip terminal control bytes from untrusted HN content.
+//!
+//! HN comments and titles flow through `html2text`, which decodes HTML
+//! entities — so a comment containing `&#x1b;[2J` re-emerges as a raw
+//! `0x1B` byte. ratatui forwards bytes to the terminal verbatim, which
+//! lets a malicious submitter rewrite the user's window title, palette,
+//! scroll region, or (on some terminals) trigger query responses that
+//! could cause command injection. The fix: replace C0/C1 controls and
+//! DEL with the Unicode replacement glyph before they reach a `Span`.
+//!
+//! `\t` and `\n` are preserved because ratatui itself handles those
+//! glyphs; everything else in the C0 range, plus `0x7F` (DEL) and the
+//! C1 range (`0x80..=0x9F`), is replaced.
+
+use std::borrow::Cow;
+
+/// Returns `s` unchanged if it contains no control bytes, otherwise an
+/// owned [`String`] with `\u{FFFD}` (REPLACEMENT CHARACTER) substituted
+/// for any C0 / C1 / DEL byte. `\t` (0x09) and `\n` (0x0A) are kept.
+#[must_use]
+pub fn sanitize_terminal(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(is_control_to_strip) {
+        return Cow::Borrowed(s);
+    }
+    Cow::Owned(
+        s.chars()
+            .map(|c| if is_control_to_strip(c) { '\u{FFFD}' } else { c })
+            .collect(),
+    )
+}
+
+#[inline]
+fn is_control_to_strip(c: char) -> bool {
+    match c {
+        '\t' | '\n' => false,
+        '\u{0000}'..='\u{001F}' => true,
+        '\u{007F}' => true,
+        '\u{0080}'..='\u{009F}' => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_ascii_is_borrowed_unchanged() {
+        let s = "hello world";
+        let out = sanitize_terminal(s);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn unicode_letters_are_borrowed() {
+        let s = "café résumé 日本語";
+        let out = sanitize_terminal(s);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn esc_is_replaced() {
+        let s = "before\x1b[2Jafter";
+        let out = sanitize_terminal(s);
+        assert_eq!(out, "before\u{FFFD}[2Jafter");
+    }
+
+    #[test]
+    fn osc_window_title_is_neutralised() {
+        // OSC 0; sets terminal title — most damaging in practice.
+        let s = "\x1b]0;owned\x07";
+        let out = sanitize_terminal(s);
+        assert!(!out.contains('\x1b'));
+        assert!(!out.contains('\x07'));
+    }
+
+    #[test]
+    fn tab_and_newline_are_preserved() {
+        let s = "a\tb\nc";
+        let out = sanitize_terminal(s);
+        assert_eq!(out, "a\tb\nc");
+    }
+
+    #[test]
+    fn del_byte_is_replaced() {
+        let s = "x\x7fy";
+        let out = sanitize_terminal(s);
+        assert_eq!(out, "x\u{FFFD}y");
+    }
+
+    #[test]
+    fn c1_range_is_replaced() {
+        let s = "x\u{0085}y\u{0090}z";
+        let out = sanitize_terminal(s);
+        assert_eq!(out, "x\u{FFFD}y\u{FFFD}z");
+    }
+}

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -57,7 +57,13 @@ impl FlatComment {
         let needs_refresh = !matches!(&self.plain_text_cache, Some((w, _)) if *w == width);
         if needs_refresh {
             let rendered = html2text::from_read(text.as_bytes(), width.max(20)).unwrap_or_default();
-            self.plain_text_cache = Some((width, rendered));
+            // Strip terminal control bytes that html2text re-emits via
+            // entity-decoded HTML (e.g. `&#x1b;`). Otherwise a malicious
+            // comment could rewrite the user's terminal title or palette.
+            self.plain_text_cache = Some((
+                width,
+                crate::sanitize::sanitize_terminal(&rendered).into_owned(),
+            ));
         }
         self.plain_text_cache.as_ref().map(|(_, s)| s.as_str())
     }
@@ -111,7 +117,11 @@ impl CommentTreeState {
             !matches!(&self.story_text_cache, Some((cid, w, _)) if *cid == id && *w == width);
         if needs_refresh {
             let rendered = html2text::from_read(text.as_bytes(), width.max(20)).unwrap_or_default();
-            self.story_text_cache = Some((id, width, rendered));
+            self.story_text_cache = Some((
+                id,
+                width,
+                crate::sanitize::sanitize_terminal(&rendered).into_owned(),
+            ));
         }
         self.story_text_cache.as_ref().map(|(_, _, s)| s.as_str())
     }
@@ -153,34 +163,32 @@ impl CommentTreeState {
     /// coherently. Returns `None` for [`CommentFilter::All`] — callers
     /// treat that as "everything passes."
     ///
-    /// O(comments) for the matching scan plus O(matches × tree_depth) for
-    /// the ancestor walk. The flat list is in pre-order, so each ancestor
-    /// is found by walking backwards over strictly-decreasing depths.
+    /// O(n) using a single forward pass: maintains a `path` stack of
+    /// ancestor indices at strictly-decreasing depths, then unions the
+    /// current path into `keep` whenever a comment passes the filter.
     fn filter_visible_set(&self) -> Option<HashSet<usize>> {
         let threshold = match self.filter {
             CommentFilter::All => return None,
             CommentFilter::NewSince(t) | CommentFilter::Recent(t) => t,
         };
-        let mut keep = HashSet::new();
+        let mut keep: HashSet<usize> = HashSet::new();
+        let mut path: Vec<usize> = Vec::with_capacity(16);
         for (i, c) in self.comments.iter().enumerate() {
-            if c.item.time.is_none_or(|t| t <= threshold) {
-                continue;
+            // Pop any ancestors at or above this depth — they can't be on
+            // the path to `i`.
+            while path
+                .last()
+                .is_some_and(|&p| self.comments[p].depth >= c.depth)
+            {
+                path.pop();
             }
-            keep.insert(i);
-            let mut wanted_depth = c.depth;
-            if wanted_depth == 0 {
-                continue;
-            }
-            for j in (0..i).rev() {
-                let d = self.comments[j].depth;
-                if d < wanted_depth {
-                    keep.insert(j);
-                    wanted_depth = d;
-                    if d == 0 {
-                        break;
-                    }
+            if c.item.time.is_some_and(|t| t > threshold) {
+                for &p in &path {
+                    keep.insert(p);
                 }
+                keep.insert(i);
             }
+            path.push(i);
         }
         Some(keep)
     }

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -18,8 +18,14 @@ pub struct LinkRef {
     /// Line index within the rendered `Vec<Vec<StyledFragment>>`.
     pub line: usize,
     /// Fragment index within that line; the label paints at this fragment's
-    /// first column, so the column offset = sum of preceding fragment widths.
+    /// first column. Kept for diagnostics — see `col` for the value the
+    /// renderer actually consumes.
     pub fragment: usize,
+    /// Visible-column offset of the link's first character, computed
+    /// once when the registry is built. Used by the hint-overlay paint
+    /// so it doesn't sum `chars().count()` across preceding fragments
+    /// on every keystroke.
+    pub col: usize,
     /// Assigned by [`LinkRegistry::assign_labels`]. Empty until then.
     pub label: String,
 }
@@ -56,13 +62,17 @@ impl LinkRegistry {
         self.links.is_empty()
     }
 
-    /// Records a new link at `(line, fragment)`. The `label` is left empty
-    /// until [`Self::assign_labels`] is called once all links are pushed.
-    pub fn push(&mut self, url: String, line: usize, fragment: usize) {
+    /// Records a new link at `(line, fragment, col)`. `col` is the
+    /// visible-column offset of the link text within its line, computed
+    /// once at registry-build time so the hint paint doesn't re-sum
+    /// fragment widths per keystroke. The `label` is left empty until
+    /// [`Self::assign_labels`] is called once all links are pushed.
+    pub fn push(&mut self, url: String, line: usize, fragment: usize, col: usize) {
         self.links.push(LinkRef {
             url,
             line,
             fragment,
+            col,
             label: String::new(),
         });
     }
@@ -103,14 +113,19 @@ impl LinkRegistry {
 /// length `length`, big-endian. Index 0 → "aa…a", index 1 → "aa…s", etc.
 fn generate_label(index: usize, length: usize) -> String {
     let alphabet_len = ALPHABET.len();
-    let mut chars = Vec::with_capacity(length);
+    let mut out = String::with_capacity(length);
     let mut n = index;
+    let mut chars: Vec<char> = Vec::with_capacity(length);
     for _ in 0..length {
-        chars.push(ALPHABET[n % alphabet_len]);
+        // ALPHABET is a literal ASCII byte slice; the cast is safe by
+        // construction. Building the string via `char` removes the
+        // panicking `String::from_utf8(...).expect(...)`.
+        chars.push(ALPHABET[n % alphabet_len] as char);
         n /= alphabet_len;
     }
     chars.reverse();
-    String::from_utf8(chars).expect("ALPHABET is valid ASCII")
+    out.extend(chars);
+    out
 }
 
 #[cfg(test)]
@@ -120,7 +135,7 @@ mod tests {
     fn registry_with(n: usize) -> LinkRegistry {
         let mut r = LinkRegistry::new();
         for i in 0..n {
-            r.push(format!("https://example.com/{}", i), i, 0);
+            r.push(format!("https://example.com/{}", i), i, 0, 0);
         }
         r.assign_labels();
         r
@@ -136,11 +151,12 @@ mod tests {
     #[test]
     fn push_adds_link_without_label() {
         let mut r = LinkRegistry::new();
-        r.push("https://x.com".into(), 5, 2);
+        r.push("https://x.com".into(), 5, 2, 17);
         assert_eq!(r.links.len(), 1);
         assert_eq!(r.links[0].url, "https://x.com");
         assert_eq!(r.links[0].line, 5);
         assert_eq!(r.links[0].fragment, 2);
+        assert_eq!(r.links[0].col, 17);
         assert!(r.links[0].label.is_empty());
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -14,6 +14,7 @@
 pub mod comment_state;
 pub mod hint_state;
 pub mod link_registry;
+mod persist;
 pub mod pin_store;
 pub mod prior_state;
 pub mod read_store;

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -1,0 +1,318 @@
+//! Generic JSON-backed entry store shared by [`crate::state::read_store`]
+//! and [`crate::state::pin_store`].
+//!
+//! Both stores persist a `HashMap<StoryId, E>` to a single JSON file with
+//! atomic tmp+rename writes, corrupt-file recovery, and an LRU-style cap
+//! by an entry-defined age key. Splitting them out keeps the per-store
+//! modules focused on their domain APIs.
+
+use crate::api::types::StoryId;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// One persisted entry — must be cheaply clonable, JSON-serializable, and
+/// expose an age key (Unix seconds) used as the LRU eviction order.
+pub(crate) trait PersistedEntry: Clone + Serialize + DeserializeOwned {
+    fn age_key(&self) -> i64;
+}
+
+#[derive(Serialize, Deserialize)]
+struct DiskStore<E> {
+    version: u32,
+    #[serde(default = "HashMap::new")]
+    entries: HashMap<String, E>,
+}
+
+/// Generic on-disk store keyed by [`StoryId`] with a soft-capped entry
+/// count and atomic disk writes. Domain wrappers ([`crate::state::read_store::ReadStore`],
+/// [`crate::state::pin_store::PinStore`]) compose around this.
+pub(crate) struct JsonStore<E: PersistedEntry> {
+    pub entries: HashMap<StoryId, E>,
+    pub path: Option<PathBuf>,
+    pub dirty: bool,
+    max_entries: usize,
+    schema_version: u32,
+}
+
+impl<E: PersistedEntry> JsonStore<E> {
+    /// In-memory-only store with no persistence path.
+    pub fn empty(max_entries: usize, schema_version: u32) -> Self {
+        Self {
+            entries: HashMap::new(),
+            path: None,
+            dirty: false,
+            max_entries,
+            schema_version,
+        }
+    }
+
+    /// Loads from `path`, returning an empty (but path-bound) store on
+    /// missing or corrupt files. Subsequent [`Self::save`] writes the path
+    /// regardless.
+    pub fn load_from(path: PathBuf, max_entries: usize, schema_version: u32) -> Self {
+        let entries = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<DiskStore<E>>(&raw).ok())
+            .map(|disk| {
+                disk.entries
+                    .into_iter()
+                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (StoryId(id), v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            entries,
+            path: Some(path),
+            dirty: false,
+            max_entries,
+            schema_version,
+        }
+    }
+
+    /// Inserts or replaces `id`'s entry, then evicts oldest entries if
+    /// the store has overflowed `max_entries`. Marks dirty.
+    pub fn insert(&mut self, id: StoryId, entry: E) {
+        self.entries.insert(id, entry);
+        if self.entries.len() > self.max_entries {
+            self.evict_oldest();
+        }
+        self.dirty = true;
+    }
+
+    /// Removes `id`. Returns whether anything was removed and marks dirty
+    /// only on a real change.
+    pub fn remove(&mut self, id: StoryId) -> bool {
+        if self.entries.remove(&id).is_some() {
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Writes the store to disk if dirty. No-op for in-memory-only or
+    /// clean stores. Atomic tmp+rename; failures are silently swallowed
+    /// because both consumers are non-critical.
+    pub fn save(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        let disk = DiskStore {
+            version: self.schema_version,
+            entries: self
+                .entries
+                .iter()
+                .map(|(&id, entry)| (id.0.to_string(), entry.clone()))
+                .collect(),
+        };
+        let Ok(json) = serde_json::to_string(&disk) else {
+            return;
+        };
+
+        // Best-effort dir creation. On Unix tighten to 0700 so per-user
+        // history isn't world-readable on shared hosts.
+        if let Some(parent) = path.parent() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt;
+                let _ = std::fs::DirBuilder::new()
+                    .recursive(true)
+                    .mode(0o700)
+                    .create(parent);
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+
+        let tmp = path.with_extension("json.tmp");
+        if write_atomic(&tmp, &json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
+            self.dirty = false;
+        } else {
+            // Clean up a stranded tmp on failure so we don't leak files.
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+
+    /// Drops entries with the lowest [`PersistedEntry::age_key`] until the
+    /// store is back within `max_entries`.
+    fn evict_oldest(&mut self) {
+        let mut ages: Vec<(i64, StoryId)> = self
+            .entries
+            .iter()
+            .map(|(&id, e)| (e.age_key(), id))
+            .collect();
+        ages.sort_unstable();
+        let excess = self.entries.len().saturating_sub(self.max_entries);
+        for (_, id) in ages.into_iter().take(excess) {
+            self.entries.remove(&id);
+        }
+    }
+}
+
+/// Writes `json` to `path` with mode 0600 on Unix (so other users on a
+/// shared host can't read pinned/read history). Existing files are
+/// truncated.
+fn write_atomic(path: &std::path::Path, json: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(json.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, json)?;
+    }
+    Ok(())
+}
+
+/// Resolves an XDG data path under `hnt/`. Tries `$XDG_DATA_HOME` first
+/// (rejecting non-absolute values per the XDG spec), falls back to
+/// `$HOME/.local/share`, and returns `None` if neither is usable (rare —
+/// containers without a `HOME`).
+pub(crate) fn xdg_data_path(filename: &str) -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        let p = PathBuf::from(&xdg);
+        if !xdg.is_empty() && p.is_absolute() {
+            return Some(p.join("hnt").join(filename));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(
+        PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("hnt")
+            .join(filename),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestEntry {
+        ts: i64,
+        n: u32,
+    }
+    impl PersistedEntry for TestEntry {
+        fn age_key(&self) -> i64 {
+            self.ts
+        }
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "hnt_persist_test_{}_{}.json",
+            name,
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn roundtrip_through_disk() {
+        let p = tmp("roundtrip");
+        let _ = std::fs::remove_file(&p);
+        {
+            let mut s = JsonStore::<TestEntry>::load_from(p.clone(), 100, 1);
+            s.insert(StoryId(1), TestEntry { ts: 10, n: 1 });
+            s.insert(StoryId(2), TestEntry { ts: 20, n: 2 });
+            s.save();
+        }
+        let s2 = JsonStore::<TestEntry>::load_from(p.clone(), 100, 1);
+        assert_eq!(s2.entries.len(), 2);
+        assert_eq!(s2.entries[&StoryId(1)].n, 1);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn corrupt_file_loads_as_empty() {
+        let p = tmp("corrupt");
+        std::fs::write(&p, "{not valid json").unwrap();
+        let s = JsonStore::<TestEntry>::load_from(p.clone(), 100, 1);
+        assert!(s.entries.is_empty());
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn evicts_oldest_when_over_cap() {
+        let mut s = JsonStore::<TestEntry>::empty(3, 1);
+        for i in 0..5 {
+            s.insert(StoryId(i), TestEntry { ts: i as i64, n: 0 });
+        }
+        assert_eq!(s.entries.len(), 3);
+        // oldest two (ts=0,1) should be gone; ts=2,3,4 retained
+        assert!(!s.entries.contains_key(&StoryId(0)));
+        assert!(!s.entries.contains_key(&StoryId(1)));
+        assert!(s.entries.contains_key(&StoryId(4)));
+    }
+
+    #[test]
+    fn save_is_noop_when_clean() {
+        let p = tmp("save_noop");
+        let _ = std::fs::remove_file(&p);
+        let mut s = JsonStore::<TestEntry>::load_from(p.clone(), 100, 1);
+        s.save();
+        assert!(!p.exists());
+    }
+
+    #[test]
+    fn xdg_path_rejects_non_absolute() {
+        // Save and clear environment to avoid polluting other tests.
+        let prev_xdg = std::env::var("XDG_DATA_HOME").ok();
+        let prev_home = std::env::var("HOME").ok();
+        // SAFETY: Tests run single-threaded by default (Cargo serializes
+        // env tests via `--test-threads`), and we restore both vars before
+        // returning.
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", "relative/path");
+            std::env::set_var("HOME", "/home/test");
+            let p = xdg_data_path("read.json").unwrap();
+            assert!(p.starts_with("/home/test/.local/share/hnt"));
+            // Now an absolute XDG should win.
+            std::env::set_var("XDG_DATA_HOME", "/var/data");
+            let p = xdg_data_path("read.json").unwrap();
+            assert!(p.starts_with("/var/data/hnt"));
+            // Restore.
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_creates_file_with_user_only_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let p = tmp("perms");
+        let _ = std::fs::remove_file(&p);
+        let mut s = JsonStore::<TestEntry>::load_from(p.clone(), 100, 1);
+        s.insert(StoryId(1), TestEntry { ts: 1, n: 1 });
+        s.save();
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "saved file mode should be 0o600, got {:o}", mode);
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -312,7 +312,11 @@ mod tests {
         s.insert(StoryId(1), TestEntry { ts: 1, n: 1 });
         s.save();
         let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "saved file mode should be 0o600, got {:o}", mode);
+        assert_eq!(
+            mode, 0o600,
+            "saved file mode should be 0o600, got {:o}",
+            mode
+        );
         let _ = std::fs::remove_file(&p);
     }
 }

--- a/src/state/pin_store.rs
+++ b/src/state/pin_store.rs
@@ -12,11 +12,12 @@
 //! resolve the path or read the file leave the store in-memory only —
 //! the feature still works within the session but is not persisted across
 //! restarts. Mirrors [`crate::state::read_store::ReadStore`]'s atomic
-//! tmp+rename write, version field, and corrupt-file recovery.
+//! tmp+rename write, version field, and corrupt-file recovery via the
+//! shared [`crate::state::persist::JsonStore`] helper.
 
 use crate::api::types::StoryId;
+use crate::state::persist::{xdg_data_path, JsonStore, PersistedEntry};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Soft cap on stored pins. Oldest (lowest `pinned_at`) entries are
@@ -51,6 +52,12 @@ pub struct PinEntry {
     pub collapsed: Vec<u64>,
 }
 
+impl PersistedEntry for PinEntry {
+    fn age_key(&self) -> i64 {
+        self.pinned_at
+    }
+}
+
 /// In-memory pinned-store with JSON-file persistence.
 ///
 /// Constructed via [`PinStore::load`] at startup. Add a pin with
@@ -60,16 +67,7 @@ pub struct PinEntry {
 /// [`PinStore::resume_for`], [`PinStore::pinned_ids_newest_first`]) are
 /// cheap.
 pub struct PinStore {
-    entries: HashMap<StoryId, PinEntry>,
-    path: Option<PathBuf>,
-    dirty: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct DiskStore {
-    version: u32,
-    #[serde(default)]
-    entries: HashMap<String, PinEntry>,
+    inner: JsonStore<PinEntry>,
 }
 
 impl PinStore {
@@ -77,9 +75,7 @@ impl PinStore {
     /// default XDG path can't be resolved.
     pub fn empty() -> Self {
         Self {
-            entries: HashMap::new(),
-            path: None,
-            dirty: false,
+            inner: JsonStore::empty(MAX_ENTRIES, SCHEMA_VERSION),
         }
     }
 
@@ -88,7 +84,7 @@ impl PinStore {
     /// in-memory store if the path can't be resolved or the file is
     /// missing/corrupt.
     pub fn load() -> Self {
-        match default_path() {
+        match xdg_data_path("pinned.json") {
             Some(path) => Self::load_from(path),
             None => Self::empty(),
         }
@@ -98,20 +94,8 @@ impl PinStore {
     /// produces an empty store with `path` still set as the save target —
     /// the next [`PinStore::save`] will replace it.
     pub fn load_from(path: PathBuf) -> Self {
-        let entries = std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|raw| serde_json::from_str::<DiskStore>(&raw).ok())
-            .map(|disk| {
-                disk.entries
-                    .into_iter()
-                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (StoryId(id), v)))
-                    .collect()
-            })
-            .unwrap_or_default();
         Self {
-            entries,
-            path: Some(path),
-            dirty: false,
+            inner: JsonStore::load_from(path, MAX_ENTRIES, SCHEMA_VERSION),
         }
     }
 
@@ -121,30 +105,7 @@ impl PinStore {
     /// Failures (permissions, missing parent, disk full) are silently
     /// swallowed — pin-state is non-critical.
     pub fn save(&mut self) {
-        if !self.dirty {
-            return;
-        }
-        let Some(path) = self.path.as_ref() else {
-            return;
-        };
-        let disk = DiskStore {
-            version: SCHEMA_VERSION,
-            entries: self
-                .entries
-                .iter()
-                .map(|(&id, entry)| (id.0.to_string(), entry.clone()))
-                .collect(),
-        };
-        let Ok(json) = serde_json::to_string(&disk) else {
-            return;
-        };
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let tmp = path.with_extension("json.tmp");
-        if std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
-            self.dirty = false;
-        }
+        self.inner.save();
     }
 
     /// Pins `id` with the current wall-clock timestamp and a default
@@ -158,10 +119,10 @@ impl PinStore {
     /// Variant of [`PinStore::pin`] that uses an explicit timestamp —
     /// used by tests to keep behavior deterministic.
     pub fn pin_at(&mut self, id: StoryId, now: i64) {
-        if self.entries.contains_key(&id) {
+        if self.inner.entries.contains_key(&id) {
             return;
         }
-        self.entries.insert(
+        self.inner.insert(
             id,
             PinEntry {
                 pinned_at: now,
@@ -169,35 +130,26 @@ impl PinStore {
                 collapsed: Vec::new(),
             },
         );
-        if self.entries.len() > MAX_ENTRIES {
-            self.evict_oldest();
-        }
-        self.dirty = true;
     }
 
     /// Unpins `id`. No-op if not pinned. Returns whether anything was
     /// removed (useful for callers that want to flag the store dirty
     /// only on a real change).
     pub fn unpin(&mut self, id: StoryId) -> bool {
-        if self.entries.remove(&id).is_some() {
-            self.dirty = true;
-            true
-        } else {
-            false
-        }
+        self.inner.remove(id)
     }
 
     /// Whether `id` is currently pinned.
     #[must_use]
     pub fn is_pinned(&self, id: StoryId) -> bool {
-        self.entries.contains_key(&id)
+        self.inner.entries.contains_key(&id)
     }
 
     /// Snapshot the user's reading position for `id`. No-op if `id` isn't
     /// pinned — only deliberately-curated stories get their position
     /// remembered.
     pub fn update_resume(&mut self, id: StoryId, selected: usize, collapsed: Vec<u64>) {
-        let Some(entry) = self.entries.get_mut(&id) else {
+        let Some(entry) = self.inner.entries.get_mut(&id) else {
             return;
         };
         // Skip a write (and `dirty`) when nothing actually changed —
@@ -207,14 +159,14 @@ impl PinStore {
         }
         entry.selected = selected;
         entry.collapsed = collapsed;
-        self.dirty = true;
+        self.inner.dirty = true;
     }
 
     /// Persisted entry for `id`, if any. Used by the comment-load path to
     /// restore reading position once the thread has finished loading.
     #[must_use]
     pub fn resume_for(&self, id: StoryId) -> Option<&PinEntry> {
-        self.entries.get(&id)
+        self.inner.entries.get(&id)
     }
 
     /// Pinned story IDs in newest-first order — the listing the Pinned
@@ -225,6 +177,7 @@ impl PinStore {
     #[must_use]
     pub fn pinned_ids_newest_first(&self) -> Vec<u64> {
         let mut entries: Vec<(i64, StoryId)> = self
+            .inner
             .entries
             .iter()
             .map(|(&id, e)| (e.pinned_at, id))
@@ -235,48 +188,24 @@ impl PinStore {
         entries.into_iter().map(|(_, id)| id.0).collect()
     }
 
-    /// Drops entries with the lowest `pinned_at` until the store is
-    /// back within [`MAX_ENTRIES`].
-    fn evict_oldest(&mut self) {
-        let mut ages: Vec<(i64, StoryId)> = self
-            .entries
-            .iter()
-            .map(|(&id, e)| (e.pinned_at, id))
-            .collect();
-        ages.sort_unstable();
-        let excess = self.entries.len().saturating_sub(MAX_ENTRIES);
-        for (_, id) in ages.into_iter().take(excess) {
-            self.entries.remove(&id);
-        }
-    }
-
     /// Number of pinned entries. Exposed for tests and diagnostics.
     #[cfg(test)]
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.inner.entries.len()
     }
-}
 
-/// Resolves the default persistence path: `$XDG_DATA_HOME/hnt/pinned.json`,
-/// falling back to `$HOME/.local/share/hnt/pinned.json`. Returns `None` if
-/// neither variable is set (rare — containers with no `HOME`).
-fn default_path() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
-        if !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join("hnt").join("pinned.json"));
-        }
+    /// Test-only: clear the dirty flag (simulate "just saved" without
+    /// hitting disk).
+    #[cfg(test)]
+    pub(crate) fn clear_dirty(&mut self) {
+        self.inner.dirty = false;
     }
-    let home = std::env::var("HOME").ok()?;
-    if home.is_empty() {
-        return None;
+
+    /// Test-only: read the dirty flag.
+    #[cfg(test)]
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.inner.dirty
     }
-    Some(
-        PathBuf::from(home)
-            .join(".local")
-            .join("share")
-            .join("hnt")
-            .join("pinned.json"),
-    )
 }
 
 #[cfg(test)]
@@ -382,10 +311,10 @@ mod tests {
     fn update_resume_no_change_does_not_dirty() {
         let mut s = fresh_store("no_change");
         s.pin_at(sid(42), 1_700_000_000);
-        s.dirty = false; // simulate "just saved"
+        s.clear_dirty(); // simulate "just saved"
         s.update_resume(sid(42), 0, Vec::new());
         assert!(
-            !s.dirty,
+            !s.is_dirty(),
             "equal-value resume update must not dirty the store"
         );
     }

--- a/src/state/read_store.rs
+++ b/src/state/read_store.rs
@@ -10,8 +10,8 @@
 //! still works within the session but is not persisted across restarts.
 
 use crate::api::types::StoryId;
+use crate::state::persist::{xdg_data_path, JsonStore, PersistedEntry};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Soft cap on stored entries. Oldest (lowest `last_seen_at`) entries are
@@ -32,6 +32,12 @@ pub struct ReadEntry {
     pub last_comment_count: i64,
 }
 
+impl PersistedEntry for ReadEntry {
+    fn age_key(&self) -> i64 {
+        self.last_seen_at
+    }
+}
+
 /// In-memory read-state store with JSON-file persistence.
 ///
 /// Constructed via [`ReadStore::load`] at startup. Mark a story as visited
@@ -42,16 +48,7 @@ pub struct ReadEntry {
 /// comment IDs. The JSON on disk still uses stringified-u64 keys —
 /// conversion happens at the serde boundary.
 pub struct ReadStore {
-    entries: HashMap<StoryId, ReadEntry>,
-    path: Option<PathBuf>,
-    dirty: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct DiskStore {
-    version: u32,
-    #[serde(default)]
-    entries: HashMap<String, ReadEntry>,
+    inner: JsonStore<ReadEntry>,
 }
 
 impl ReadStore {
@@ -59,9 +56,7 @@ impl ReadStore {
     /// default XDG path can't be resolved.
     pub fn empty() -> Self {
         Self {
-            entries: HashMap::new(),
-            path: None,
-            dirty: false,
+            inner: JsonStore::empty(MAX_ENTRIES, SCHEMA_VERSION),
         }
     }
 
@@ -70,7 +65,7 @@ impl ReadStore {
     /// in-memory store if the path can't be resolved or the file is
     /// missing/corrupt.
     pub fn load() -> Self {
-        match default_path() {
+        match xdg_data_path("read.json") {
             Some(path) => Self::load_from(path),
             None => Self::empty(),
         }
@@ -80,20 +75,8 @@ impl ReadStore {
     /// produces an empty store with `path` still set as the save target —
     /// the next [`ReadStore::save`] will replace it.
     pub fn load_from(path: PathBuf) -> Self {
-        let entries = std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|raw| serde_json::from_str::<DiskStore>(&raw).ok())
-            .map(|disk| {
-                disk.entries
-                    .into_iter()
-                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (StoryId(id), v)))
-                    .collect()
-            })
-            .unwrap_or_default();
         Self {
-            entries,
-            path: Some(path),
-            dirty: false,
+            inner: JsonStore::load_from(path, MAX_ENTRIES, SCHEMA_VERSION),
         }
     }
 
@@ -103,30 +86,7 @@ impl ReadStore {
     /// Failures (permissions, missing parent, disk full) are silently
     /// swallowed — read-state is non-critical.
     pub fn save(&mut self) {
-        if !self.dirty {
-            return;
-        }
-        let Some(path) = self.path.as_ref() else {
-            return;
-        };
-        let disk = DiskStore {
-            version: SCHEMA_VERSION,
-            entries: self
-                .entries
-                .iter()
-                .map(|(&id, entry)| (id.0.to_string(), *entry))
-                .collect(),
-        };
-        let Ok(json) = serde_json::to_string(&disk) else {
-            return;
-        };
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let tmp = path.with_extension("json.tmp");
-        if std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
-            self.dirty = false;
-        }
+        self.inner.save();
     }
 
     /// Records or refreshes the entry for `id` with the current wall-clock
@@ -139,23 +99,19 @@ impl ReadStore {
     /// Variant of [`ReadStore::mark`] that uses an explicit timestamp —
     /// used by tests to keep behavior deterministic.
     pub fn mark_at(&mut self, id: StoryId, current_comment_count: i64, now: i64) {
-        self.entries.insert(
+        self.inner.insert(
             id,
             ReadEntry {
                 last_seen_at: now,
                 last_comment_count: current_comment_count,
             },
         );
-        if self.entries.len() > MAX_ENTRIES {
-            self.evict_oldest();
-        }
-        self.dirty = true;
     }
 
     /// Returns whether `id` has ever been visited.
     #[must_use]
     pub fn is_read(&self, id: StoryId) -> bool {
-        self.entries.contains_key(&id)
+        self.inner.entries.contains_key(&id)
     }
 
     /// Wall-clock timestamp (Unix seconds) of the last visit to `id`, if
@@ -163,13 +119,13 @@ impl ReadStore {
     /// older than the user's previous visit as already-seen.
     #[must_use]
     pub fn last_seen_at(&self, id: StoryId) -> Option<i64> {
-        self.entries.get(&id).map(|e| e.last_seen_at)
+        self.inner.entries.get(&id).map(|e| e.last_seen_at)
     }
 
     /// Persisted entry for `id`, if any.
     #[cfg(test)]
     pub fn entry(&self, id: StoryId) -> Option<&ReadEntry> {
-        self.entries.get(&id)
+        self.inner.entries.get(&id)
     }
 
     /// New comments since the last visit, if any. Returns `Some(n)` when
@@ -177,52 +133,15 @@ impl ReadStore {
     /// comments. A shrinking count (rare — deletions) is clamped to `None`.
     #[must_use]
     pub fn new_comments_since(&self, id: StoryId, current_count: i64) -> Option<i64> {
-        let entry = self.entries.get(&id)?;
+        let entry = self.inner.entries.get(&id)?;
         Some(current_count - entry.last_comment_count).filter(|&d| d > 0)
-    }
-
-    /// Drops entries with the lowest `last_seen_at` until the store is
-    /// back within [`MAX_ENTRIES`].
-    fn evict_oldest(&mut self) {
-        let mut ages: Vec<(i64, StoryId)> = self
-            .entries
-            .iter()
-            .map(|(&id, e)| (e.last_seen_at, id))
-            .collect();
-        ages.sort_unstable();
-        let excess = self.entries.len().saturating_sub(MAX_ENTRIES);
-        for (_, id) in ages.into_iter().take(excess) {
-            self.entries.remove(&id);
-        }
     }
 
     /// Number of persisted entries. Exposed for tests and diagnostics.
     #[cfg(test)]
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.inner.entries.len()
     }
-}
-
-/// Resolves the default persistence path: `$XDG_DATA_HOME/hnt/read.json`,
-/// falling back to `$HOME/.local/share/hnt/read.json`. Returns `None` if
-/// neither variable is set (rare — containers with no `HOME`).
-fn default_path() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
-        if !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join("hnt").join("read.json"));
-        }
-    }
-    let home = std::env::var("HOME").ok()?;
-    if home.is_empty() {
-        return None;
-    }
-    Some(
-        PathBuf::from(home)
-            .join(".local")
-            .join("share")
-            .join("hnt")
-            .join("read.json"),
-    )
 }
 
 #[cfg(test)]

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -12,9 +12,18 @@ use crate::api::types::Item;
 /// `stories` is the currently loaded window; `all_ids` is the full ID list
 /// from the initial feed fetch, used as a stable index for pagination so
 /// appended pages don't drift when new stories are posted mid-session.
+///
+/// `domains` is a parallel cache of `Item::domain()` results, populated
+/// once when stories load so per-frame rendering doesn't re-parse URLs.
+/// Mutate `stories` only through [`Self::replace_stories`] /
+/// [`Self::append_stories`] so the cache stays in sync.
 #[derive(Default)]
 pub struct StoryListState {
     pub stories: Vec<Item>,
+    /// Pre-computed `story.domain()` for each story at the same index.
+    /// Avoids the per-frame `url::Url::parse` that
+    /// [`StoryList`](crate::ui::story_list::StoryList) used to do.
+    pub domains: Vec<Option<String>>,
     pub all_ids: Vec<u64>,
     pub selected: usize,
     pub loading: bool,
@@ -23,6 +32,20 @@ pub struct StoryListState {
 impl StoryListState {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Replaces the loaded stories and refreshes the parallel domain
+    /// cache. Use instead of `state.stories = ...` so per-frame rendering
+    /// can keep using the cache.
+    pub fn replace_stories(&mut self, stories: Vec<Item>) {
+        self.domains = stories.iter().map(Item::domain).collect();
+        self.stories = stories;
+    }
+
+    /// Appends a paginated batch and extends the parallel domain cache.
+    pub fn append_stories(&mut self, stories: Vec<Item>) {
+        self.domains.extend(stories.iter().map(Item::domain));
+        self.stories.extend(stories);
     }
 
     pub fn select_next(&mut self) {
@@ -74,6 +97,7 @@ impl StoryListState {
 
     pub fn reset(&mut self) {
         self.stories.clear();
+        self.domains.clear();
         self.all_ids.clear();
         self.selected = 0;
         self.loading = false;

--- a/src/ui/article_reader.rs
+++ b/src/ui/article_reader.rs
@@ -63,10 +63,7 @@ pub fn render_article_overlay(
 }
 
 fn build_title(reader: &ReaderState) -> String {
-    let truncated: Option<String> = (reader.title.chars().count() > 60)
-        .then(|| reader.title.chars().take(57).collect::<String>() + "...");
-    let title: &str = truncated.as_deref().unwrap_or(reader.title.as_str());
-
+    let title = crate::ui::util::truncate_to(&reader.title, 60);
     match &reader.domain {
         Some(domain) => format!(" {} ({}) ", title, domain),
         None => format!(" {} ", title),
@@ -207,16 +204,10 @@ fn paint_hint_labels(frame: &mut Frame, inner: Rect, reader: &ReaderState, hint:
         if link.line < scroll || link.line >= scroll + visible_height {
             continue;
         }
-        let line = match reader.lines.get(link.line) {
-            Some(l) => l,
-            None => continue,
-        };
-        let col_offset: usize = line
-            .iter()
-            .take(link.fragment)
-            .map(|f| f.text.chars().count())
-            .sum();
-        let label_x = inner.x.saturating_add(col_offset as u16);
+        // `link.col` is pre-computed at registry-build time
+        // (`tagged_lines_to_styled_with_links`) — no per-keystroke
+        // chars().count() summing across preceding fragments here.
+        let label_x = inner.x.saturating_add(link.col as u16);
         if label_x >= inner.right() {
             continue;
         }

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -374,9 +374,8 @@ fn measure_comments(
         let comment = &all_comments[idx];
         let depth_color = theme::depth_color(comment.depth);
 
-        let author_sanitized = crate::sanitize::sanitize_terminal(
-            comment.item.by.as_deref().unwrap_or("[deleted]"),
-        );
+        let author_sanitized =
+            crate::sanitize::sanitize_terminal(comment.item.by.as_deref().unwrap_or("[deleted]"));
         let author: &str = author_sanitized.as_ref();
         let time_ago = comment
             .item

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -9,7 +9,7 @@
 use crate::api::types::CommentId;
 use crate::state::comment_state::{CommentFilter, CommentTreeState, FlatComment};
 use crate::ui::spinner;
-use crate::ui::story_list::format_time_ago;
+use crate::ui::story_list::format_time_ago_since;
 use crate::ui::theme;
 use ratatui::{
     buffer::Buffer,
@@ -31,6 +31,10 @@ pub struct CommentTree<'a> {
     pub focused: bool,
     pub tick: u64,
     pub prior_count: usize,
+    /// Wall-clock timestamp captured once per frame in [`crate::ui::render`]
+    /// so the `Ns/Nm/Nh` ago column doesn't `clock_gettime` per visible
+    /// comment.
+    pub now_secs: i64,
 }
 
 /// A pre-measured comment: all the lines it will produce and its visual index.
@@ -136,20 +140,25 @@ impl<'a> Widget for CommentTree<'a> {
 
         let meta_snapshot = self.state.story.as_ref().map(|s| {
             let has_text = s.text.is_some();
+            // Sanitize HN-supplied fields before they enter the rendered
+            // line — a malicious URL or username could otherwise embed
+            // terminal escapes via entity-decoded HTML upstream.
+            let by = crate::sanitize::sanitize_terminal(s.by.as_deref().unwrap_or("?"));
             let line = if has_text {
                 format!(
                     "  {} pts | {} | {} comments",
                     s.score.unwrap_or(0),
-                    s.by.as_deref().unwrap_or("?"),
+                    by,
                     s.descendants.unwrap_or(0),
                 )
             } else {
+                let url = crate::sanitize::sanitize_terminal(s.url.as_deref().unwrap_or(""));
                 format!(
                     "  {} pts | {} | {} comments | {}",
                     s.score.unwrap_or(0),
-                    s.by.as_deref().unwrap_or("?"),
+                    by,
                     s.descendants.unwrap_or(0),
-                    s.url.as_deref().unwrap_or(""),
+                    url,
                 )
             };
             (has_text, line)
@@ -229,6 +238,7 @@ impl<'a> Widget for CommentTree<'a> {
             inner.width as usize,
             &self.state.pending_root_ids,
             spinner_frame,
+            self.now_secs,
         );
 
         // Initialize row_map for mouse click handling
@@ -341,6 +351,7 @@ fn measure_comments(
     width: usize,
     pending_root_ids: &std::collections::HashSet<CommentId>,
     spinner_frame: &str,
+    now_secs: i64,
 ) -> Vec<MeasuredComment> {
     let mut result = Vec::new();
 
@@ -363,19 +374,25 @@ fn measure_comments(
         let comment = &all_comments[idx];
         let depth_color = theme::depth_color(comment.depth);
 
-        let author = comment.item.by.as_deref().unwrap_or("[deleted]");
-        let time_ago = comment.item.time.map(format_time_ago).unwrap_or_default();
+        let author_sanitized = crate::sanitize::sanitize_terminal(
+            comment.item.by.as_deref().unwrap_or("[deleted]"),
+        );
+        let author: &str = author_sanitized.as_ref();
+        let time_ago = comment
+            .item
+            .time
+            .map(|t| format_time_ago_since(t, now_secs))
+            .unwrap_or_default();
         let collapse_indicator = if is_collapsed { " [+]" } else { "" };
 
-        let child_count = if is_collapsed {
+        // Only allocate when there's actually a hidden-children badge to
+        // show — for the common "not collapsed" path this stays None and
+        // skips a per-comment-per-frame `String::new()` plus its Span.
+        let child_count: Option<String> = if is_collapsed {
             let count = count_hidden_children(all_comments, idx);
-            if count > 0 {
-                format!(" ({} hidden)", count)
-            } else {
-                String::new()
-            }
+            (count > 0).then(|| format!(" ({} hidden)", count))
         } else {
-            String::new()
+            None
         };
 
         // Header line — build Spans directly. Each Span owns its String
@@ -406,8 +423,13 @@ fn measure_comments(
                 collapse_indicator.to_string(),
                 ratatui::style::Style::default().fg(theme::YELLOW),
             ),
-            Span::styled(child_count, ratatui::style::Style::default().fg(theme::DIM)),
         ]);
+        if let Some(text) = child_count {
+            header_spans.push(Span::styled(
+                text,
+                ratatui::style::Style::default().fg(theme::DIM),
+            ));
+        }
         lines.push(CommentLine::Header(header_spans));
 
         // Comment text lines

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,6 +14,7 @@ pub mod spinner;
 pub mod status_bar;
 pub mod story_list;
 pub mod theme;
+pub mod util;
 
 use crate::app::App;
 use layout::build_layout;
@@ -40,6 +41,10 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     let search_active = app.search_state.is_some();
     let search_query = app.search_state.as_ref().map(|ss| ss.query.as_str());
 
+    // Capture wall-clock once per frame so per-row `format_time_ago`
+    // callers don't `clock_gettime` per visible comment / story.
+    let now_secs = chrono::Utc::now().timestamp();
+
     // Header
     frame.render_widget(
         header::Header {
@@ -53,6 +58,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     frame.render_widget(
         story_list::StoryList {
             stories: &app.story_state.stories,
+            domains: &app.story_state.domains,
             selected: app.story_state.selected,
             focused: app.focus == crate::app::Pane::Stories,
             loading: app.story_state.loading,
@@ -68,11 +74,13 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     let visible_indices = app.comment_state.visible_indices();
 
     // Comment tree
+    // `peek` reads without bumping recency — every render frame would
+    // otherwise pin whichever story is currently open as MRU.
     let prior_count = app
         .comment_state
         .story
         .as_ref()
-        .and_then(|s| app.prior_results.get(&crate::api::types::StoryId(s.id)))
+        .and_then(|s| app.prior_results.peek(&crate::api::types::StoryId(s.id)))
         .map(|v| v.len())
         .unwrap_or(0);
     frame.render_widget(
@@ -82,6 +90,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             focused: app.focus == crate::app::Pane::Comments,
             tick: app.tick_count,
             prior_count,
+            now_secs,
         },
         layout.comments,
     );

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -7,6 +7,7 @@
 use crate::api::types::Item;
 use crate::state::prior_state::PriorDiscussionsState;
 use crate::ui::theme;
+use crate::ui::util::truncate_to;
 use ratatui::{
     layout::Rect,
     text::{Line, Span},
@@ -110,8 +111,15 @@ fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static
         .and_then(|t| chrono::DateTime::<chrono::Utc>::from_timestamp(t, 0))
         .map(|dt| dt.format("%Y-%m-%d").to_string())
         .unwrap_or_else(|| "?".into());
-    let title = item.display_title();
-    let author = item.by.as_deref().unwrap_or("[deleted]");
+    // Sanitize HN-supplied strings before they enter a Span — a comment
+    // submitter could otherwise inject ANSI escapes that retarget the
+    // terminal's title/palette/scroll region.
+    let title_sanitized = crate::sanitize::sanitize_terminal(item.display_title());
+    let title: &str = title_sanitized.as_ref();
+    let author_sanitized = crate::sanitize::sanitize_terminal(
+        item.by.as_deref().unwrap_or("[deleted]"),
+    );
+    let author: &str = author_sanitized.as_ref();
 
     let cursor = if selected { "> " } else { "  " };
     let title_style = if selected {
@@ -156,15 +164,4 @@ fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static
     let line2 = Line::from(Span::styled(byline, dim_style)).style(row_bg);
 
     [line1, line2]
-}
-
-/// Truncates `s` to at most `max` characters (operating on `char`s to stay
-/// UTF-8-safe), appending `...` when truncation occurs. Returns `s`
-/// unchanged when it already fits.
-fn truncate_to(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let truncated: String = s.chars().take(max.saturating_sub(3)).collect();
-    format!("{}...", truncated)
 }

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -116,9 +116,8 @@ fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static
     // terminal's title/palette/scroll region.
     let title_sanitized = crate::sanitize::sanitize_terminal(item.display_title());
     let title: &str = title_sanitized.as_ref();
-    let author_sanitized = crate::sanitize::sanitize_terminal(
-        item.by.as_deref().unwrap_or("[deleted]"),
-    );
+    let author_sanitized =
+        crate::sanitize::sanitize_terminal(item.by.as_deref().unwrap_or("[deleted]"));
     let author: &str = author_sanitized.as_ref();
 
     let cursor = if selected { "> " } else { "  " };

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -98,9 +98,13 @@ impl<'a> Widget for StatusBar<'a> {
             }
         }
 
-        // Right-aligned position indicator
+        // Right-aligned position indicator. Use `chars().count()` rather
+        // than byte `.len()` so the alignment stays correct if any field
+        // ever picks up a non-ASCII glyph.
         let right_text = format!(" {} [{}] ", self.position, self.focus_pane);
-        let right_start = area.right().saturating_sub(right_text.len() as u16);
+        let right_start = area
+            .right()
+            .saturating_sub(right_text.chars().count() as u16);
 
         let line = Line::from(spans);
         buf.set_line(area.left(), area.top(), &line, area.width);

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -20,6 +20,9 @@ use ratatui::{
 /// app state; rebuilt each frame.
 pub struct StoryList<'a> {
     pub stories: &'a [Item],
+    /// Pre-computed `Item::domain()` results, parallel to `stories`.
+    /// Avoids a per-frame `url::Url::parse` per visible row.
+    pub domains: &'a [Option<String>],
     pub selected: usize,
     pub focused: bool,
     pub loading: bool,
@@ -102,33 +105,41 @@ impl<'a> Widget for StoryList<'a> {
                 .read_store
                 .new_comments_since(sid, story.descendants.unwrap_or(0));
 
-            let title = story.display_title();
+            // Sanitize untrusted HN-supplied strings before they reach a
+            // ratatui Span — terminal escapes embedded in titles/domains
+            // would otherwise be forwarded straight to crossterm.
+            let title_sanitized = crate::sanitize::sanitize_terminal(story.display_title());
+            let title: &str = title_sanitized.as_ref();
             let badge = story.badge();
-            let domain = story
-                .domain()
-                .map(|d| format!(" ({})", d))
+            // Domain is pre-parsed by `StoryListState::replace_stories` /
+            // `append_stories`; rendering only formats the cached value.
+            let domain = self
+                .domains
+                .get(i)
+                .and_then(|d| d.as_deref())
+                .map(|d| format!(" ({})", crate::sanitize::sanitize_terminal(d)))
                 .unwrap_or_default();
             let new_badge_text = new_comments.map(|n| format!(" +{}", n));
 
             let num = format!("{:>3}. ", i + 1);
             let badge_text = badge.map(|b| format!("[{}] ", b.label()));
-            let badge_width = badge_text.as_ref().map_or(0, |t| t.len());
-            let new_badge_width = new_badge_text.as_ref().map_or(0, |t| t.len());
+            // Visible-column math: `chars().count()` not `.len()` so a
+            // future non-ASCII badge or `+N` glyph doesn't misalign the
+            // truncation boundary.
+            let badge_width = badge_text.as_ref().map_or(0, |t| t.chars().count());
+            let new_badge_width = new_badge_text.as_ref().map_or(0, |t| t.chars().count());
             // ★ + space = 2 visual columns. Reserved before the badge so a
             // pinned Ask HN story stays aligned: "  1. ★ [Ask HN] Title".
             let pin_width = if is_pinned { 2 } else { 0 };
             let max_title_width = (inner.width as usize).saturating_sub(
-                num.len() + pin_width + badge_width + new_badge_width + domain.len() + 2,
+                num.chars().count()
+                    + pin_width
+                    + badge_width
+                    + new_badge_width
+                    + domain.chars().count()
+                    + 2,
             );
-            let truncated_title: String = if title.chars().count() > max_title_width {
-                let truncated: String = title
-                    .chars()
-                    .take(max_title_width.saturating_sub(3))
-                    .collect();
-                format!("{}...", truncated)
-            } else {
-                title.to_string()
-            };
+            let truncated_title = crate::ui::util::truncate_to(title, max_title_width);
 
             let row_bg = if is_selected {
                 theme::SURFACE
@@ -191,12 +202,9 @@ impl<'a> Widget for StoryList<'a> {
 }
 
 /// Renders a Unix timestamp as `"Ns"`/`"Nm"`/`"Nh"`/`"Nd"` relative to
-/// the current wall-clock time.
-pub fn format_time_ago(timestamp: i64) -> String {
-    format_time_ago_since(timestamp, chrono::Utc::now().timestamp())
-}
-
-fn format_time_ago_since(timestamp: i64, now: i64) -> String {
+/// `now`. Per-frame callers should hoist `now` out of any visible-rows
+/// loop so they only `clock_gettime` once per render.
+pub fn format_time_ago_since(timestamp: i64, now: i64) -> String {
     let diff = now - timestamp;
 
     if diff < 60 {

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,0 +1,44 @@
+//! Small UI helpers shared across widgets.
+
+/// Truncates `s` to at most `max` characters (operating on `char`s to
+/// stay UTF-8-safe), appending `...` when truncation occurs. Returns
+/// `s` unchanged when it already fits. `max < 3` collapses to just the
+/// ellipsis (or to `max` chars of it) so callers passing tiny widths
+/// still get a sensible visual.
+pub fn truncate_to(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let keep = max.saturating_sub(3);
+    let mut out: String = s.chars().take(keep).collect();
+    out.push_str("...");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_unchanged_when_fits() {
+        assert_eq!(truncate_to("abc", 10), "abc");
+        assert_eq!(truncate_to("abc", 3), "abc");
+    }
+
+    #[test]
+    fn truncates_with_ellipsis() {
+        assert_eq!(truncate_to("abcdefghij", 6), "abc...");
+    }
+
+    #[test]
+    fn unicode_safe() {
+        // 5 multi-byte chars; max=4 should keep 1 char + "..."
+        assert_eq!(truncate_to("日本語のテスト", 4), "日...");
+    }
+
+    #[test]
+    fn max_zero_returns_just_ellipsis() {
+        // saturating_sub clamps `max - 3` at 0 → all that's left is "...".
+        assert_eq!(truncate_to("abcdef", 0), "...");
+    }
+}


### PR DESCRIPTION
Closes #120

## Summary
- **Security**: strip C0/C1/DEL bytes from rendered HN content (`sanitize_terminal`); add 15s/5s timeouts to `HnClient`; restrict article-fetcher redirects to public hosts (SSRF guard); validate `http(s)` scheme on `Item.url` at decode boundary; tighten Unix mode to 0700 dir / 0600 file on persistent stores; reject non-absolute `XDG_DATA_HOME`.
- **Performance**: cache `Item::domain` so URL parsing happens once on load; thread `now_secs` through render so `format_time_ago` stops `clock_gettime`-ing per row; rewrite filter ancestor walk as O(n) forward path-stack pass; parallelize per-root comment subtree fetches (`for_each_concurrent(4)`); bound `prior_results` with `LruCache(200)`; `select_ok` for parallel README probes; pre-compute link column offsets for hint paint.
- **Structure**: extract generic `state::persist::JsonStore<E>`; thin `ReadStore`/`PinStore` to wrappers; split `App::dispatch` into `dispatch_reader`/`_prior`/`_normal`; extract `run_comment_load`, `user_navigated_comments`, `reset_panes_and_reload`, `apply_pending_resume`, `pane_at`, `truncate_to`, `article_client`; replace `Action::None` sentinel with `Option<Action>`; drop dead `Resize` `#[allow(dead_code)]` and unused `EventHandler._tx`.
- **Correctness**: surface `fetch_item` errors via `AppMessage::Error` instead of silently rendering an empty thread; `PriorInFlightGuard` Drop guard so a panicking task doesn't leak the in-flight set; 60s clock-skew slack on `Recent` filter; skip caching dead/deleted items; safe ASCII byte→char in `link_registry::generate_label`.
- **Deferred**: R13 (return `Vec<Option<Arc<Item>>>` from `fetch_items`) — every consumer materializes owned `Item`, so the change would relocate clones rather than eliminate them. Genuine win requires propagating `Arc<Item>` through downstream state types; out of scope here.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 284 tests pass (40+ new across `sanitize`, `persist`, `types`, `article`, `link_registry`, `ui::util`)
- [x] `cargo clippy --all-targets` — no new warnings
- [ ] Manual smoke (TUI):
  - [ ] Top → Best → Pinned feed switches reload cleanly
  - [ ] Open a story with comments; cycle filters with `n`
  - [ ] Open prior-discussions overlay with `h`
  - [ ] Open reader on a GH/GL repo link (README path)
  - [ ] Lazy-load past 80% scroll
- [ ] Confirm `~/.local/share/hnt/{read,pinned}.json` are mode 0600 (Unix only)