### PR TITLE
Release 0.4.3: bump rand to clear RUSTSEC-2026-0097 (CI fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `hnt` are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] — 2026-05-14
+
+Hotfix for a `cargo audit` CI regression introduced by the audit job
+that landed in 0.4.2. `rustsec/audit-check@v2` treats RustSec
+"informational/unsound" advisories as build failures by default;
+[RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097)
+flagged a soundness issue in `rand` 0.9.x reachable only via
+`thread_rng` + a custom `log` logger with reseed during trace logging.
+`hnt` doesn't hit that path, but the audit job correctly refused to
+let CI ignore the advisory.
+
+### Fixed
+
+- Bump transitive `rand` 0.9.2 → 0.9.4 via `cargo update -p rand@0.9.2`.
+  0.9.4 is in the patched range (≥0.9.3) of the advisory. No source
+  change.
+
 ## [0.4.2] — 2026-05-14
 
 Repository-hygiene + CI-hardening patch release. A `/github-audit`
@@ -272,6 +289,7 @@ eighteen and adds ~150 new tests along the way.
 Final 0.3.x release. See `git log` for individual commits; the 0.3.x
 series predates this changelog file.
 
+[0.4.3]: https://github.com/thijsvos/hnt/releases/tag/v0.4.3
 [0.4.2]: https://github.com/thijsvos/hnt/releases/tag/v0.4.2
 [0.4.1]: https://github.com/thijsvos/hnt/releases/tag/v0.4.1
 [0.4.0]: https://github.com/thijsvos/hnt/releases/tag/v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1771,7 +1771,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Hotfix for the `cargo audit` CI regression that landed with 0.4.2.

[`rustsec/audit-check@v2`](https://github.com/rustsec/audit-check) (added in #179) treats RustSec "informational/unsound" advisories as build failures by default — and immediately caught [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097), a soundness issue in `rand` 0.9.x reachable only via `thread_rng()` + a custom `log` logger with reseed during trace logging. `hnt` doesn't use `thread_rng` or `log`, but the audit job correctly refused to let CI ignore the advisory.

`cargo update -p rand@0.9.2` bumps the transitive `rand` 0.9.2 → 0.9.4 (the advisory's patched range is ≥0.9.3). `Cargo.lock`-only change; no source touched.

Version bumped 0.4.2 → 0.4.3 so the release workflow auto-publishes a new tag with the clean lockfile.

## Test plan

- [x] `cargo build --release` — produces `hnt 0.4.3` binary.
- [x] Local diff is only `Cargo.lock` (rand 0.9.2 → 0.9.4) + `Cargo.toml` (version) + `CHANGELOG.md` (0.4.3 entry).
- [ ] CI: `cargo audit (RUSTSEC)` must turn green; the other three required checks unaffected.
- [ ] Release workflow auto-tags v0.4.3 on merge.