### PR TITLE
Release 0.4.4: prior-discussions overlay fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to `hnt` are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] — 2026-05-14
+
+Bug-fix release for the prior-discussions overlay (the `h` overlay on a
+story that has prior HN submissions of the same URL).
+
+### Fixed
+
+- **Enter on a selected prior submission no longer shows "No comments".**
+  `run_comment_load` now substitutes the partial Algolia hit with the
+  freshly-fetched Firebase record when a full fetch is required, so
+  `comment_state.story` reflects authoritative `kids`/`title`/
+  `descendants` after picking a prior submission. The non-prior path
+  is unchanged. Closes
+  [#189](https://github.com/thijsvos/hnt/issues/189) via
+  [PR #190](https://github.com/thijsvos/hnt/pull/190).
+- **`o` from the prior-discussions overlay now opens the prior post's
+  HN discussion page** (`https://news.ycombinator.com/item?id={id}`)
+  instead of the article URL. Prior submissions by definition share
+  the parent's article URL (`HnClient::search_by_url` filters to
+  same-URL matches), so the old behaviour always re-opened the
+  parent's target; the new behaviour is the unique-per-submission HN
+  thread. Same closing issue/PR as above.
+- Overlay footer hint updated from `o:browser` to `o:open HN page`.
+
 ## [0.4.3] — 2026-05-14
 
 Hotfix for a `cargo audit` CI regression introduced by the audit job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Bug-fix release for the prior-discussions overlay (`h` on a story with prior HN submissions of the same URL). Rolls up [PR #190](https://github.com/thijsvos/hnt/pull/190) (closes [#189](https://github.com/thijsvos/hnt/issues/189)):

- **Enter on a selected prior submission no longer shows "No comments".** `run_comment_load` now substitutes the partial Algolia hit with the freshly-fetched Firebase record when a full fetch is required, so `comment_state.story` reflects authoritative `kids`/`title`/`descendants` after picking a prior submission.
- **`o` opens the prior post's HN discussion page** (`https://news.ycombinator.com/item?id={id}`) instead of the article URL. Prior submissions by definition share the parent's article URL, so the old behaviour always re-opened the parent's target.
- Overlay footer hint updated from `o:browser` to `o:open HN page`.

Version bumped 0.4.3 → 0.4.4 so the release workflow auto-publishes the new tag.

## Test plan

- [x] `cargo build --release` — produces `hnt 0.4.4` binary.
- [x] `cargo test` — 368/368 pass.
- [x] `cargo clippy -- -D warnings` — clean.
- [ ] CI green.
- [ ] Release workflow auto-tags v0.4.4 and publishes binaries on merge.