### PR TITLE
ci: run cargo test on the build matrix (closes #170)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo build --release
+      - run: cargo test --release --locked


### PR DESCRIPTION
Closes #170.

## Summary

- Changes the build job's `cargo build --release` to `cargo test --release --locked` so the macOS runner actually exercises tests.
- The `--locked` flag also enforces `Cargo.lock` reproducibility — a stale lockfile no longer silently updates during CI.

## Test plan

- [x] One-line YAML edit.
- [ ] CI green on both ubuntu and macos (tests must pass on both).