### PR TITLE
chore(deps): loosen patch pins and group Docker dependabot block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,6 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["dependencies"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ open = "5"
 chrono = "0.4"
 futures = "0.3"
 html2text = "0.17"
-readability-rs = { version = "0.5.0", default-features = false }
-url = "2.5.8"
-indicatif = "0.18.4"
+readability-rs = { version = "0.5", default-features = false }
+url = "2.5"
+indicatif = "0.18"
 lru = "0.18"


### PR DESCRIPTION
## Summary

Two hygiene-only cleanups surfaced by the `/dep-check` audit. No behavioural change, no lockfile change — `cargo check` still resolves to the same versions.

**H1 — `Cargo.toml`**: three deps were pinned to a specific patch where every peer used major- or minor-only constraints. Loosened for consistency:
- `readability-rs = \"0.5.0\"` → `\"0.5\"`
- `url = \"2.5.8\"` → `\"2.5\"`
- `indicatif = \"0.18.4\"` → `\"0.18\"`

Cargo's `^` semantics already absorbed future patches, so the lockfile resolution is byte-identical until a new patch ships — at which point `cargo update` picks it up without a manifest edit.

**H2 — `.github/dependabot.yml`**: the cargo and github-actions blocks already had a `groups: minor-and-patch` key that batches small bumps into one PR; the docker block didn't. Added it for parity — future Docker base-image minor/patch bumps now land grouped too.

## Test plan

- [x] `cargo check` — still resolves cleanly
- [x] `git diff` — only the 6 lines documented above
- [ ] CI green