### PR TITLE
ci: add weekly scheduled run (closes #174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Mondays 06:00 UTC — catches ecosystem drift (new clippy lints on
+    # stable, registry API changes, fresh RUSTSEC advisories) before a
+    # user-submitted PR is mysteriously broken on Monday morning.
+    - cron: "0 6 * * 1"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #174.

## Summary

Adds a Monday 06:00 UTC cron trigger to `ci.yml`. Catches ecosystem drift (new clippy lints on stable, registry API changes, fresh RUSTSEC advisories) before a user-submitted PR is mysteriously broken — without the cron, a regression in the `cargo audit` job (added in #169) would silently linger until someone opens a PR.

Free on public repos: cron-triggered Actions use the same uncapped standard-runner tier.

## Test plan

- [x] YAML edit; `on:` block extended with a single `schedule:` entry.
- [ ] CI green on push (the scheduled run won't fire until next Monday).