### PR TITLE
Sanitize story titles before rendering into title bars (closes #129)

### DIFF
--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -8,6 +8,7 @@
 //! shared line-fragment type used by both article extraction and HTML
 //! comment rendering.
 
+use crate::sanitize::sanitize_terminal;
 use crate::state::link_registry::LinkRegistry;
 use ratatui::style::Style;
 
@@ -49,7 +50,17 @@ impl ReaderState {
     /// Starts in the loading state; the overlay renders a placeholder until
     /// [`set_content`](Self::set_content) or [`set_error`](Self::set_error)
     /// is called.
+    ///
+    /// `title` and `domain` originate from untrusted HN content
+    /// (`Item::title`, the host of `Item::url`). Both are scrubbed through
+    /// [`sanitize_terminal`] here so the overlay header cannot smuggle
+    /// terminal control bytes through ratatui to the user's terminal. The
+    /// `url` itself is not sanitized because it is only used for the
+    /// HTTP fetch and OSC-52 copy paths, both of which apply their own
+    /// safeguards (the SSRF guard for the fetch, base64 for OSC 52).
     pub fn new_loading(title: String, domain: Option<String>, url: Option<String>) -> Self {
+        let title = sanitize_terminal(&title).into_owned();
+        let domain = domain.map(|d| sanitize_terminal(&d).into_owned());
         Self {
             title,
             domain,
@@ -252,5 +263,65 @@ mod tests {
         let mut r = ReaderState::new_loading("T".into(), None, None);
         r.set_content(make_lines(1), LinkRegistry::new());
         assert_eq!(r.scroll_percent(), 100); // max_scroll is 0
+    }
+
+    // --- new_loading sanitises untrusted title / domain inputs ---
+
+    #[test]
+    fn new_loading_sanitises_escape_in_title() {
+        // OSC-0 ("set window title") plus its terminator — the most
+        // damaging escape an HN submitter can land in a title.
+        let r = ReaderState::new_loading("\x1b]0;OWNED\x07hello".into(), None, None);
+        assert!(!r.title.contains('\x1b'));
+        assert!(!r.title.contains('\x07'));
+        assert!(r.title.contains("hello"));
+    }
+
+    #[test]
+    fn new_loading_sanitises_csi_in_title() {
+        let r = ReaderState::new_loading("clear\x1b[2Jhere".into(), None, None);
+        assert!(!r.title.contains('\x1b'));
+        assert!(r.title.contains("clear"));
+        assert!(r.title.contains("here"));
+    }
+
+    #[test]
+    fn new_loading_sanitises_domain() {
+        // Domains come from `url::Url::host_str` so this is defence in
+        // depth — but we still scrub since a future code path could
+        // route a less-trusted value in.
+        let r = ReaderState::new_loading(
+            "Title".into(),
+            Some("example.com\x1b]0;owned\x07".into()),
+            None,
+        );
+        let domain = r.domain.expect("domain set");
+        assert!(!domain.contains('\x1b'));
+        assert!(!domain.contains('\x07'));
+        assert!(domain.contains("example.com"));
+    }
+
+    #[test]
+    fn new_loading_preserves_safe_title_unchanged() {
+        let r = ReaderState::new_loading("Just a normal title".into(), None, None);
+        assert_eq!(r.title, "Just a normal title");
+    }
+
+    #[test]
+    fn new_loading_preserves_unicode_letters_in_title() {
+        let r = ReaderState::new_loading("café résumé 日本語".into(), None, None);
+        assert_eq!(r.title, "café résumé 日本語");
+    }
+
+    #[test]
+    fn new_loading_does_not_sanitise_url() {
+        // The URL field feeds the HTTP fetch (which has its own SSRF
+        // guard) and OSC 52 copy (base64-encoded); it is never spliced
+        // back into a `Span`. Verify it is preserved verbatim so escape
+        // characters in a percent-decoded URL don't trigger surprising
+        // mutation here.
+        let url = "https://example.com/path?q=1".to_string();
+        let r = ReaderState::new_loading("T".into(), None, Some(url.clone()));
+        assert_eq!(r.url.as_deref(), Some(url.as_str()));
     }
 }

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -6,7 +6,8 @@
 //! populates `CommentTreeState::row_map` so mouse clicks can map rows
 //! back to comment indices.
 
-use crate::api::types::CommentId;
+use crate::api::types::{CommentId, Item};
+use crate::sanitize::sanitize_terminal;
 use crate::state::comment_state::{CommentFilter, CommentTreeState, FlatComment};
 use crate::ui::spinner;
 use crate::ui::story_list::format_time_ago_since;
@@ -17,6 +18,24 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Widget},
 };
+
+/// Builds the block-title label for the comments pane.
+///
+/// `story.display_title()` is attacker-controlled (the HN Firebase API
+/// returns titles as plain strings, not HTML, so they bypass
+/// `html2text`'s entity-decode path). Running it through
+/// [`sanitize_terminal`] before interpolation prevents a story title
+/// containing `\x1b]0;OWNED\x07` from rewriting the user's terminal
+/// tab title or otherwise injecting escape sequences when the comments
+/// pane is opened.
+fn build_block_title_label(story: &Item) -> String {
+    let safe_title = sanitize_terminal(story.display_title());
+    if let Some(badge) = story.badge() {
+        format!(" [{}] {} ", badge.label(), safe_title)
+    } else {
+        format!(" {} ", safe_title)
+    }
+}
 
 /// Stateless widget that renders the right pane. Takes a mutable reference
 /// to [`CommentTreeState`] because rendering populates the `row_map` and
@@ -64,12 +83,7 @@ impl<'a> Widget for CommentTree<'a> {
         };
 
         let title_span = if let Some(story) = &self.state.story {
-            let label = if let Some(badge) = story.badge() {
-                format!(" [{}] {} ", badge.label(), story.display_title())
-            } else {
-                format!(" {} ", story.display_title())
-            };
-            Span::styled(label, theme::title_style())
+            Span::styled(build_block_title_label(story), theme::title_style())
         } else {
             Span::styled(" Comments ", theme::title_style())
         };
@@ -492,4 +506,117 @@ const INDENTS: [&str; 11] = [
 
 fn indent_for(depth: usize) -> &'static str {
     INDENTS[depth.min(INDENTS.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::ItemType;
+
+    fn make_story(title: Option<&str>, item_type: Option<ItemType>) -> Item {
+        Item {
+            id: 1,
+            title: title.map(String::from),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type,
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    // --- build_block_title_label ---
+
+    #[test]
+    fn block_title_neutralises_osc_window_title_escape() {
+        // OSC-0 ("set window title") — the primary attack vector for
+        // C2. Make sure neither ESC nor BEL survive the label build.
+        let story = make_story(Some("Cool tool\x1b]0;OWNED\x07"), None);
+        let label = build_block_title_label(&story);
+        assert!(!label.contains('\x1b'), "ESC must not appear: {label:?}");
+        assert!(!label.contains('\x07'), "BEL must not appear: {label:?}");
+        assert!(label.contains("Cool tool"));
+    }
+
+    #[test]
+    fn block_title_neutralises_csi_clear_screen() {
+        let story = make_story(Some("Title\x1b[2Jcleared"), None);
+        let label = build_block_title_label(&story);
+        assert!(!label.contains('\x1b'));
+        assert!(label.contains("Title"));
+        assert!(label.contains("cleared"));
+    }
+
+    #[test]
+    fn block_title_neutralises_c1_range_bytes() {
+        // 0x9B is the 8-bit CSI introducer; rendered through a Latin-1
+        // terminal it kicks off a control sequence on its own.
+        let story = make_story(Some("a\u{009b}b"), None);
+        let label = build_block_title_label(&story);
+        assert!(!label.contains('\u{009b}'));
+        assert!(label.contains('a'));
+        assert!(label.contains('b'));
+    }
+
+    #[test]
+    fn block_title_preserves_plain_title() {
+        let story = make_story(Some("My cool tool"), None);
+        let label = build_block_title_label(&story);
+        assert_eq!(label, " My cool tool ");
+    }
+
+    #[test]
+    fn block_title_preserves_unicode_letters() {
+        let story = make_story(Some("café résumé 日本語"), None);
+        let label = build_block_title_label(&story);
+        assert!(label.contains("café"));
+        assert!(label.contains("日本語"));
+    }
+
+    #[test]
+    fn block_title_includes_badge_for_ask_hn() {
+        let story = make_story(Some("Ask HN: How do I X?"), None);
+        let label = build_block_title_label(&story);
+        // `display_title` strips the "Ask HN:" prefix; the label
+        // re-introduces the badge from `Item::badge`.
+        assert!(
+            label.contains("[Ask HN]"),
+            "expected badge in label: {label:?}"
+        );
+        assert!(label.contains("How do I X?"));
+        assert!(!label.contains("Ask HN: How do I X?"));
+    }
+
+    #[test]
+    fn block_title_includes_badge_for_job_item_type() {
+        let story = make_story(Some("We are hiring"), Some(ItemType::Job));
+        let label = build_block_title_label(&story);
+        assert!(label.contains("[Job]"));
+        assert!(label.contains("We are hiring"));
+    }
+
+    #[test]
+    fn block_title_no_badge_for_plain_story() {
+        let story = make_story(Some("Just a regular story"), None);
+        let label = build_block_title_label(&story);
+        assert!(
+            !label.contains('['),
+            "plain story should not carry a badge: {label:?}"
+        );
+    }
+
+    #[test]
+    fn block_title_handles_missing_title() {
+        // Item with `title = None` falls back to "[no title]" via
+        // `display_title`. Make sure the label still builds and the
+        // sanitiser doesn't choke on the literal brackets.
+        let story = make_story(None, None);
+        let label = build_block_title_label(&story);
+        assert!(label.contains("[no title]"));
+    }
 }


### PR DESCRIPTION
## Summary

- Sanitises `story.title` / `story.display_title()` everywhere it reaches a `Span::styled` block title — closing the terminal-escape-injection gap where most other title call sites (`story_list`, `prior_overlay`, the comment-row header) already passed through `sanitize_terminal` but the comments-pane block title and the article-reader overlay title did not.
- Adds a `build_block_title_label` helper in `ui/comment_tree.rs` so the title-bar build is testable and the sanitiser sits one call away from the formatter.
- Moves the sanitiser into `ReaderState::new_loading` so both `open_article_reader` and `open_url_in_reader` (and any future caller) are safe by construction — `build_title` in `ui/article_reader.rs` already reads from `reader.title`, so it inherits the scrub.

Fixes #129.

## Threat model recap

An HN submitter sets a story title containing `\x1b]0;OWNED\x07` (OSC-0, ''set window title'') or `\x1b[2J` (CSI clear-screen). The HN Firebase API returns titles as plain strings — they bypass `html2text`'s entity-decode path entirely. When the user opens the story's comments or article reader, the title bytes flow straight into ratatui and out to the terminal. Effects: rewriting the user's terminal tab title, clearing the screen, or — on terminals that respond to OSC queries — provoking a response that some shells (notoriously older `bash` configurations) may interpret as input.

## Caveats

`Item::title` flows to many places; sanitising at every span site is whack-a-mole. The two changes here together cover the missed sites listed in #129. A follow-up could push the scrub even earlier — e.g. sanitising `Item::title` once at deserialisation time inside `api/types.rs` — but that's a wider refactor and changes the semantics of the raw `Item` shape. Sanitising at the rendering boundary keeps the wire type as-is and matches the existing pattern.

The `url` field on `ReaderState` is deliberately left raw: it feeds the HTTP fetch (covered by the SSRF guard from #128) and the OSC-52 copy path (base64-encoded and so injection-safe). It is never spliced into a `Span`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 315 passed (15 new)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --document-private-items`
- [ ] CI green on ubuntu + macos