### PR TITLE
Improve rustdoc coverage and fix broken intra-doc links

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -44,6 +44,12 @@ impl Default for HnClient {
 impl HnClient {
     /// Builds a fresh client with an empty LRU cache of up to
     /// `CACHE_CAPACITY` items.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `CACHE_CAPACITY` is zero (compile-time guaranteed
+    /// non-zero) or if [`reqwest::Client::builder`] fails (e.g. unable
+    /// to load native TLS roots — exotic).
     pub fn new() -> Self {
         let capacity = NonZeroUsize::new(CACHE_CAPACITY).expect("cache capacity > 0");
         // Timeouts prevent a stalled HN endpoint from leaving spawned
@@ -80,6 +86,11 @@ impl HnClient {
     /// list for virtual feeds (those whose [`FeedKind::endpoint`] is
     /// `None`) — the caller is responsible for sourcing those IDs from
     /// local state instead.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`reqwest::Error`] when the HTTP request
+    /// fails or when the response body fails to decode as `Vec<u64>`.
     pub async fn fetch_story_ids(&self, feed: FeedKind) -> Result<Vec<u64>> {
         let Some(endpoint) = feed.endpoint() else {
             return Ok(Vec::new());
@@ -90,8 +101,14 @@ impl HnClient {
     }
 
     /// Fetches a single item by ID, consulting the LRU cache first.
-    /// Returns [`Arc<Item>`] so callers that only read fields (e.g.
+    /// Returns an `Arc<Item>` so callers that only read fields (e.g.
     /// `item.kids`) can skip cloning the whole struct.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`reqwest::Error`] when the HTTP request
+    /// fails (DNS, TLS, timeout, non-success status surfaced through
+    /// `.json()`) or when the response body fails to decode as JSON.
     pub async fn fetch_item(&self, id: u64) -> Result<Option<Arc<Item>>> {
         // Check cache first — release the lock before the network call.
         // `cloned()` on an `Option<&Arc<Item>>` is just a refcount bump.
@@ -119,7 +136,7 @@ impl HnClient {
     /// in flight) and returns them in the order of `ids` — `result[i]`
     /// corresponds to `ids[i]`, and is `None` when the item was missing
     /// or its fetch failed. Owned `Item`s are returned — deref-cloned from
-    /// the cached [`Arc<Item>`] at the boundary because every downstream
+    /// the cached `Arc<Item>` at the boundary because every downstream
     /// consumer needs mutable ownership to stash in state.
     pub async fn fetch_items(&self, ids: &[u64]) -> Vec<Option<Item>> {
         let results: Vec<Option<Arc<Item>>> = stream::iter(ids.iter().copied())
@@ -148,6 +165,13 @@ impl HnClient {
     /// Fetches a page of items from a pre-fetched ID list. Used for pagination
     /// so callers can reuse the initial ID list instead of re-fetching it —
     /// avoiding drift when new stories have been posted since the last fetch.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible in practice — per-item failures inside
+    /// [`Self::fetch_items`] surface as `None` entries that are filtered
+    /// out — but the signature returns `Result` to leave room for future
+    /// boundary errors (e.g. propagating a hard failure from upstream).
     pub async fn fetch_items_page(
         &self,
         ids: &[u64],
@@ -171,6 +195,11 @@ impl HnClient {
     /// Fetches a page of a feed. Returns `(items, all_ids)` where `all_ids`
     /// is the complete ID list from the feed endpoint — callers should stash
     /// it for stable subsequent pagination.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from [`Self::fetch_story_ids`] (network, HTTP,
+    /// JSON decode of the ID list).
     pub async fn fetch_stories(
         &self,
         feed: FeedKind,
@@ -192,6 +221,12 @@ impl HnClient {
     ///
     /// Empty result is not an error — a novel URL legitimately has no prior
     /// submissions.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`reqwest::Error`] when the Algolia
+    /// request fails (network, timeout, non-success status) or when the
+    /// response body fails to decode as a [`SearchResponse`].
     pub async fn search_by_url(&self, url: &str) -> Result<Vec<Item>> {
         let target = normalize_url(url);
         if target.is_empty() {
@@ -221,6 +256,12 @@ impl HnClient {
     /// Returns `(stories, total_pages, total_hits)`. `page` is 0-indexed.
     /// Story [`Item::kids`] is always `None` in results — fetch the full
     /// item if comment IDs are needed.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`reqwest::Error`] when the Algolia
+    /// request fails (network, timeout, non-success status) or when the
+    /// response body fails to decode as a [`SearchResponse`].
     pub async fn search_stories(
         &self,
         query: &str,

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,8 +144,11 @@ pub enum AppMessage {
 /// Central application state — owned by the main loop.
 ///
 /// Aggregates every pane's state, the shared [`HnClient`], and an MPSC
-/// channel that async tasks use to send [`AppMessage`]s back. All input
-/// flows through [`App::dispatch`]; all async results flow through
+/// channel that async tasks use to send [`AppMessage`]s back. Most input
+/// flows through [`App::dispatch`] as keymapped [`Action`]s; the
+/// `SearchInput` and hint-mode paths bypass dispatch and call
+/// `App::search_input_*` / hint-key methods directly so raw characters
+/// reach the input buffers verbatim. All async results flow through
 /// [`App::process_messages`].
 pub struct App {
     pub running: bool,
@@ -163,8 +166,10 @@ pub struct App {
     pub tick_count: u64,
 
     /// Prior-discussions overlay state. `Some` while the overlay is open;
-    /// `None` otherwise. Contents are populated from [`App::prior_results`]
-    /// when the user presses `h`.
+    /// `None` otherwise. Contents come from [`App::prior_results`] when
+    /// cached; on a cache miss the overlay opens empty and is backfilled
+    /// when the background Algolia query lands in
+    /// [`App::process_messages`].
     pub prior_state: Option<PriorDiscussionsState>,
     /// Prior-submissions query results, keyed by the story ID that was
     /// queried. Keeps each result around for reopening the
@@ -216,6 +221,11 @@ pub struct App {
 impl App {
     /// Constructs an [`App`] sized to the given terminal dimensions, with
     /// a fresh HN client, empty state, and a brand-new message channel.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `PRIOR_RESULTS_CACHE` is zero (compile-time guaranteed
+    /// non-zero).
     pub fn new(terminal_width: u16, terminal_height: u16) -> Self {
         let (msg_tx, msg_rx) = mpsc::unbounded_channel();
         Self {
@@ -539,9 +549,10 @@ impl App {
         self.dispatch_normal(action);
     }
 
-    /// Dispatch arm for the article-reader overlay. Assumes
-    /// `reader_state.is_some()`. Hint actions are filtered upstream by
-    /// [`Self::dispatch`]. Unmapped actions are silently consumed.
+    /// Dispatch arm for the article-reader overlay. Caller is expected to
+    /// ensure `reader_state.is_some()`; a `None` state is handled
+    /// defensively as a silent return. Hint actions are filtered upstream
+    /// by [`Self::dispatch`]. Unmapped actions are silently consumed.
     fn dispatch_reader(&mut self, action: Action) {
         // Back mutates the Option itself, so handle it before borrowing
         // the inner state.
@@ -564,8 +575,10 @@ impl App {
         }
     }
 
-    /// Dispatch arm for the prior-discussions overlay. Assumes
-    /// `prior_state.is_some()`. Unmapped actions are silently consumed.
+    /// Dispatch arm for the prior-discussions overlay. Caller is expected
+    /// to ensure `prior_state.is_some()`; a `None` state is handled
+    /// defensively as a silent return. Unmapped actions are silently
+    /// consumed.
     fn dispatch_prior(&mut self, action: Action) {
         // Actions that mutate App itself (not just the overlay's inner
         // state) go first so the subsequent borrow of `p` is clean.
@@ -1113,8 +1126,9 @@ impl App {
     }
 
     /// Opens the focused story's URL in the system browser. Falls back to
-    /// the HN item page for text-only stories. Only http(s) URLs are
-    /// opened.
+    /// the HN item page for stories without a usable http(s) URL —
+    /// text-only Ask/Show HN posts plus any story whose URL was rejected
+    /// at deserialization. Only http(s) URLs are opened.
     fn open_in_browser(&self) {
         let url = match self.focus {
             Pane::Stories => self

--- a/src/article.rs
+++ b/src/article.rs
@@ -261,10 +261,19 @@ fn markdown_to_styled_lines(text: &str, width: usize) -> Vec<Vec<StyledFragment>
     lines
 }
 
-/// Fetches article HTML, runs readability extraction, converts to styled
-/// lines and a [`LinkRegistry`] of every hyperlink (for Quickjump hint
+/// Fetches `url` and produces styled lines for the article reader.
+///
+/// Runs readability extraction first, then converts the result to styled
+/// lines plus a [`LinkRegistry`] of every hyperlink (for Quickjump hint
 /// mode). Markdown READMEs render without a link registry today — only
 /// the rich-HTML path produces hint targets.
+///
+/// # Errors
+///
+/// Propagates errors from the HTTP fetch (network, TLS, timeout) and
+/// `bail!`s when the response is non-success, exceeds 5 MB, or has a
+/// non-HTML/plain content-type. Readability and html2text errors
+/// propagate from the `spawn_blocking` join.
 pub async fn fetch_and_extract_article(
     url: &str,
     width: usize,
@@ -379,11 +388,13 @@ fn extract_article_content(
     Ok(tagged_lines_to_styled_with_links(tagged_lines))
 }
 
-/// Walks html2text rich-tagged lines, producing per-line
-/// [`StyledFragment`] vectors and a parallel [`LinkRegistry`] that records
-/// where every hyperlink lives (line index + fragment index of the
-/// link-text fragment). The dim ` [https://...]` suffix is preserved as a
-/// secondary fragment so non-hint-mode rendering looks identical.
+/// Walks html2text rich-tagged lines and produces per-line styled output.
+///
+/// Returns a `Vec<Vec<StyledFragment>>` plus a parallel [`LinkRegistry`]
+/// that records where every hyperlink lives (line index + fragment index
+/// of the link-text fragment). The dim ` [https://...]` suffix is
+/// preserved as a secondary fragment so non-hint-mode rendering looks
+/// identical.
 fn tagged_lines_to_styled_with_links(
     tagged_lines: Vec<html2text::render::TaggedLine<Vec<RichAnnotation>>>,
 ) -> (Vec<Vec<StyledFragment>>, LinkRegistry) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -68,8 +68,13 @@ impl EventHandler {
         Self { rx }
     }
 
-    /// Awaits the next [`Event`]. Returns an error if the channel closes,
-    /// which means the background task has terminated.
+    /// Awaits the next [`Event`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the MPSC channel closes, which means the
+    /// background input/tick task has terminated (crossterm stream
+    /// errored or hit EOF).
     pub async fn next(&mut self) -> Result<Event> {
         self.rx
             .recv()

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -14,9 +14,12 @@
 
 use std::borrow::Cow;
 
-/// Returns `s` unchanged if it contains no control bytes, otherwise an
-/// owned [`String`] with `\u{FFFD}` (REPLACEMENT CHARACTER) substituted
-/// for any C0 / C1 / DEL byte. `\t` (0x09) and `\n` (0x0A) are kept.
+/// Replaces C0 / C1 / DEL bytes in `s` with `\u{FFFD}` (REPLACEMENT
+/// CHARACTER).
+///
+/// Returns `s` unchanged (as [`Cow::Borrowed`]) when it contains no
+/// control bytes, otherwise an owned [`String`] with the substitution
+/// applied. `\t` (0x09) and `\n` (0x0A) are preserved.
 #[must_use]
 pub fn sanitize_terminal(s: &str) -> Cow<'_, str> {
     if !s.chars().any(is_control_to_strip) {

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -49,9 +49,11 @@ impl FlatComment {
         }
     }
 
-    /// Returns the plain-text rendering of `item.text` at `width`, reusing
-    /// the last-rendered result if the width matches. The cache is keyed
-    /// only on width because each `FlatComment` wraps a single `Item`.
+    /// Returns the plain-text rendering of `item.text` rendered at
+    /// `width.max(20)` (html2text refuses very narrow widths), reusing
+    /// the last-rendered result when `width` matches the cached key. The
+    /// cache is keyed on the caller's `width`, not the floored value, so
+    /// each `FlatComment` wraps a single `Item`.
     pub fn plain_text(&mut self, width: usize) -> Option<&str> {
         let text = self.item.text.as_deref()?;
         let needs_refresh = !matches!(&self.plain_text_cache, Some((w, _)) if *w == width);
@@ -77,6 +79,8 @@ impl FlatComment {
 /// loads complete.
 #[derive(Default)]
 pub struct CommentTreeState {
+    /// Flat pre-order comment list. Mutated through [`Self::set_comments`]
+    /// (replace) and [`Self::insert_children`] (splice).
     pub comments: Vec<FlatComment>,
     /// Row-based scroll offset, updated by the renderer.
     pub scroll: usize,
@@ -85,7 +89,10 @@ pub struct CommentTreeState {
     /// Collapsed-subtree comment IDs; their descendants are hidden from
     /// `visible_comments()`.
     pub collapsed: HashSet<CommentId>,
+    /// True while async comment fetches are still in flight; cleared on
+    /// [`crate::app::AppMessage::CommentsDone`].
     pub loading: bool,
+    /// The story whose comments are loaded. `None` between selections.
     pub story: Option<Item>,
     /// Root-comment IDs whose subtrees are still being fetched.
     pub pending_root_ids: HashSet<CommentId>,
@@ -107,8 +114,9 @@ impl CommentTreeState {
     }
 
     /// Returns the plain-text rendering of the current story's text at
-    /// `width`, reusing the last-rendered result if the story and width
-    /// match.
+    /// `width.max(20)` (html2text refuses very narrow widths), reusing
+    /// the last-rendered result if the story and `width` match the
+    /// cached key.
     pub fn story_plain_text(&mut self, width: usize) -> Option<&str> {
         let story = self.story.as_ref()?;
         let text = story.text.as_deref()?;
@@ -140,7 +148,8 @@ impl CommentTreeState {
         self.filter = CommentFilter::All;
     }
 
-    /// Insert child comments right after their parent in the flattened list.
+    /// Inserts child comments right after their parent in the flattened
+    /// list.
     pub fn insert_children(&mut self, parent_id: CommentId, children: Vec<CommentWithDepth>) {
         let insert_pos = self
             .comments
@@ -252,6 +261,9 @@ impl CommentTreeState {
             .collect()
     }
 
+    /// Advances the cursor by one visible row, saturating at the last
+    /// visible comment. Honors collapse and filter state via
+    /// [`Self::visible_len`].
     pub fn select_next(&mut self) {
         let len = self.visible_len();
         if len > 0 {
@@ -259,15 +271,19 @@ impl CommentTreeState {
         }
     }
 
+    /// Moves the cursor up by one row, saturating at zero.
     pub fn select_prev(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
 
+    /// Jumps the cursor to the first visible comment and resets scroll.
     pub fn jump_top(&mut self) {
         self.selected = 0;
         self.scroll = 0;
     }
 
+    /// Jumps the cursor to the last visible comment. No-op when no
+    /// comments are visible.
     pub fn jump_bottom(&mut self) {
         let len = self.visible_len();
         if len > 0 {
@@ -275,6 +291,8 @@ impl CommentTreeState {
         }
     }
 
+    /// Advances the cursor by `page_size` visible rows, saturating at
+    /// the last visible comment. No-op when no comments are visible.
     pub fn page_down(&mut self, page_size: usize) {
         let len = self.visible_len();
         if len > 0 {
@@ -282,6 +300,7 @@ impl CommentTreeState {
         }
     }
 
+    /// Moves the cursor up by `page_size` rows, saturating at zero.
     pub fn page_up(&mut self, page_size: usize) {
         self.selected = self.selected.saturating_sub(page_size);
     }
@@ -300,6 +319,10 @@ impl CommentTreeState {
         }
     }
 
+    /// Clears the comment list, collapse set, pending-roots set, row
+    /// map, loading flag, and loaded story; resets the filter to
+    /// [`CommentFilter::All`]. Called from `App::dispatch_normal` on
+    /// `Back` from the comments pane and from `App::reset_panes_and_reload`.
     pub fn reset(&mut self) {
         self.comments.clear();
         self.scroll = 0;

--- a/src/state/hint_state.rs
+++ b/src/state/hint_state.rs
@@ -18,9 +18,10 @@ pub enum HintAction {
 
 /// Which surface holds the labeled links.
 ///
-/// The article reader carries its own [`LinkRegistry`](crate::state::link_registry::LinkRegistry)
-/// alongside its content; the comment-tree registry is built on demand
-/// when the user enters hint mode there.
+/// The article reader carries its own
+/// [`LinkRegistry`](crate::state::link_registry::LinkRegistry) alongside
+/// its content; the comment-tree registry is built on demand when the
+/// user enters hint mode there.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HintContext {
     Reader,
@@ -31,12 +32,16 @@ pub enum HintContext {
 /// `Some` only while the user is mid-selection.
 #[derive(Debug, Clone)]
 pub struct HintState {
+    /// Action to fire on a unique-label match.
     pub action: HintAction,
+    /// Surface (reader / comments) the labels live on.
     pub context: HintContext,
+    /// Prefix accumulated so far via [`Self::push`].
     pub buffer: String,
 }
 
 impl HintState {
+    /// Starts a fresh hint-mode session with an empty prefix buffer.
     pub fn new(action: HintAction, context: HintContext) -> Self {
         Self {
             action,
@@ -50,6 +55,8 @@ impl HintState {
         self.buffer.push(c);
     }
 
+    /// Returns the prefix accumulated so far, used to look up against the
+    /// active [`crate::state::link_registry::LinkRegistry`].
     pub fn buffer(&self) -> &str {
         &self.buffer
     }

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -57,6 +57,7 @@ impl LinkRegistry {
         Self::default()
     }
 
+    /// Whether the registry contains zero links.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.links.is_empty()

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 /// One persisted entry — must be cheaply clonable, JSON-serializable, and
 /// expose an age key (Unix seconds) used as the LRU eviction order.
 pub(crate) trait PersistedEntry: Clone + Serialize + DeserializeOwned {
+    /// Unix-second age key used for LRU eviction (oldest first).
     fn age_key(&self) -> i64;
 }
 

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -14,22 +14,34 @@ use ratatui::style::Style;
 /// A run of text sharing one ratatui [`Style`]. Multiple fragments compose
 /// one rendered line (see `Vec<Vec<StyledFragment>>`).
 pub struct StyledFragment {
+    /// Visible text content of this fragment (UTF-8).
     pub text: String,
+    /// Ratatui style applied uniformly across `text`.
     pub style: Style,
 }
 
 /// Article-reader overlay state: title/domain chrome, pre-rendered styled
 /// lines, scroll position, and loading/error status.
 pub struct ReaderState {
+    /// Title for the overlay header. Truncated on render.
     pub title: String,
+    /// Host of `url` (with `www.` stripped), shown after the title in
+    /// parentheses. `None` for HN-native text posts.
     pub domain: Option<String>,
+    /// Source URL for the article. `None` for HN-native text posts that
+    /// render inline `Item::text`.
     pub url: Option<String>,
+    /// Pre-rendered styled lines populated by [`Self::set_content`].
     pub lines: Vec<Vec<StyledFragment>>,
     /// Every hyperlink in `lines`, with assigned hint labels. Populated by
     /// [`Self::set_content`].
     pub links: LinkRegistry,
+    /// Top-of-viewport line index. Updated by `scroll_*`/`page_*`/`jump_*`.
     pub scroll: usize,
+    /// `true` between [`Self::new_loading`] and
+    /// [`Self::set_content`]/[`Self::set_error`].
     pub loading: bool,
+    /// `Some` after a fetch failure; rendered via the error path.
     pub error: Option<String>,
 }
 
@@ -66,27 +78,37 @@ impl ReaderState {
         self.loading = false;
     }
 
+    /// Scrolls the viewport down by `n` lines, clamped to `max_scroll`.
     pub fn scroll_down(&mut self, n: usize) {
         let max = self.max_scroll();
         self.scroll = (self.scroll + n).min(max);
     }
 
+    /// Scrolls the viewport up by `n` lines, saturating at zero.
     pub fn scroll_up(&mut self, n: usize) {
         self.scroll = self.scroll.saturating_sub(n);
     }
 
+    /// Pages the viewport down by `n` lines (currently identical to
+    /// [`Self::scroll_down`]; kept as a separate entry point so the
+    /// keybinding layer can stay symmetric with [`Self::page_up`]).
     pub fn page_down(&mut self, n: usize) {
         self.scroll_down(n);
     }
 
+    /// Pages the viewport up by `n` lines (currently identical to
+    /// [`Self::scroll_up`]).
     pub fn page_up(&mut self, n: usize) {
         self.scroll_up(n);
     }
 
+    /// Jumps to the top of the article.
     pub fn jump_top(&mut self) {
         self.scroll = 0;
     }
 
+    /// Jumps to the bottom of the article (last line at the top of the
+    /// viewport).
     pub fn jump_bottom(&mut self) {
         self.scroll = self.max_scroll();
     }

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -30,6 +30,8 @@ pub struct StoryListState {
 }
 
 impl StoryListState {
+    /// Constructs an empty state with no loaded stories, no cached IDs,
+    /// selection at zero, and not loading.
     pub fn new() -> Self {
         Self::default()
     }
@@ -48,32 +50,41 @@ impl StoryListState {
         self.stories.extend(stories);
     }
 
+    /// Advances the cursor by one row, saturating at the last loaded
+    /// story. No-op when `stories` is empty.
     pub fn select_next(&mut self) {
         if !self.stories.is_empty() {
             self.selected = (self.selected + 1).min(self.stories.len() - 1);
         }
     }
 
+    /// Moves the cursor up by one row, saturating at zero.
     pub fn select_prev(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
 
+    /// Jumps the cursor to the first row.
     pub fn jump_top(&mut self) {
         self.selected = 0;
     }
 
+    /// Jumps the cursor to the last loaded story. No-op when `stories` is
+    /// empty.
     pub fn jump_bottom(&mut self) {
         if !self.stories.is_empty() {
             self.selected = self.stories.len() - 1;
         }
     }
 
+    /// Advances the cursor by `page_size` rows, saturating at the last
+    /// loaded story. No-op when `stories` is empty.
     pub fn page_down(&mut self, page_size: usize) {
         if !self.stories.is_empty() {
             self.selected = (self.selected + page_size).min(self.stories.len() - 1);
         }
     }
 
+    /// Moves the cursor up by `page_size` rows, saturating at zero.
     pub fn page_up(&mut self, page_size: usize) {
         self.selected = self.selected.saturating_sub(page_size);
     }
@@ -95,6 +106,9 @@ impl StoryListState {
         self.selected >= threshold && self.stories.len() < self.all_ids.len()
     }
 
+    /// Clears the loaded stories, the parallel domain cache, the cached
+    /// ID list, and resets selection and the loading flag. Used on feed
+    /// switch and refresh.
     pub fn reset(&mut self) {
         self.stories.clear();
         self.domains.clear();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -18,6 +18,12 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
 /// Enters raw mode, switches to the alternate screen, and enables mouse
 /// capture; returns a ready-to-draw [`Tui`].
+///
+/// # Errors
+///
+/// Returns the underlying `crossterm`/[`std::io::Error`] if
+/// `enable_raw_mode`, the alternate-screen / mouse-capture sequences, or
+/// terminal construction fail.
 pub fn init() -> Result<Tui> {
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
@@ -28,6 +34,12 @@ pub fn init() -> Result<Tui> {
 
 /// Undoes [`init`]: disables raw mode, leaves the alternate screen, and
 /// disables mouse capture. Safe to call from a panic hook.
+///
+/// # Errors
+///
+/// Returns the underlying `crossterm`/[`std::io::Error`] if
+/// `disable_raw_mode` or the alternate-screen / mouse-capture teardown
+/// sequences fail.
 pub fn restore() -> Result<()> {
     disable_raw_mode()?;
     execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -2,7 +2,7 @@
 //!
 //! [`StoryList`] renders numbered story rows with badge, title, and
 //! domain, scrolling to keep the selected row in view. Also exposes
-//! [`format_time_ago`], used by the comment-tree widget for author
+//! [`format_time_ago_since`], used by the comment-tree widget for author
 //! timestamps.
 
 use crate::api::types::{Item, StoryId};


### PR DESCRIPTION
Closes #122

## Summary

- Fix two broken intra-doc links: `` [`format_time_ago`] `` → `` [`format_time_ago_since`] `` in `ui/story_list.rs`; two `` [`Arc<Item>`] `` references in `api/client.rs` rewritten as plain backticks (rustdoc can't resolve generics inside bracket-links).
- Correct stale prose: `App` struct doc no longer claims "all input flows through dispatch"; `dispatch_reader` / `dispatch_prior` "Assumes …is_some()" reworded to reflect defensive `None` handling; `open_in_browser` "text-only stories" widened; `prior_state` field doc now mentions the cache-miss path; `plain_text` / `story_plain_text` document the `width.max(20)` floor.
- Add docstrings to public navigation methods on `StoryListState` (8), `CommentTreeState` (7), `ReaderState` (6), `HintState::new` / `buffer`, and `LinkRegistry::is_empty`.
- Add `# Errors` sections on `HnClient` (6 methods), `tui::init` / `restore`, `EventHandler::next`, and `fetch_and_extract_article` — standardizing on the convention `clipboard.rs` already uses.
- Add field-level docs on `StyledFragment`, `ReaderState`, three fields of `CommentTreeState`, and `HintState`.
- Add `# Panics` sections on `HnClient::new` and `App::new`; rewrite `sanitize_terminal` summary-first; document `PersistedEntry::age_key`; minor style polish.

13 files changed, +189 / -35 lines. Pure documentation — no behavior changes.

## Test plan

- [x] `cargo doc --no-deps --document-private-items` — silent (no rustdoc warnings)
- [x] `cargo build` — clean compile
- [x] `cargo test --bins` — 284 passed, 0 failed
- [x] Reviewer spot-checks IDE hover tooltips for the changed items