### PR TITLE
feat(release): add x86_64 + aarch64 Windows binaries (0.4.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,22 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            binary_suffix: ""
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            binary_suffix: ""
           - target: x86_64-apple-darwin
             os: macos-latest
+            binary_suffix: ""
           - target: aarch64-apple-darwin
             os: macos-latest
+            binary_suffix: ""
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary_suffix: ".exe"
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            binary_suffix: ".exe"
 
     steps:
       - uses: actions/checkout@v6
@@ -81,13 +91,14 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Rename binary
-        run: cp target/${{ matrix.target }}/release/hnt hnt-${{ matrix.target }}
+        shell: bash
+        run: cp "target/${{ matrix.target }}/release/hnt${{ matrix.binary_suffix }}" "hnt-${{ matrix.target }}${{ matrix.binary_suffix }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: hnt-${{ matrix.target }}
-          path: hnt-${{ matrix.target }}
+          path: hnt-${{ matrix.target }}${{ matrix.binary_suffix }}
 
   release:
     name: Create Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to `hnt` are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] — 2026-05-14
+
+Adds Windows to the release matrix. The release workflow now produces
+six platform binaries instead of four: x86_64 and ARM64 Windows
+binaries (Surface Pro X / Copilot+ PCs) ship alongside the existing
+Linux + macOS builds.
+
+### Added
+
+- **`hnt-x86_64-pc-windows-msvc.exe`** — native x86_64 Windows binary,
+  produced on `windows-latest`.
+- **`hnt-aarch64-pc-windows-msvc.exe`** — ARM64 Windows binary,
+  cross-compiled from `windows-latest` (uses the ARM64 MSVC linker
+  that ships with Visual Studio Build Tools — no extra setup
+  required). The ARM64 binary is built but not smoke-tested in CI
+  (no ARM64 Windows runner used).
+- README install snippets for both Windows binaries.
+
+### Changed
+
+- `.github/workflows/release.yml`: matrix grows from 4 to 6 entries;
+  each entry now carries a `binary_suffix` column so the rename step
+  picks up `.exe` on Windows. Rename step uses `shell: bash` to keep
+  the same syntax across all runners (Windows hosted runners ship Git
+  Bash, so this is portable).
+
 ## [0.4.4] — 2026-05-14
 
 Bug-fix release for the prior-discussions overlay (the `h` overlay on a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ chmod +x hnt
 ./hnt
 ```
 
-> **Windows**: not currently in the release matrix. Build from source — `crossterm` (the terminal layer) supports Windows, so the only blocker is that the release workflow doesn't cross-build for it yet.
+```powershell
+# Windows (x86_64)
+curl.exe -L https://github.com/thijsvos/hnt/releases/latest/download/hnt-x86_64-pc-windows-msvc.exe -o hnt.exe
+.\hnt.exe
+
+# Windows (ARM64 — Surface Pro X, Copilot+ PCs)
+curl.exe -L https://github.com/thijsvos/hnt/releases/latest/download/hnt-aarch64-pc-windows-msvc.exe -o hnt.exe
+.\hnt.exe
+```
 
 ### Install via cargo
 


### PR DESCRIPTION
Closes #192

## Summary

Adds Windows to the release matrix — `.github/workflows/release.yml` now builds 6 binaries per release (was 4):

- `hnt-x86_64-pc-windows-msvc.exe` — native build on `windows-latest`.
- `hnt-aarch64-pc-windows-msvc.exe` — cross-compiled from `windows-latest` using the ARM64 MSVC linker that ships with Visual Studio Build Tools. No extra setup beyond `rustup target add` (already handled by `dtolnay/rust-toolchain`'s `targets:` param).

Each matrix entry now carries a `binary_suffix` column (`""` for Unix, `".exe"` for Windows); the rename + upload steps interpolate it, and the rename step uses `shell: bash` so the same syntax works across all runners (Windows hosted runners ship Git Bash).

README install snippets added for both Windows binaries. Version bumped 0.4.4 → 0.4.5 so the release workflow auto-publishes the new tag.

## Cost

`windows-latest` runners are **free on public repos** (standard tier). Two Windows builds in parallel add ~2-4 min wall-clock to the release pipeline.

## Test plan

- [x] `cargo build --release` — produces `hnt 0.4.5` binary.
- [x] `cargo test` — 368/368 pass.
- [x] `cargo clippy -- -D warnings` — clean.
- [ ] CI green on the PR.
- [ ] Release workflow auto-tags v0.4.5 on merge and publishes all 6 binaries + checksums.
- [ ] Manual: download `hnt-x86_64-pc-windows-msvc.exe` on a Windows machine and verify it runs.

## Notes

- The ARM64 Windows binary is built but not smoke-tested in CI (no ARM64 Windows runner is used — the cross-compile pattern matches what we already do for `aarch64-unknown-linux-gnu`).
- The CI workflow (`ci.yml`) remains Linux+macOS only. If Windows-specific regressions land, they'll surface at release time, not at PR time. Adding Windows to `ci.yml` is a reasonable follow-up but out of scope for this PR.
