### PR TITLE
Refetch pinned IDs on Pinned-feed Append (closes #135)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1075,9 +1075,21 @@ impl App {
         let gen = self.feed_gen;
 
         if matches!(mode, LoadMode::Append) {
-            // Reuse the ID list from the initial load so offsets stay stable
-            // even if new stories have been posted to the feed since.
-            let cached_ids = self.story_state.all_ids.clone();
+            // For remote feeds, reuse the ID list from the initial load
+            // so offsets stay stable even if new stories have been posted
+            // since. For Pinned — a virtual feed sourced from the local
+            // pin store — refetch the list because pins added or removed
+            // since the initial load would otherwise be missed (closes
+            // #135). The offset stays at `stories.len()`; if pins shifted
+            // significantly the user may see a couple of duplicates or
+            // gaps, but the next scroll round-trips back to a consistent
+            // view.
+            let pinned_branch = matches!(self.current_feed, FeedKind::Pinned);
+            let cached_ids = if pinned_branch {
+                self.pin_store.pinned_ids_newest_first()
+            } else {
+                self.story_state.all_ids.clone()
+            };
             let offset = self.story_state.stories.len();
             tokio::spawn(async move {
                 match client
@@ -1088,7 +1100,12 @@ impl App {
                         let _ = tx.send(AppMessage::StoriesLoaded {
                             gen,
                             stories,
-                            all_ids: None,
+                            // For Pinned, ship the freshly-fetched ID
+                            // list so process_messages updates the
+                            // backing `all_ids` — that way subsequent
+                            // pages see the same list this page used.
+                            // Remote feeds keep their stable cached list.
+                            all_ids: pinned_branch.then(|| cached_ids.clone()),
                             mode: LoadMode::Append,
                         });
                     }


### PR DESCRIPTION
## Summary

- `LoadMode::Append` for `FeedKind::Pinned` was reusing `story_state.all_ids` — but Pinned is a virtual feed backed by the local pin store, not by a remote ID list. If the user pinned or unpinned stories between the initial load and a lazy-load page, the cached list was stale: newly pinned stories silently missing, recently unpinned stories still fetched.
- Branch the Append source by feed: remote feeds keep reusing the cached list (offsets stay stable against real-time HN drift), Pinned refetches `pin_store.pinned_ids_newest_first()`. Pinned ships the refetched list back as `all_ids` so subsequent pages see the same list this page used.

If pins shifted significantly between page boundaries the user may see a couple of duplicates or gaps in the Pinned feed, but the next scroll round-trips back to a consistent view. The alternative (force `Replace` on every Pinned page) would reset scroll position, which is worse UX.

Fixes #135.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 337 passed (no new test; spawn behaviour is HTTP-mediated and the existing fixture coverage in pin_store_tests verifies pinned_ids_newest_first ordering)
- [ ] CI green