### PR TITLE
fix: prior-discussions overlay Enter/o handlers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -785,7 +785,15 @@ impl App {
             Action::JumpTop => p.jump_top(),
             Action::JumpBottom => p.jump_bottom(),
             Action::OpenInBrowser => {
-                open_http_url(p.selected_submission().and_then(|i| i.url.as_deref()));
+                // Prior submissions all share the parent's article URL by
+                // construction (search_by_url filters to same-URL matches),
+                // so opening `item.url` would always re-open the parent's
+                // target. The user-meaningful "open the prior post" is its
+                // own HN discussion page, which is unique per submission.
+                if let Some(item) = p.selected_submission() {
+                    let hn_url = format!("https://news.ycombinator.com/item?id={}", item.id);
+                    open_http_url(Some(hn_url.as_str()));
+                }
             }
             _ => {}
         }
@@ -1758,17 +1766,25 @@ async fn run_comment_load(
 ) {
     use futures::stream::{self, StreamExt};
 
-    let kids: Vec<u64> = if needs_full_fetch {
+    // When a full fetch is required (e.g. caller had only an Algolia hit
+    // with `kids: None`), swap the partial `story` for the freshly-fetched
+    // Firebase record so `CommentsLoaded` installs the authoritative Item
+    // (correct title, descendants, kids, item_type) — not the partial hit.
+    let (story, kids): (Arc<Item>, Vec<u64>) = if needs_full_fetch {
         match client.fetch_item(story.id).await {
-            Ok(Some(full_item)) => full_item.kids.as_deref().unwrap_or(&[]).to_vec(),
-            Ok(None) => Vec::new(),
+            Ok(Some(full_item)) => {
+                let kids = full_item.kids.as_deref().unwrap_or(&[]).to_vec();
+                (full_item, kids)
+            }
+            Ok(None) => (story, Vec::new()),
             Err(e) => {
                 let _ = tx.send(AppMessage::Error(format!("Failed to load comments: {}", e)));
                 return;
             }
         }
     } else {
-        story.kids.as_deref().unwrap_or(&[]).to_vec()
+        let kids = story.kids.as_deref().unwrap_or(&[]).to_vec();
+        (story, kids)
     };
 
     let root_items = client.fetch_items(&kids).await;

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -41,7 +41,7 @@ pub fn render_prior_overlay(frame: &mut Frame, area: Rect, state: &PriorDiscussi
     );
 
     let footer = Line::from(Span::styled(
-        " j/k:navigate  Enter:load comments  o:browser  Esc:close ",
+        " j/k:navigate  Enter:load comments  o:open HN page  Esc:close ",
         theme::dim_style(),
     ))
     .centered();


### PR DESCRIPTION
Closes #189

## Summary
- `dispatch_prior` `o` handler now opens `https://news.ycombinator.com/item?id={item.id}` instead of the prior submission's article URL (which is the same as the parent's by construction, since `search_by_url` filters to same-URL matches).
- `run_comment_load` substitutes the partial Algolia `Item` with the freshly-fetched Firebase record when a full fetch was required, so `comment_state.story` reflects authoritative `kids`/`title`/`descendants` after the user picks a prior submission. The non-prior path is unchanged.
- Overlay footer hint updated from `o:browser` to `o:open HN page` so the new behavior is discoverable.

## Test plan
- [x] `cargo build --release`
- [x] `cargo test` — 368/368 passed
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: find a story with prior HN submissions, press `h`, select a prior, press `o` → browser opens that submission's HN discussion thread (not the article URL)
- [ ] Manual: from the overlay, press Enter on a prior with known comments → its comments load (not "No comments")
- [ ] Manual: Enter on a prior with 0 comments → legitimate "No comments" empty state
