### PR TITLE
ci: add cargo doc and cargo audit (closes #169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
       - run: cargo clippy -- -D warnings
       - run: cargo check
       - run: cargo test
+      - name: cargo doc (warnings = errors)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --document-private-items
+
+  audit:
+    name: cargo audit (RUSTSEC)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: Build (${{ matrix.os }})


### PR DESCRIPTION
Closes #169.

## Summary

- Appends a `cargo doc --no-deps --document-private-items` step (with `RUSTDOCFLAGS=\"-D warnings\"`) to the Check & Lint job. Prevents intra-doc-link rot at PR time instead of waiting for someone to run `cargo doc` locally.
- New `audit` job using `rustsec/audit-check@v2` complements Dependabot vuln alerts (enabled in #168) — Dependabot catches registry-level CVEs, audit-check catches them at PR time.

## Test plan

- [x] Local: `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --document-private-items` clean.
- [ ] CI: new audit job appears + Check & Lint shows the cargo doc step.