### PR TITLE
docs: post-0.4.0 docstring sweep (32 findings)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -15,9 +15,18 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+/// Firebase HN API root. All non-search requests interpolate this base.
 const BASE_URL: &str = "https://hacker-news.firebaseio.com/v0";
+/// Algolia HN search endpoint. Used by [`HnClient::search_stories`] and
+/// [`HnClient::search_by_url`].
 const ALGOLIA_URL: &str = "https://hn.algolia.com/api/v1/search";
+/// Outstanding-fetch ceiling for [`HnClient::fetch_items`]. Empirically
+/// chosen — above ~20 the HN endpoint has been observed to return
+/// truncated or rate-limited responses.
 const CONCURRENT_REQUESTS: usize = 20;
+/// LRU item-cache capacity. Sized to hold a typical browse session
+/// (several feed pages × their comment trees) without evicting the
+/// stories the user is likely to revisit.
 const CACHE_CAPACITY: usize = 2000;
 
 /// Shared HTTP client for the Hacker News API.

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -115,11 +115,19 @@ pub struct CommentId(pub u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ItemType {
+    /// User-submitted link or HN-native text post.
     Story,
+    /// Reply within a comment thread.
     Comment,
+    /// YC "Who's hiring" / "Who wants to be hired" entry.
     Job,
+    /// Multiple-choice poll question.
     Poll,
+    /// One option of a [`Self::Poll`].
     Pollopt,
+    /// Forward-compat catch-all for tags this build doesn't recognise —
+    /// keeps the app decoding rather than crashing when HN adds a new
+    /// variant.
     #[serde(other)]
     Unknown,
 }
@@ -129,11 +137,19 @@ pub enum ItemType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StoryBadge {
+    /// "Ask HN:" — a question post.
     Ask,
+    /// "Show HN:" — a project / work-in-progress reveal.
     Show,
+    /// "Tell HN:" — a narrative or anecdote post (rare).
     Tell,
+    /// "Launch HN:" — a YC company launch announcement.
     Launch,
+    /// Item type was [`ItemType::Job`] — derived from `item_type`, not
+    /// title prefix.
     Job,
+    /// Item type was [`ItemType::Poll`] — derived from `item_type`, not
+    /// title prefix.
     Poll,
 }
 
@@ -258,11 +274,17 @@ fn url_domain(raw: &str) -> Option<String> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FeedKind {
+    /// Front-page stories — Firebase `topstories` endpoint.
     Top,
+    /// Newest submissions — Firebase `newstories`.
     New,
+    /// Best-of recent — Firebase `beststories`.
     Best,
+    /// Ask HN posts — Firebase `askstories`.
     Ask,
+    /// Show HN posts — Firebase `showstories`.
     Show,
+    /// Job postings — Firebase `jobstories`.
     Jobs,
     /// Locally-curated stories saved by the user (`b` to toggle). Aggregated
     /// by [`crate::state::pin_store::PinStore`], not fetched over HTTP.

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -17,7 +17,12 @@ use std::fmt;
 /// stories and counts the total transitive comment count.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Item {
+    /// HN item ID — unique across all item kinds. Stays as raw `u64`
+    /// for serde simplicity; [`StoryId`] / [`CommentId`] wrap it at app
+    /// boundaries where mixing IDs would be a bug.
     pub id: u64,
+    /// Story headline / job title. `None` on comments (the body lives
+    /// in `text`).
     #[serde(default)]
     pub title: Option<String>,
     /// Story URL — only populated for `http`/`https` schemes. Other
@@ -26,22 +31,40 @@ pub struct Item {
     /// [`validate_http_url`].
     #[serde(default, deserialize_with = "deserialize_http_url")]
     pub url: Option<String>,
+    /// HTML-formatted comment body, or HN-native post body (Ask HN,
+    /// Show HN text, job description). `None` for URL stories.
     #[serde(default)]
     pub text: Option<String>,
+    /// Submitter's HN username. `None` for deleted authors.
     #[serde(default)]
     pub by: Option<String>,
+    /// Net score (upvotes − downvotes). `None` on items that aren't
+    /// scored (comments, polls in some cases).
     #[serde(default)]
     pub score: Option<i64>,
+    /// Submission timestamp in Unix seconds. `None` only on the rare
+    /// malformed item.
     #[serde(default)]
     pub time: Option<i64>,
+    /// Direct child IDs — top-level comment IDs for a story, reply IDs
+    /// for a comment. HN-supplied order (roughly chronological with
+    /// moderator reshuffles).
     #[serde(default)]
     pub kids: Option<Vec<u64>>,
+    /// Total transitive comment count. Only set on stories — `None` on
+    /// comments and (typically) jobs.
     #[serde(default)]
     pub descendants: Option<i64>,
+    /// Firebase `type` field (`story` / `comment` / `job` / `poll` /
+    /// `pollopt`). Unknown future strings collapse to
+    /// [`ItemType::Unknown`] via `#[serde(other)]` so wire-format
+    /// evolution doesn't crash the app.
     #[serde(rename = "type", default)]
     pub item_type: Option<ItemType>,
+    /// Killed by moderators — see [`Self::is_dead_or_deleted`].
     #[serde(default)]
     pub dead: Option<bool>,
+    /// Removed by the author — see [`Self::is_dead_or_deleted`].
     #[serde(default)]
     pub deleted: Option<bool>,
 }
@@ -187,23 +210,38 @@ impl StoryBadge {
 /// of "is this id real" guards).
 #[derive(Debug, Deserialize)]
 pub struct SearchHit {
+    /// Algolia's object identifier — a stringified u64 HN item ID.
+    /// Parsed back to `u64` by `TryFrom<SearchHit> for Item`.
     #[serde(rename = "objectID")]
     pub object_id: String,
+    /// Story title at index time.
     pub title: Option<String>,
+    /// Story URL — `None` for HN-native posts. Re-validated through
+    /// `validate_http_url` inside `TryFrom` before reaching `Item::url`.
     pub url: Option<String>,
+    /// Submitter's HN username. Maps to `Item::by`.
     pub author: Option<String>,
+    /// Net score at index time. Maps to `Item::score`.
     pub points: Option<i64>,
+    /// Comment count at index time. Maps to `Item::descendants`.
     pub num_comments: Option<i64>,
+    /// Submission time in Unix seconds (integer form — the `_i` suffix
+    /// is the Algolia wire-side naming). Maps to `Item::time`.
     pub created_at_i: Option<i64>,
+    /// HN-native post body. Maps to `Item::text`.
     pub story_text: Option<String>,
 }
 
 /// Top-level envelope of an Algolia search response.
 #[derive(Debug, Deserialize)]
 pub struct SearchResponse {
+    /// Result entries for the requested page, in Algolia-relevance order.
     pub hits: Vec<SearchHit>,
+    /// Total page count for the query — drives the lazy-pagination cap
+    /// in `App::check_lazy_load`.
     #[serde(rename = "nbPages")]
     pub nb_pages: usize,
+    /// Total hit count across all pages — surfaced in the status bar.
     #[serde(rename = "nbHits")]
     pub nb_hits: usize,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,8 +26,19 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
+/// Floor for `page_size()` so a tiny terminal still requests a useful
+/// batch — fewer than ~30 items per fetch would round-trip the Firebase
+/// list endpoint more than necessary on lazy-load pagination.
 const MIN_PAGE_SIZE: usize = 30;
+/// Rows per `PageDown` / `PageUp` action. Smaller than a literal
+/// terminal page so the user keeps two-thirds of the prior context in
+/// view across each jump.
 const SCROLL_PAGE: usize = 10;
+/// Hard cap on comment-subtree depth walked by
+/// `HnClient::fetch_children_recursive`. Deeper threads exist on HN but
+/// rendering and navigation in the TUI degrade past ~10 levels of
+/// indent, and the bound prevents pathological recursion on adversarial
+/// input.
 const MAX_COMMENT_DEPTH: usize = 10;
 /// Maximum prior-discussions results retained across a session. Long
 /// browse sessions otherwise grow this cache unboundedly (one entry per

--- a/src/app.rs
+++ b/src/app.rs
@@ -1698,7 +1698,11 @@ impl App {
 /// this guard, the user would be unable to reopen prior-discussions for
 /// that story for the rest of the session.
 struct PriorInFlightGuard {
+    /// Shared in-flight set — refcount-cloned from `App::prior_in_flight`
+    /// so the guard outlives the spawn and can still reach the set on
+    /// drop.
     set: Arc<Mutex<HashSet<StoryId>>>,
+    /// The story ID this guard is responsible for clearing on drop.
     id: StoryId,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -422,9 +422,19 @@ impl App {
 
     /// Shared body for [`Self::try_advance_resume`] (in-progress) and
     /// [`Self::finalize_pending_resume`] (final pass after `CommentsDone`).
-    /// Returns silently with the resume still pending when the loaded
-    /// tree hasn't grown enough yet — except in the final pass, where
-    /// past-end targets clamp to `visible_len - 1` and the resume clears.
+    ///
+    /// Five outcomes:
+    /// - No pending resume → returns silently.
+    /// - `comment_state.story` is `None` → clears the resume (the user
+    ///   left the comments pane).
+    /// - Loaded `story_id` doesn't match the pending target → clears
+    ///   the resume (the user moved to a different story).
+    /// - Visible-tree empty → leaves the resume pending, or clears
+    ///   when `clamp_to_end` is set (final pass — no clamp possible).
+    /// - Target inside visible range → places the cursor and clears.
+    /// - Target past visible range → leaves the resume pending, except
+    ///   in the final pass where it clamps to `visible_len - 1` and
+    ///   clears.
     fn apply_pending_resume(&mut self, clamp_to_end: bool) {
         let Some(target) = self.pending_pinned_resume else {
             return;
@@ -1291,8 +1301,14 @@ impl App {
     /// Opens the reader overlay for the story in the focused pane.
     ///
     /// For text-only posts (Ask HN, etc.) renders the inline `text`
-    /// locally. For URL stories, validates the http(s) scheme and then
-    /// spawns a fetch + readability extraction task.
+    /// locally via [`html_to_styled_lines`] — no network I/O. For URL
+    /// stories, validates the http(s) scheme and then spawns a fetch
+    /// + readability extraction task.
+    ///
+    /// Bumps [`Self::article_gen`] before spawning so any in-flight
+    /// fetch from a previously-opened reader (or from
+    /// [`Self::open_url_in_reader`]) is invalidated and its result
+    /// dropped by [`Self::process_messages`].
     fn open_article_reader(&mut self) {
         let Some(story) = (match self.focus {
             Pane::Stories => self.story_state.selected_story().cloned(),
@@ -1425,11 +1441,12 @@ impl App {
 
     /// Handles a mouse left-click at the given terminal cell.
     ///
-    /// Maps the cell to a pane via `build_layout`: in the stories pane,
-    /// selects the clicked story (triggering lazy load + comment fetch);
-    /// in the comments pane, selects the clicked comment, treating a second
-    /// click on the same row within 400ms as a double-click to toggle
-    /// collapse. No-op when the reader overlay is open.
+    /// Routes through [`Self::pane_at`] (which calls `build_layout`
+    /// internally): in the stories pane, selects the clicked story
+    /// (triggering lazy load + comment fetch); in the comments pane,
+    /// selects the clicked comment, treating a second click on the
+    /// same row within 400ms as a double-click to toggle collapse.
+    /// No-op when the reader overlay is open.
     pub fn handle_click(&mut self, column: u16, row: u16) {
         // When reader is open, consume clicks
         if self.reader_state.is_some() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -381,7 +381,11 @@ impl App {
         visible.max(MIN_PAGE_SIZE)
     }
 
-    /// Updates cached terminal dimensions after a resize event.
+    /// Caches the new terminal dimensions after `Event::Resize`. Read
+    /// by [`Self::page_size`] (story pagination batch sizing) and by
+    /// `open_article_reader` / `open_url_in_reader` for the
+    /// `width.saturating_sub(6)` text-wrap width. Rendered widgets pick
+    /// the change up on the next draw.
     pub fn set_terminal_size(&mut self, w: u16, h: u16) {
         self.terminal_width = w;
         self.terminal_height = h;
@@ -1027,7 +1031,10 @@ impl App {
         ));
     }
 
-    /// Transitions into search-input mode, showing an empty search prompt.
+    /// Transitions into search-input mode, showing an empty search
+    /// prompt. Also forces focus back to the Stories pane so the
+    /// user's first character of input doesn't land on a
+    /// focused-Comments keymap.
     pub fn enter_search_mode(&mut self) {
         self.input_mode = InputMode::SearchInput;
         self.search_state = Some(SearchState::new());

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,9 @@ const PROCESS_MESSAGES_BUDGET: usize = 32;
 /// Which content pane currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
+    /// Left pane — the story list.
     Stories,
+    /// Right pane — the comment tree.
     Comments,
 }
 
@@ -53,7 +55,10 @@ pub enum Pane {
 /// `false`) and prevent flipped-arg bugs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadMode {
+    /// Discard the current story list and install the new one — used on
+    /// initial load, feed switch, refresh, and search submit.
     Replace,
+    /// Extend the current list with a new page — lazy-pagination tail.
     Append,
 }
 

--- a/src/article.rs
+++ b/src/article.rs
@@ -13,7 +13,11 @@ use html2text::render::RichAnnotation;
 use ratatui::style::{Modifier, Style};
 use std::sync::OnceLock;
 
-const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024; // 5MB
+/// Hard cap on article body size — 5 MB. Larger responses are rejected
+/// before allocation so a malicious site can't OOM the reader. Checked
+/// twice: once against `Content-Length` (pre-stream) and once against
+/// the actual byte count (in case the header is absent or wrong).
+const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
 /// Shared HTTP client for article fetches. Built once on first use so
 /// connection pools are reused across reader opens (multiple GH README

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,9 +16,15 @@ use tokio::sync::mpsc;
 /// (e.g. the loading spinner).
 #[derive(Debug)]
 pub enum Event {
+    /// A crossterm keypress (modifiers + code), forwarded verbatim.
     Key(KeyEvent),
+    /// A crossterm mouse event — click, scroll, or motion.
     Mouse(MouseEvent),
+    /// Terminal resize. New dimensions are cached on `App` via
+    /// `App::set_terminal_size`; widgets pick them up on the next draw.
     Resize { width: u16, height: u16 },
+    /// Fixed-rate timer pulse; drives the loading-spinner animation.
+    /// Does not imply user activity.
     Tick,
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -15,7 +15,12 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 /// characters for the search-query input or a Quickjump hint label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
+    /// Default navigation mode — `main.rs` routes keys through
+    /// [`map_key`] to produce [`Action`]s.
     Normal,
+    /// Active while the user is typing a search query — `main.rs`
+    /// routes raw chars to `App::search_input_char` and Enter to
+    /// `App::submit_search`.
     SearchInput,
     /// Active during Quickjump label selection — `main.rs` routes raw
     /// chars to [`Action::HintKey`] and Esc to [`Action::ExitHintMode`].
@@ -30,21 +35,46 @@ pub enum InputMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Action {
+    /// Tear down the main loop on the next iteration (`App::running = false`).
     Quit,
+    /// Move the cursor up one row in the focused pane or overlay.
     MoveUp,
+    /// Move the cursor down one row in the focused pane or overlay.
     MoveDown,
+    /// Stories pane → load the focused story's comments. Comments pane →
+    /// toggle the focused subtree's collapse. Prior-discussions overlay
+    /// → load the selected submission as if it had been opened from the
+    /// stories pane.
     Select,
+    /// Open the focused story's URL in the system browser. Falls back
+    /// to `https://news.ycombinator.com/item?id=<id>` for HN-native
+    /// posts (Ask HN, etc.) that don't carry an external URL.
     OpenInBrowser,
+    /// Open the focused story in the inline article-reader overlay.
     OpenReader,
+    /// Cycle keyboard focus between the stories and comments panes.
     SwitchPane,
+    /// Switch the active feed by index into [`crate::api::types::FeedKind::ALL`]
+    /// (0..=6). Out-of-range indices are silently ignored.
     SwitchFeed(usize),
+    /// Reload the current feed (or rerun the current search). Bumps
+    /// every generation counter so in-flight spawns land as no-ops and
+    /// clears the prior-discussions LRU.
     Refresh,
+    /// Jump the cursor / scroll to the top of the focused pane or overlay.
     JumpTop,
+    /// Jump the cursor / scroll to the bottom of the focused pane or overlay.
     JumpBottom,
+    /// Advance by one page (`SCROLL_PAGE` rows) in the focused pane or
+    /// overlay.
     PageDown,
+    /// Move up by one page in the focused pane or overlay.
     PageUp,
+    /// Show or hide the modal keybindings overlay.
     ToggleHelp,
+    /// Show or hide the prior-discussions overlay for the loaded story.
     TogglePriorDiscussions,
+    /// Enter search-input mode with an empty query buffer.
     EnterSearch,
     /// Cycle the comment-pane "what's new" filter: All → New since last
     /// visit → Recent 24h → All. Falls through to All when the story has
@@ -63,6 +93,10 @@ pub enum Action {
     HintKey(char),
     /// Cancel hint-label selection and return to the prior input mode.
     ExitHintMode,
+    /// Context-sensitive cancel: close the current overlay if one is
+    /// open → cancel a search if one is active → leave the comments
+    /// pane back to stories → quit. The comments-pane back path also
+    /// snapshots any pinned-resume state and bumps `story_gen`.
     Back,
 }
 

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -31,9 +31,16 @@ type FilterCache = Option<((CommentFilter, usize), Option<Rc<HashSet<usize>>>)>;
 /// thread reads coherently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CommentFilter {
+    /// No filter — every comment in the loaded tree is visible (modulo
+    /// collapse). Default state and reset target on `set_comments`.
     #[default]
     All,
+    /// Show comments newer than the user's previous visit (Unix seconds
+    /// from `read_store.last_seen_at`). Ancestors of passing comments
+    /// stay visible so reply context survives.
     NewSince(i64),
+    /// Show comments newer than `now - 24h - 60s skew` (Unix seconds).
+    /// Same ancestor-keep rule as [`Self::NewSince`].
     Recent(i64),
 }
 

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -201,10 +201,12 @@ impl CommentTreeState {
     ///
     /// For a pre-order flat tree, each comment's descendants are the
     /// contiguous suffix starting at the next index whose depth stays
-    /// strictly greater than the comment's own depth. Outer loop is
-    /// O(n); inner scan is bounded by the tree depth (capped at
-    /// `crate::app::MAX_COMMENT_DEPTH` = 10), so total cost is
-    /// O(n × MAX_DEPTH) — essentially linear. Called from
+    /// strictly greater than the comment's own depth. The inner `while`
+    /// loop walks every descendant of the current comment, so total
+    /// cost is the sum of all subtree sizes — O(n²) worst case on a
+    /// single tall chain, but effectively linear on real HN threads
+    /// which stay shallow (capped at `crate::app::MAX_COMMENT_DEPTH`
+    /// = 10) and broad rather than tall. Called from
     /// [`Self::set_comments`] and [`Self::insert_children`]; the count
     /// stays current with every tree mutation so
     /// `crate::ui::comment_tree::count_hidden_children` can return

--- a/src/state/hint_state.rs
+++ b/src/state/hint_state.rs
@@ -24,7 +24,11 @@ pub enum HintAction {
 /// user enters hint mode there.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HintContext {
+    /// The labels overlay sits over the article reader's hyperlinks.
     Reader,
+    /// The labels overlay sits over comment-body hyperlinks — currently
+    /// a stub (the comments registry isn't wired yet; see
+    /// `App::active_link_registry`).
     Comments,
 }
 

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -14,6 +14,9 @@ const ALPHABET: &[u8] = b"asdfweiou";
 /// One labeled hyperlink within a rendered surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkRef {
+    /// Target URL, scrubbed through `sanitize_terminal` at
+    /// registry-build time so the hint overlay can't reflect attacker
+    /// bytes back to the terminal.
     pub url: String,
     /// Line index within the rendered `Vec<Vec<StyledFragment>>`.
     pub line: usize,
@@ -47,6 +50,8 @@ pub enum MatchResult<'a> {
 /// by the input-mode dispatch on every keypress.
 #[derive(Debug, Default)]
 pub struct LinkRegistry {
+    /// Insertion-ordered list of registered links. Labels are assigned
+    /// uniformly once by [`Self::assign_labels`] and not after.
     pub links: Vec<LinkRef>,
 }
 

--- a/src/state/search_state.rs
+++ b/src/state/search_state.rs
@@ -11,10 +11,20 @@
 /// why pagination anchors to `query`.
 #[derive(Default)]
 pub struct SearchState {
+    /// Committed search query — what pagination spawns send to Algolia.
+    /// Empty until `App::submit_search` copies from `input`.
     pub query: String,
+    /// In-progress typed input buffer. Driven by
+    /// `App::search_input_char` / `_backspace` while
+    /// [`crate::keys::InputMode::SearchInput`] is active.
     pub input: String,
+    /// Last-fetched Algolia page index (0-based). Bumped by
+    /// `App::check_lazy_load` when the user nears the loaded tail.
     pub current_page: usize,
+    /// Total pages reported by the most recent Algolia response —
+    /// drives the lazy-pagination cap.
     pub total_pages: usize,
+    /// Total hit count from Algolia — surfaced in the status bar.
     pub total_hits: usize,
 }
 

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -25,13 +25,26 @@ use std::sync::Arc;
 /// increments) instead of 30 deep `Item` clones.
 #[derive(Default)]
 pub struct StoryListState {
+    /// Currently loaded story window. Mutate only through
+    /// [`Self::replace_stories`] / [`Self::append_stories`] so
+    /// `domains` stays in sync.
     pub stories: Vec<Arc<Item>>,
     /// Pre-computed `story.domain()` for each story at the same index.
     /// Avoids the per-frame `url::Url::parse` that
     /// [`StoryList`](crate::ui::story_list::StoryList) used to do.
     pub domains: Vec<Option<String>>,
+    /// Full ID list from the initial feed fetch — used as a stable
+    /// pagination index so a feed that gains stories mid-session
+    /// doesn't shift the offset. Refreshed only on Replace; appended
+    /// pages reuse the snapshot.
     pub all_ids: Vec<u64>,
+    /// Cursor row, indexing into `stories`. Clamped by every nav
+    /// method so it never points past the loaded tail.
     pub selected: usize,
+    /// True while a feed-page fetch is in flight; flipped on by
+    /// `App::spawn_load_stories` before spawn (so the
+    /// "Loading stories..." placeholder appears immediately) and off
+    /// in `apply_loaded_stories`.
     pub loading: bool,
 }
 

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -45,10 +45,21 @@ fn build_block_title_label(story: &Item) -> String {
 /// non-zero — the number of prior HN submissions of the loaded story's URL
 /// that the [`crate::ui::prior_overlay`] overlay (bound to `h`) will surface.
 pub struct CommentTree<'a> {
+    /// Mutable handle to the comment-pane state — rendering populates
+    /// `row_map` and may advance `scroll` to keep the selection in view.
     pub state: &'a mut CommentTreeState,
+    /// Pre-walked visible-comment indices (from
+    /// [`CommentTreeState::visible_indices`]); shared with the status
+    /// bar so the two stay in sync within a single frame.
     pub visible: &'a [usize],
+    /// True when the comments pane has keyboard focus — drives the
+    /// border accent.
     pub focused: bool,
+    /// Monotonic tick counter; indexes into the loading-spinner glyph
+    /// sequence.
     pub tick: u64,
+    /// Prior-discussions count for the loaded story; rendered as the
+    /// `· N prior (h)` title suffix when non-zero.
     pub prior_count: usize,
     /// Wall-clock timestamp captured once per frame in [`crate::ui::render`]
     /// so the `Ns/Nm/Nh` ago column doesn't `clock_gettime` per visible

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -12,7 +12,11 @@ use ratatui::{
 /// Top header: brand, feed tabs (highlighting `current_feed` unless a
 /// search is active), and a "Search" chip when `search_active`.
 pub struct Header {
+    /// Highlighted feed tab — ignored when `search_active` is true so
+    /// the "Search" chip wins the active highlight.
     pub current_feed: FeedKind,
+    /// Whether to paint the "Search" indicator and suppress the feed
+    /// tab highlight.
     pub search_active: bool,
 }
 

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -6,6 +6,9 @@
 use indicatif::ProgressStyle;
 use std::sync::OnceLock;
 
+/// Braille glyphs cycled by [`frame`]. Six frames chosen for visual
+/// continuity at the ~4 Hz tick rate — fewer would look stuttery,
+/// more would slow the perceived motion.
 const FRAMES: &[&str] = &["⠾", "⠷", "⠯", "⠟", "⠻", "⠽"];
 
 fn style() -> &'static ProgressStyle {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -22,12 +22,25 @@ use ratatui::{
 /// rebuilt per-frame and consumed immediately, so ownership is
 /// unnecessary — cloning the same strings every frame was wasted work.
 pub struct StatusBar<'a> {
+    /// Currently selected feed — drives the `[<Feed>]` chip on the
+    /// left.
     pub feed: FeedKind,
+    /// Pre-formatted "N/total" counter for the focused pane, built by
+    /// `ui::render`.
     pub position: &'a str,
+    /// Last error to surface (sanitised at render time). `None` paints
+    /// the normal keybinding hint line instead.
     pub error: Option<&'a str>,
+    /// Pane label for the right-aligned `[Stories]` / `[Comments]` tag.
     pub focus_pane: &'static str,
+    /// Current input mode — drives the search-input vs normal layout
+    /// branch.
     pub input_mode: InputMode,
+    /// In-progress search input — rendered with a block cursor when
+    /// `input_mode == SearchInput`.
     pub search_input: Option<&'a str>,
+    /// Committed search query — rendered as the `Search: "<q>"` chip
+    /// while results are shown.
     pub search_query: Option<&'a str>,
 }
 

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -20,13 +20,23 @@ use std::sync::Arc;
 /// Stateless widget that renders the left pane. Composed from borrowed
 /// app state; rebuilt each frame.
 pub struct StoryList<'a> {
+    /// Loaded stories — borrowed for the frame's lifetime; rebuilt per
+    /// draw. `Arc<Item>` matches the cache shape so no deep clone is
+    /// needed to render.
     pub stories: &'a [Arc<Item>],
     /// Pre-computed `Item::domain()` results, parallel to `stories`.
     /// Avoids a per-frame `url::Url::parse` per visible row.
     pub domains: &'a [Option<String>],
+    /// Index into `stories` of the highlighted row.
     pub selected: usize,
+    /// Whether the pane currently has keyboard focus (drives border
+    /// accent).
     pub focused: bool,
+    /// True while the first batch is still in flight — paints
+    /// "Loading stories..." instead of the empty-list placeholder.
     pub loading: bool,
+    /// Active search query, when one is set — used in the pane title
+    /// (`" Search: <q> "`) in place of `" Stories "`.
     pub search_query: Option<&'a str>,
     /// Persisted read-state: stories present here render dimmed, and those
     /// whose comment count has grown since the last visit get a `+N` badge.

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -7,20 +7,40 @@
 
 use ratatui::style::{Color, Modifier, Style};
 
+/// Body background (Mocha "base").
 pub const BG: Color = Color::Rgb(30, 30, 46);
+/// Selected-row, accent-chip, and status-bar background (Mocha
+/// "surface0").
 pub const SURFACE: Color = Color::Rgb(49, 50, 68);
+/// Reserved for future nested-overlay backgrounds; unused today but
+/// kept for parity with the upstream Mocha palette.
 #[allow(dead_code)]
 pub const OVERLAY: Color = Color::Rgb(69, 71, 90);
+/// Primary foreground — body text (Mocha "text").
 pub const TEXT: Color = Color::Rgb(205, 214, 244);
+/// Secondary foreground — metadata, blockquote text (Mocha "subtext0").
 pub const SUBTEXT: Color = Color::Rgb(166, 173, 200);
+/// Dimmed foreground — visited-story titles, hint text (Mocha
+/// "overlay2").
 pub const DIM: Color = Color::Rgb(127, 132, 156);
+/// HN brand orange — accents, active tab, pin glyph, depth-0 comment
+/// thread bar.
 pub const HN_ORANGE: Color = Color::Rgb(255, 102, 0);
+/// "Show HN" badge and code-block foreground (Mocha "green").
 pub const GREEN: Color = Color::Rgb(166, 227, 161);
+/// Error text in the status bar (Mocha "red").
 pub const RED: Color = Color::Rgb(243, 139, 168);
+/// Hyperlink color and "Ask HN" badge (Mocha "blue").
 pub const BLUE: Color = Color::Rgb(137, 180, 250);
+/// "Job" badge and `h2` markdown headings (Mocha "yellow").
 pub const YELLOW: Color = Color::Rgb(249, 226, 175);
+/// "Tell HN" badge and inline-image marker (Mocha "mauve").
 pub const MAUVE: Color = Color::Rgb(203, 166, 247);
+/// "Poll" badge and one of the comment-depth thread bars (Mocha
+/// "teal").
 pub const TEAL: Color = Color::Rgb(148, 226, 213);
+/// "Launch HN" badge and one of the comment-depth thread bars (Mocha
+/// "peach").
 pub const PEACH: Color = Color::Rgb(250, 179, 135);
 
 /// Colors for comment depth levels (cycles through these).


### PR DESCRIPTION
## Summary

Follow-up to the 0.4.0 release: a full `/docstring-check` sweep over the 33 source files surfaced 32 findings. All applied here across 5 logically-separate commits for clean review.

## Commits

1. **`docs: correct prose drift in 4 internal helpers`** — fixes wrong/misleading docs:
   - `recompute_descendant_counts`: complexity claim said "O(n × MAX_DEPTH) — essentially linear" with "inner scan bounded by tree depth." The inner walk is bounded by descendant count, not depth — corrected to "O(sum of subtree sizes) — O(n²) worst case, effectively linear on shallow-broad HN threads."
   - `apply_pending_resume`: doc described 2 of 5 observable outcomes; now lists all five (no-pending / story-None / story-mismatch / empty-visible / inside-range / past-range).
   - `handle_click`: doc named `build_layout` directly; the function now routes through `Self::pane_at` (which calls `build_layout` internally). Names the actual call site.
   - `open_article_reader`: doc lacked the `bump_article_gen` invariant that every other `spawn_*` helper documents. Added.

2. **`docs: document enum variants on 8 public enums`** — `Action` (16 of 21 variants were bare), `InputMode`, `FeedKind`, `ItemType`, `StoryBadge`, `CommentFilter`, `Pane`/`LoadMode`, `Event`/`HintContext`.

3. **`docs: document pub struct fields across types, state, and widgets`** — `Item` (10 of 11 fields bare), `SearchHit` (8), `SearchResponse` (3), `SearchState`, `StoryListState`, all four ratatui widget structs (`Header`, `StatusBar`, `CommentTree`, `StoryList`), `LinkRef` / `LinkRegistry`, `PriorInFlightGuard`.

4. **`docs: document tuning constants across app, client, article, ui`** — `MIN_PAGE_SIZE`, `SCROLL_PAGE`, `MAX_COMMENT_DEPTH`, `BASE_URL`, `ALGOLIA_URL`, `CONCURRENT_REQUESTS`, `CACHE_CAPACITY`, `MAX_RESPONSE_BYTES`, `FRAMES`, and the full Catppuccin palette in `theme.rs`.

5. **`docs: expand under-informative pub-fn docs`** — `App::set_terminal_size` and `App::enter_search_mode` now name their non-obvious downstream readers / side effects.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 368 passed (no behavioural change)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --document-private-items` — clean
- [ ] CI green on ubuntu + macos