### PR TITLE
docs: add Closes # prompt and Screenshots section to PR template (closes #175)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,17 @@
+Closes #
+
 ## Summary
 
-<!-- What does this PR do? -->
+<!-- What does this PR do? Why? -->
 
 ## Test plan
 
-<!-- How did you verify the changes? -->
+<!-- How did you verify the changes? Specific commands or click-paths. -->
+
+## Screenshots / before-after
+
+<!-- Optional. Helpful for any change that affects the rendered UI. Remove
+this section if the change is non-visual. -->
 
 ## Checklist
 


### PR DESCRIPTION
Closes #175.

## Summary

- Leading `Closes #` line so GitHub auto-closes linked issues on merge (matches the convention adopted across the recent issue cycle).
- Optional `## Screenshots / before-after` section — useful in a TUI where most user-visible PRs change rendering. Marked optional so non-visual changes can drop the section.

## Test plan

- [x] Markdown renders cleanly on GitHub PR preview.
- [ ] CI green.