### PR TITLE
Propagate Arc<Item> through the story-load path (closes #140)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -135,10 +135,14 @@ impl HnClient {
     /// Fetches multiple items concurrently (up to `CONCURRENT_REQUESTS`
     /// in flight) and returns them in the order of `ids` — `result[i]`
     /// corresponds to `ids[i]`, and is `None` when the item was missing
-    /// or its fetch failed. Owned `Item`s are returned — deref-cloned from
-    /// the cached `Arc<Item>` at the boundary because every downstream
-    /// consumer needs mutable ownership to stash in state.
-    pub async fn fetch_items(&self, ids: &[u64]) -> Vec<Option<Item>> {
+    /// or its fetch failed.
+    ///
+    /// Returns `Arc<Item>` per slot so the cached pointer travels
+    /// end-to-end into [`crate::state::story_state::StoryListState`]
+    /// (closes #140 on the story side). The comment-tree's
+    /// `FlatComment::item` still owns `Item` directly; that conversion
+    /// is a separate refactor.
+    pub async fn fetch_items(&self, ids: &[u64]) -> Vec<Option<Arc<Item>>> {
         let results: Vec<Option<Arc<Item>>> = stream::iter(ids.iter().copied())
             .map(|id| {
                 let client = self.clone();
@@ -157,9 +161,7 @@ impl HnClient {
             .map(|arc| (arc.id, arc))
             .collect();
 
-        ids.iter()
-            .map(|id| result_map.get(id).map(|arc| (**arc).clone()))
-            .collect()
+        ids.iter().map(|id| result_map.get(id).cloned()).collect()
     }
 
     /// Fetches a page of items from a pre-fetched ID list. Used for pagination
@@ -177,7 +179,7 @@ impl HnClient {
         ids: &[u64],
         offset: usize,
         count: usize,
-    ) -> Result<Vec<Item>> {
+    ) -> Result<Vec<Arc<Item>>> {
         if offset >= ids.len() {
             return Ok(Vec::new());
         }
@@ -205,7 +207,7 @@ impl HnClient {
         feed: FeedKind,
         offset: usize,
         count: usize,
-    ) -> Result<(Vec<Item>, Vec<u64>)> {
+    ) -> Result<(Vec<Arc<Item>>, Vec<u64>)> {
         let all_ids = self.fetch_story_ids(feed).await?;
         let items = self.fetch_items_page(&all_ids, offset, count).await?;
         Ok((items, all_ids))
@@ -301,10 +303,16 @@ impl HnClient {
 
             let items = self.fetch_items(ids).await;
 
-            for mut item in items.into_iter().flatten() {
-                if item.is_dead_or_deleted() {
+            for arc in items.into_iter().flatten() {
+                if arc.is_dead_or_deleted() {
                     continue;
                 }
+                // `FlatComment::item` still owns `Item` directly; unwrap
+                // the cached `Arc` here. `try_unwrap` only succeeds when
+                // the LRU has evicted this entry — fallback to a deep
+                // clone in the common path. Future refactor: thread
+                // `Arc<Item>` into `FlatComment` and avoid this clone.
+                let mut item = Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone());
                 // Move kids out of `item` before pushing — avoids a Vec<u64>
                 // clone per comment per recursion level.
                 let item_kids = std::mem::take(&mut item.kids);

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,10 +103,12 @@ struct PendingResume {
 #[non_exhaustive]
 pub enum AppMessage {
     /// Initial or paginated batch of stories finished loading. Gated by
-    /// [`App::feed_gen`].
+    /// [`App::feed_gen`]. Items arrive as `Arc<Item>` so the cached
+    /// pointer travels straight into the story list with no deep clone
+    /// at the boundary (closes #140 on the story side).
     StoriesLoaded {
         gen: u64,
-        stories: Vec<Item>,
+        stories: Vec<Arc<Item>>,
         /// Only populated on initial load; subsequent paginated loads
         /// reuse the cached ID list to avoid drift when the feed changes
         /// mid-session.
@@ -114,14 +116,14 @@ pub enum AppMessage {
         mode: LoadMode,
     },
     /// Root-level comments for a story are available; deeper descendants
-    /// still pending. `story` is boxed so this variant doesn't dominate
-    /// the enum's size — `Vec<CommentWithDepth>` and `HashSet<CommentId>`
-    /// only contribute their headers (24/48 bytes), not their contents,
-    /// so an inline `Item` (~150 bytes) would trip
-    /// `clippy::large_enum_variant`. Gated by [`App::story_gen`].
+    /// still pending. `story` arrives as `Arc<Item>` — the cached
+    /// pointer travels straight into `comment_state.story` with no
+    /// deep clone (`Arc<Item>` is one pointer = 8 bytes so the variant
+    /// stays small and `clippy::large_enum_variant` is happy). Gated
+    /// by [`App::story_gen`].
     CommentsLoaded {
         gen: u64,
-        story: Box<Item>,
+        story: Arc<Item>,
         comments: Vec<CommentWithDepth>,
         pending_roots: HashSet<CommentId>,
     },
@@ -144,10 +146,13 @@ pub enum AppMessage {
         links: LinkRegistry,
     },
     /// Algolia search returned a page of results. Gated by
-    /// [`App::feed_gen`].
+    /// [`App::feed_gen`]. Items arrive as `Arc<Item>` to match the
+    /// `StoriesLoaded` shape, even though search results are
+    /// constructed locally (the `Arc` is fresh in this path; the
+    /// downstream `StoryListState` doesn't care).
     SearchResultsLoaded {
         gen: u64,
-        stories: Vec<Item>,
+        stories: Vec<Arc<Item>>,
         total_pages: usize,
         total_hits: usize,
         mode: LoadMode,
@@ -492,7 +497,7 @@ impl App {
     /// install/append the new stories, clear the loading flag, clear the
     /// error banner. Auto-load and search-pagination bookkeeping are
     /// caller-specific and stay at the call sites.
-    fn apply_loaded_stories(&mut self, stories: Vec<Item>, mode: LoadMode) {
+    fn apply_loaded_stories(&mut self, stories: Vec<Arc<Item>>, mode: LoadMode) {
         match mode {
             LoadMode::Append => self.story_state.append_stories(stories),
             LoadMode::Replace => self.story_state.replace_stories(stories),
@@ -572,7 +577,7 @@ impl App {
                         continue;
                     }
                     let story_id = StoryId(story.id);
-                    self.comment_state.story = Some(*story);
+                    self.comment_state.story = Some(story);
                     self.comment_state.set_comments(comments);
                     self.comment_state.pending_root_ids = pending_roots;
                     self.error = None;
@@ -990,7 +995,7 @@ impl App {
         tokio::spawn(run_comment_load(
             self.client.clone(),
             self.msg_tx.clone(),
-            item,
+            Arc::new(item),
             needs_full_fetch,
             gen,
         ));
@@ -1073,6 +1078,10 @@ impl App {
         tokio::spawn(async move {
             match client.search_stories(&query, page, page_size).await {
                 Ok((stories, total_pages, total_hits)) => {
+                    // Algolia returns owned `Item`s; wrap each so the
+                    // downstream `StoryListState::stories: Vec<Arc<Item>>`
+                    // contract is uniform across both load paths.
+                    let stories = stories.into_iter().map(Arc::new).collect();
                     let _ = tx.send(AppMessage::SearchResultsLoaded {
                         gen,
                         stories,
@@ -1699,7 +1708,7 @@ impl Drop for PriorInFlightGuard {
 async fn run_comment_load(
     client: HnClient,
     tx: mpsc::UnboundedSender<AppMessage>,
-    story: Item,
+    story: Arc<Item>,
     needs_full_fetch: bool,
     gen: u64,
 ) {
@@ -1719,11 +1728,20 @@ async fn run_comment_load(
     };
 
     let root_items = client.fetch_items(&kids).await;
+    // `FlatComment::item` still owns `Item` directly, so unwrap the
+    // cached `Arc` here. `try_unwrap` would only succeed when the
+    // cache has already evicted the entry, so fall through to a deep
+    // clone — same cost as the pre-#140 boundary, just expressed
+    // explicitly. Future refactor: propagate `Arc<Item>` into
+    // FlatComment so this clone disappears too.
     let root_comments: Vec<CommentWithDepth> = root_items
         .into_iter()
         .flatten()
         .filter(|item| !item.is_dead_or_deleted())
-        .map(|item| CommentWithDepth { item, depth: 0 })
+        .map(|arc| CommentWithDepth {
+            item: Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone()),
+            depth: 0,
+        })
         .collect();
 
     let pending_roots: HashSet<CommentId> = root_comments
@@ -1745,7 +1763,7 @@ async fn run_comment_load(
 
     let _ = tx.send(AppMessage::CommentsLoaded {
         gen,
-        story: Box::new(story),
+        story,
         comments: root_comments,
         pending_roots,
     });
@@ -1813,10 +1831,14 @@ mod tests {
         }
     }
 
-    fn fake_story_with_kids(id: u64, kids: Vec<u64>) -> Item {
+    fn fake_arc(id: u64) -> Arc<Item> {
+        Arc::new(fake_item(id))
+    }
+
+    fn fake_arc_with_kids(id: u64, kids: Vec<u64>) -> Arc<Item> {
         let mut s = fake_item(id);
         s.kids = Some(kids);
-        s
+        Arc::new(s)
     }
 
     fn fake_comment(id: u64) -> CommentWithDepth {
@@ -1875,7 +1897,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::StoriesLoaded {
                 gen,
-                stories: vec![fake_item(1), fake_item(2)],
+                stories: vec![fake_arc(1), fake_arc(2)],
                 all_ids: Some(vec![1, 2]),
                 mode: LoadMode::Replace,
             })
@@ -1893,7 +1915,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::StoriesLoaded {
                 gen: stale_gen,
-                stories: vec![fake_item(99)],
+                stories: vec![fake_arc(99)],
                 all_ids: Some(vec![99]),
                 mode: LoadMode::Replace,
             })
@@ -1920,7 +1942,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::StoriesLoaded {
                 gen: gen_feed_one,
-                stories: vec![fake_item(101), fake_item(102)],
+                stories: vec![fake_arc(101), fake_arc(102)],
                 all_ids: Some(vec![101, 102]),
                 mode: LoadMode::Replace,
             })
@@ -1929,7 +1951,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::StoriesLoaded {
                 gen: gen_feed_two,
-                stories: vec![fake_item(201), fake_item(202)],
+                stories: vec![fake_arc(201), fake_arc(202)],
                 all_ids: Some(vec![201, 202]),
                 mode: LoadMode::Replace,
             })
@@ -1949,7 +1971,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::SearchResultsLoaded {
                 gen: stale_gen,
-                stories: vec![fake_item(5)],
+                stories: vec![fake_arc(5)],
                 total_pages: 7,
                 total_hits: 42,
                 mode: LoadMode::Replace,
@@ -1968,7 +1990,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::CommentsLoaded {
                 gen,
-                story: Box::new(fake_story_with_kids(10, vec![100, 101])),
+                story: fake_arc_with_kids(10, vec![100, 101]),
                 comments: vec![fake_comment(100), fake_comment(101)],
                 pending_roots: HashSet::new(),
             })
@@ -1992,7 +2014,7 @@ mod tests {
         app.msg_tx
             .send(AppMessage::CommentsLoaded {
                 gen: stale_gen,
-                story: Box::new(fake_story_with_kids(999, vec![])),
+                story: fake_arc_with_kids(999, vec![]),
                 comments: vec![],
                 pending_roots: HashSet::new(),
             })
@@ -2242,11 +2264,11 @@ mod tests {
     #[test]
     fn apply_loaded_stories_replace_installs_fresh_list() {
         let mut app = App::new(80, 24);
-        app.story_state.stories = vec![fake_item(99), fake_item(98)];
+        app.story_state.stories = vec![fake_arc(99), fake_arc(98)];
         app.story_state.selected = 1;
         app.story_state.loading = true;
         app.error = Some("old".into());
-        app.apply_loaded_stories(vec![fake_item(1), fake_item(2)], LoadMode::Replace);
+        app.apply_loaded_stories(vec![fake_arc(1), fake_arc(2)], LoadMode::Replace);
         let ids: Vec<u64> = app.story_state.stories.iter().map(|s| s.id).collect();
         assert_eq!(ids, vec![1, 2], "Replace installs the new list");
         assert!(!app.story_state.loading, "loading cleared");
@@ -2256,9 +2278,9 @@ mod tests {
     #[test]
     fn apply_loaded_stories_append_extends_existing_list() {
         let mut app = App::new(80, 24);
-        app.story_state.stories = vec![fake_item(1), fake_item(2)];
+        app.story_state.stories = vec![fake_arc(1), fake_arc(2)];
         app.story_state.loading = true;
-        app.apply_loaded_stories(vec![fake_item(3), fake_item(4)], LoadMode::Append);
+        app.apply_loaded_stories(vec![fake_arc(3), fake_arc(4)], LoadMode::Append);
         let ids: Vec<u64> = app.story_state.stories.iter().map(|s| s.id).collect();
         assert_eq!(ids, vec![1, 2, 3, 4], "Append extends");
         assert!(!app.story_state.loading);
@@ -2269,7 +2291,7 @@ mod tests {
     fn loaded_story(app: &mut App, id: u64) {
         // Minimal fixture for cycle_comment_filter: a loaded story so
         // `comment_state.story.is_some()` short-circuits don't fire.
-        app.comment_state.story = Some(fake_item(id));
+        app.comment_state.story = Some(fake_arc(id));
     }
 
     #[test]

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -12,6 +12,7 @@ use crate::api::types::{CommentId, CommentWithDepth, Item};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// Cached `(filter, comments.len())` keyed visible-set, owned by
 /// [`CommentTreeState::filter_cache`]. Outer `Option` is the cache
@@ -111,7 +112,9 @@ pub struct CommentTreeState {
     /// [`crate::app::AppMessage::CommentsDone`].
     pub loading: bool,
     /// The story whose comments are loaded. `None` between selections.
-    pub story: Option<Item>,
+    /// Held as `Arc<Item>` so the cached pointer travels in from
+    /// `AppMessage::CommentsLoaded` without a deep clone (#140).
+    pub story: Option<Arc<Item>>,
     /// Root-comment IDs whose subtrees are still being fetched.
     pub pending_root_ids: HashSet<CommentId>,
     /// Maps screen row (relative to inner area top) → visible comment index.
@@ -200,11 +203,11 @@ impl CommentTreeState {
     /// contiguous suffix starting at the next index whose depth stays
     /// strictly greater than the comment's own depth. Outer loop is
     /// O(n); inner scan is bounded by the tree depth (capped at
-    /// [`crate::app::MAX_COMMENT_DEPTH`] = 10), so total cost is
+    /// `crate::app::MAX_COMMENT_DEPTH` = 10), so total cost is
     /// O(n × MAX_DEPTH) — essentially linear. Called from
     /// [`Self::set_comments`] and [`Self::insert_children`]; the count
     /// stays current with every tree mutation so
-    /// [`crate::ui::comment_tree::count_hidden_children`] can return
+    /// `crate::ui::comment_tree::count_hidden_children` can return
     /// the value in O(1) (closes #138).
     fn recompute_descendant_counts(&mut self) {
         let n = self.comments.len();
@@ -705,7 +708,7 @@ mod tests {
         state.collapsed.insert(cid(1));
         state.selected = 2;
         state.loading = true;
-        state.story = Some(make_item(99));
+        state.story = Some(Arc::new(make_item(99)));
         state.pending_root_ids.insert(cid(1));
         state.reset();
         assert!(state.comments.is_empty());

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -6,6 +6,7 @@
 //! pagination when the cursor approaches the end.
 
 use crate::api::types::Item;
+use std::sync::Arc;
 
 /// State for the story-list pane.
 ///
@@ -17,9 +18,14 @@ use crate::api::types::Item;
 /// once when stories load so per-frame rendering doesn't re-parse URLs.
 /// Mutate `stories` only through [`Self::replace_stories`] /
 /// [`Self::append_stories`] so the cache stays in sync.
+///
+/// Items are owned through `Arc<Item>` end-to-end with the
+/// [`crate::api::client::HnClient`] LRU cache — see #94 / #140 — so a
+/// feed page that returns 30 items adds 30 Arc clones (~30 atomic
+/// increments) instead of 30 deep `Item` clones.
 #[derive(Default)]
 pub struct StoryListState {
-    pub stories: Vec<Item>,
+    pub stories: Vec<Arc<Item>>,
     /// Pre-computed `story.domain()` for each story at the same index.
     /// Avoids the per-frame `url::Url::parse` that
     /// [`StoryList`](crate::ui::story_list::StoryList) used to do.
@@ -39,14 +45,14 @@ impl StoryListState {
     /// Replaces the loaded stories and refreshes the parallel domain
     /// cache. Use instead of `state.stories = ...` so per-frame rendering
     /// can keep using the cache.
-    pub fn replace_stories(&mut self, stories: Vec<Item>) {
-        self.domains = stories.iter().map(Item::domain).collect();
+    pub fn replace_stories(&mut self, stories: Vec<Arc<Item>>) {
+        self.domains = stories.iter().map(|s| s.domain()).collect();
         self.stories = stories;
     }
 
     /// Appends a paginated batch and extends the parallel domain cache.
-    pub fn append_stories(&mut self, stories: Vec<Item>) {
-        self.domains.extend(stories.iter().map(Item::domain));
+    pub fn append_stories(&mut self, stories: Vec<Arc<Item>>) {
+        self.domains.extend(stories.iter().map(|s| s.domain()));
         self.stories.extend(stories);
     }
 
@@ -90,7 +96,7 @@ impl StoryListState {
     }
 
     #[must_use]
-    pub fn selected_story(&self) -> Option<&Item> {
+    pub fn selected_story(&self) -> Option<&Arc<Item>> {
         self.stories.get(self.selected)
     }
 
@@ -142,7 +148,7 @@ mod tests {
     fn state_with_stories(n: usize) -> StoryListState {
         let mut s = StoryListState::new();
         for i in 0..n {
-            s.stories.push(make_item(i as u64));
+            s.stories.push(Arc::new(make_item(i as u64)));
         }
         s
     }

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -15,11 +15,12 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Widget},
 };
+use std::sync::Arc;
 
 /// Stateless widget that renders the left pane. Composed from borrowed
 /// app state; rebuilt each frame.
 pub struct StoryList<'a> {
-    pub stories: &'a [Item],
+    pub stories: &'a [Arc<Item>],
     /// Pre-computed `Item::domain()` results, parallel to `stories`.
     /// Avoids a per-frame `url::Url::parse` per visible row.
     pub domains: &'a [Option<String>],


### PR DESCRIPTION
## Summary

`fetch_items` used to deref-clone the cached `Arc<Item>` at its boundary into `Vec<Option<Item>>`, undoing #94's Arc work and copying every field of every item per page load. This PR pushes the `Arc` all the way into `StoryListState` so the cached pointer becomes the story-list pointer with zero deep clones.

**Boundary changes**
- `HnClient::fetch_items` → `Vec<Option<Arc<Item>>>`
- `HnClient::fetch_items_page` → `Vec<Arc<Item>>`
- `HnClient::fetch_stories` → `(Vec<Arc<Item>>, Vec<u64>)`

**Plumbing**
- `AppMessage::StoriesLoaded` / `SearchResultsLoaded` carry `Vec<Arc<Item>>`.
- `AppMessage::CommentsLoaded` carries `Arc<Item>` directly (replaces `Box<Item>` — `Arc<Item>` is one pointer, already heap-stored).
- `apply_loaded_stories` takes `Vec<Arc<Item>>`.
- `StoryListState::stories: Vec<Arc<Item>>`; `replace_stories`, `append_stories`, `selected_story` updated.
- `CommentTreeState::story: Option<Arc<Item>>`.
- `ui::story_list::StoryList::stories: &[Arc<Item>]` — `Arc` deref makes every consumer (badge, `display_title`, score, by, url, …) work unchanged.
- Algolia search wraps each returned `Item` in `Arc::new` so both load paths produce the same shape downstream.

**Deferred**
- `FlatComment::item` still owns `Item` directly. `run_comment_load` and `fetch_children_recursive` unwrap the cached `Arc` via `try_unwrap` (falling back to a deep clone when the LRU still holds the entry — identical cost to the old boundary, just expressed explicitly). A full Arc-through-`FlatComment` refactor is deferred.

Fixes #140.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 368 passed; existing story-state and app-state fixtures updated to use new `fake_arc` / `fake_arc_with_kids` helpers
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --document-private-items`
- [ ] CI green