### PR TITLE
feat(ci): publish multi-arch Docker image to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,71 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker-compose.yml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and push to ghcr.io
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=main-,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=hnt
+            org.opencontainers.image.description=A dark-themed terminal client for Hacker News
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ cargo install --git https://github.com/thijsvos/hnt
 
 The crate isn't on crates.io yet, so the `--git` form is the idiomatic install path.
 
+### Run with Docker
+
+Multi-arch image (linux/amd64 + linux/arm64) published to GitHub Container Registry on every push to `main` and every release tag:
+
+```bash
+# Latest from main
+docker run -it --rm ghcr.io/thijsvos/hnt:latest
+
+# Pin to a specific version
+docker run -it --rm ghcr.io/thijsvos/hnt:0.4.5
+```
+
+`-it` is required — `hnt` is a TUI, so `crossterm` needs a real terminal.
+
 ### Build from source
 
 Requires [Rust](https://rustup.rs/) 1.88+.


### PR DESCRIPTION
Closes #194

## Summary

Adds `.github/workflows/docker.yml` that builds and pushes a multi-arch image (`linux/amd64` + `linux/arm64`) to `ghcr.io/thijsvos/hnt`.

**Triggers:**
- Push to `main` → tags `latest` + `main-<sha7>` (keeps `:latest` in sync with HEAD)
- Push of a release tag (`v*.*.*`) → semver tags `v0.4.5`, `0.4.5`, `0.4`
- PRs touching Docker files → **build only, do not push** (catches Dockerfile regressions at PR time)
- `workflow_dispatch` → manual re-publish

**Implementation notes:**
- Third-party actions all SHA-pinned (matches the repo convention from `ci.yml:23` / `release.yml:60`).
- GHA build cache via `cache-from/to: type=gha` — first build will be slow (multi-arch QEMU), subsequent builds 2-4 min.
- OCI image labels carry title, description, license, and source URL.
- Uses `${{ secrets.GITHUB_TOKEN }}` — no PAT needed, no new secret to manage.

**README**: added a "Run with Docker" subsection between "Install via cargo" and "Build from source" with the pull-and-run snippet, including a note about `-it` being required (TUI).

## Cost

**$0.** ghcr.io storage = free for public images, `ubuntu-latest` runners = free on public repos, multi-platform manifests = free.

## ⚠️ One-time post-merge manual step

ghcr packages are **PRIVATE by default** on first push. After this PR merges and the workflow publishes for the first time:

1. Visit https://github.com/users/thijsvos/packages/container/package/hnt
2. Package settings → Danger Zone → "Change package visibility" → **Public**
3. (Optional) "Connect repository" → `thijsvos/hnt` so it shows under the repo's Packages sidebar.

There's no stable `gh api` for changing package visibility, so this is a single click in the UI.

## Test plan

- [x] Local: `git diff main...HEAD` shows only `.github/workflows/docker.yml` (new) + `README.md` (one section added). No source/binary changes.
- [ ] CI: existing 4 checks (Check & Lint, Build × 2, cargo audit) unaffected — workflow doesn't touch any Rust code.
- [ ] CI: new `docker.yml` workflow's PR-trigger runs and the build step succeeds (push step is gated to non-PR, so nothing leaves the runner).
- [ ] Post-merge: `:latest` and `:main-<sha>` appear at https://github.com/thijsvos/hnt/pkgs/container/hnt.
- [ ] After flipping visibility to public: `docker pull ghcr.io/thijsvos/hnt:latest` succeeds without auth.
- [ ] Next release (v0.4.6 or 0.5.0) auto-tags the image with the version.

## Why no version bump

CI/infra-only change. The `hnt` binary itself is identical to v0.4.5. The first ghcr image will be tagged with the *current* version (0.4.5) once a release tag is pushed, but no new release is needed to land this PR.
