### PR TITLE
ci: restrict auto-merge to cargo ecosystem (closes #176)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,9 +17,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge
+        # Auto-merge only `cargo` ecosystem bumps. `github-actions` and
+        # `docker` updates carry elevated supply-chain risk (a compromised
+        # action gets the full GITHUB_TOKEN; a poisoned base image runs
+        # at build time), so they stay manual.
         if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+          steps.meta.outputs.package-ecosystem == 'cargo' && (
+            steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+            steps.meta.outputs.update-type == 'version-update:semver-minor'
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Closes #176.

## Summary

- Adds `steps.meta.outputs.package-ecosystem == 'cargo'` to the auto-merge `if:` gate.
- Effect: cargo patch/minor bumps continue to auto-merge (they can't run code at install time). `github-actions` and `docker` Dependabot PRs now stay open until manually reviewed — a compromised action gets the full `GITHUB_TOKEN` in CI and a poisoned base image runs at `docker build`, so both warrant a human glance.

## Test plan

- [x] YAML syntax sanity (single block edit).
- [ ] CI green.