### PR TITLE
docs(readme): document cargo install --git path (closes #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ chmod +x hnt
 
 > **Windows**: not currently in the release matrix. Build from source — `crossterm` (the terminal layer) supports Windows, so the only blocker is that the release workflow doesn't cross-build for it yet.
 
+### Install via cargo
+
+```bash
+cargo install --git https://github.com/thijsvos/hnt
+```
+
+The crate isn't on crates.io yet, so the `--git` form is the idiomatic install path.
+
 ### Build from source
 
 Requires [Rust](https://rustup.rs/) 1.88+.


### PR DESCRIPTION
Closes #173.

## Summary

Adds an "Install via cargo" subsection between the binary-download block and the Build-from-source instructions. `cargo install --git` is the idiomatic Rust install for a crate that isn't yet on crates.io — much shorter than the `git clone` + `cargo build` dance.

The Homepage URL piece of #173 was applied via `gh repo edit` (`https://github.com/thijsvos/hnt/releases/latest`) and is documented in the issue comments. This PR closes the README half of the same recommendation.

## Test plan

- [x] Markdown renders.
- [ ] CI green.