### PR TITLE
docs: add docs/ tree with configuration and internals (closes #177)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Docs
+
+Supplementary documentation for `hnt`. The main README at the repository
+root is the canonical starting point — these files exist to keep deeper
+explanations out of it.
+
+- [Configuration & state](configuration.md) — where `read.json` and
+  `pinned.json` live per platform; how state is persisted and reset.
+- [Internals](internals.md) — load-bearing-but-non-obvious mechanisms:
+  the async architecture, generation-counter result gating, the SSRF
+  guard, terminal-escape sanitisation, Quickjump labels, comment-tree
+  memoisation.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,45 @@
+# Configuration & State
+
+`hnt` is configuration-free — there's no config file. It persists two pieces
+of state across runs:
+
+| File | What it stores | Created by |
+|---|---|---|
+| `read.json` | Stories you've opened, plus the comment count at the time of each visit. Drives the dim styling on visited rows and the `+N` "what's new" badge. | First time you press `Enter` on a story. |
+| `pinned.json` | Stories you've pinned (`b`) plus their resume position (selected-comment index, collapsed subtree IDs). Backs the `Pinned` virtual feed. | First time you pin a story. |
+
+## File locations
+
+Per-platform data directory:
+
+| OS | Path |
+|---|---|
+| Linux | `$XDG_DATA_HOME/hnt/` (defaults to `~/.local/share/hnt/`) |
+| macOS | `~/Library/Application Support/hnt/` |
+| Windows | `%APPDATA%\hnt\` |
+
+## On-disk shape
+
+Both files are JSON, schema-versioned, and written atomically:
+
+1. The file is serialised to `<file>.tmp` first.
+2. `<file>.tmp` is then atomically renamed over `<file>`.
+
+On Unix, the directory is created with mode `0700` (owner-only) and files
+with mode `0600`. A corrupt file (e.g. truncated by a crashed write) is
+silently re-initialised to an empty store on the next load rather than
+crashing the app.
+
+Each store has a soft cap (currently 200 entries for `read.json`, 100 for
+`pinned.json`); the oldest entries are evicted when the cap is reached.
+
+## Resetting state
+
+Delete either file to reset the corresponding state. No other side effects;
+the app will recreate them on next use.
+
+## Why no config file?
+
+The keymap, feed list, color palette, and tunables are all currently
+compile-time constants. If you want different defaults, fork and rebuild.
+A proper config layer is a possible 1.0 milestone; see issue tracker.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,121 @@
+# Internals
+
+Notes on the load-bearing-but-non-obvious mechanisms in the codebase, for
+maintainers and curious users.
+
+## Async architecture
+
+The app is a single tokio runtime hosting a `crossterm` event loop in the
+main task plus N spawned tasks for HTTP fetches. They communicate via an
+unbounded MPSC channel:
+
+```
+keys/mouse ──► main loop ──► dispatch ──► tokio::spawn(fetch)
+                  ▲                            │
+                  └───────── AppMessage ◄──────┘
+```
+
+`process_messages` drains the channel each tick with a per-frame budget
+(`PROCESS_MESSAGES_BUDGET = 32`) so a `CommentsAppended` flood from a deep
+thread can't starve render.
+
+## Generation-counter result gating
+
+Every `tokio::spawn` for feed loads, search, comment-tree walks, and
+article fetches used to be fire-and-forget — a stale result could land
+on top of post-action state (feed switch race, story-select race, search
+pagination race). Three monotonic `u64` counters on `App` (`feed_gen`,
+`story_gen`, `article_gen`) tag every spawned task at spawn time. Each
+gated `AppMessage` variant carries the snapshot, and `process_messages`
+drops the message when the snapshot doesn't match the current counter.
+
+The state-change points that bump counters: `reset_panes_and_reload`,
+`submit_search`, `load_selected_comments`, `open_article_reader`,
+`open_url_in_reader`, the comments-pane `Back` arm, the reader-overlay
+`Back` arm. `Error` and `PriorDiscussionsLoaded` are intentionally
+ungated.
+
+## SSRF guard
+
+The article reader (`p`) fetches user-supplied URLs. To prevent abuse
+(e.g. an HN submission of `http://192.168.1.1/admin` probing the user's
+LAN), `check_host_is_public` runs before the initial `client.get()`:
+
+1. If the host is a literal IP (parsed via `url::Url::host()`), reject if
+   it's in any private / loopback / link-local / unique-local range
+   (`is_private_ip`).
+2. If the host is a hostname, resolve via `tokio::net::lookup_host` and
+   reject if any resolved address is private.
+
+This is best-effort against DNS rebinding (`reqwest` re-resolves at
+connect time), but closes the literal-IP and obvious hostname cases.
+
+The redirect callback inside the `reqwest::Client` builder applies the
+same `is_private_ip` check to every redirect target as a second layer.
+
+## Terminal-escape sanitisation
+
+Every untrusted-content boundary that flows into a ratatui `Span` is
+scrubbed through `sanitize::sanitize_terminal` — it replaces C0 / C1 /
+DEL bytes with the Unicode replacement character. Sanitised paths:
+
+- Story titles in the comments-pane block title (`ui::comment_tree::build_block_title_label`).
+- Reader overlay title + domain (sanitised inside `ReaderState::new_loading`).
+- Status-bar error display (`ui::status_bar::StatusBar::render`).
+- Article body fragments (`article.rs::tagged_lines_to_styled_with_links`).
+- Markdown README content (`article.rs::markdown_to_styled_lines`).
+- Plain-text README fallback (`article.rs::fetch_and_extract_article`'s RST/plain path).
+- Comment HTML body cache (`state::comment_state::FlatComment::plain_text`).
+
+A malicious HN title containing `\x1b]0;OWNED\x07` will not rewrite the
+user's terminal tab title.
+
+## Quickjump (`f` / `F` / `y` in reader)
+
+When the user presses `f` (or `F`, or `y`) in the article reader, the
+reader's `LinkRegistry` is consulted. Each hyperlink gets a 1- or 2-
+character label drawn from a curated alphabet (`asdfweiou` — home-row,
+non-collisional with vim navigation keys). Labels are assigned uniformly
+in `LinkRegistry::assign_labels` once at content-set time, then painted
+over the reader by `paint_hint_labels` on every render while
+`HintState` is active.
+
+Typing the label characters narrows the match. A unique match fires
+the configured `HintAction` (`Open` browser / `OpenInReader` / `CopyUrl`
+via OSC-52). A non-matching prefix cancels.
+
+OSC-52 clipboard works through SSH because the escape sequence is
+interpreted by the user's *local* terminal emulator (iTerm2, kitty,
+WezTerm, etc.), not by the remote machine.
+
+## Comment-tree memoisation
+
+Two caches make the comments pane O(1)-per-frame for the common case:
+
+- `CommentTreeState::filter_cache` — memoises the "what's new" filter's
+  visible-index set, keyed by `(filter, comments.len())`. `Rc<HashSet>`
+  so each `visible_indices_iter` call clones a pointer rather than
+  rebuilding the O(n) path-stack walk.
+- `FlatComment::descendant_count` — precomputed at `set_comments` /
+  `insert_children` time. `count_hidden_children` reads the field in
+  O(1) instead of scanning the comments-slice tail per call.
+
+## Persistence layer
+
+`state::persist::JsonStore<E>` is the shared atomic-write + LRU-bounded
+JSON store used by both `read_store.rs` and `pin_store.rs`. Generic over
+an entry type that implements `PersistedEntry` (provides an `age_key`
+used for eviction).
+
+See `docs/configuration.md` for the per-platform paths.
+
+## Where to look first
+
+- New feature: `keys.rs` (keymap) + `app.rs` (`dispatch_normal` /
+  `dispatch_reader` / `dispatch_prior`) + the relevant pane state.
+- New bug: `app.rs` `process_messages` is the choke point; check
+  whether the affected variant is gated and whether the gen invariant
+  matches.
+- New panic: `tui.rs` panic hook restores the terminal on crash.
+- New flaky test: `app.rs` `#[cfg(test)] mod tests` covers the gating
+  + state machine; `comment_state.rs` covers the comment tree.


### PR DESCRIPTION
Closes #177.

## Summary

Three new files under `docs/`:

- `docs/README.md` — index pointing at the two siblings below.
- `docs/configuration.md` — persisted-state shape (`read.json`, `pinned.json`), per-platform paths (XDG / macOS Application Support / Windows AppData), atomic-write + 0600 perms semantics, reset procedure.
- `docs/internals.md` — load-bearing-but-non-obvious mechanisms for future maintainers: the tokio/MPSC architecture, generation-counter result gating (PR #148), the SSRF guard (PR #146), terminal-escape sanitisation paths (PRs #147, #155), Quickjump labels, comment-tree memoisation (PRs #157, #159).

None of these change behaviour. They lift detail out of the README (which is now linked from there in PR #180) and out of code comments (which remain authoritative; the docs cross-reference rather than duplicate).

## Test plan

- [x] Markdown renders cleanly.
- [ ] CI green.