### PR TITLE
fix(docker): touch sources to bust cargo fingerprint cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,14 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release 2>/dev/null || true
 RUN rm -rf src
 
-# Copy source and build
+# Copy source and build. The `touch` is load-bearing: Docker COPY may set
+# source mtimes older than the cached stub-binary artifact from the layer
+# above, in which case cargo's fingerprint check decides "nothing changed"
+# and skips the application rebuild, leaving the stub `fn main() {}` binary
+# in target/release/hnt. Touching every .rs file forces cargo to invalidate
+# the application crate while preserving the warmed dependency cache.
 COPY src/ src/
-RUN cargo build --release
+RUN find src -name '*.rs' -exec touch {} + && cargo build --release
 
 # Stage 2: Runtime
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
Closes #196

## Summary

`Dockerfile` second `cargo build --release` was being short-circuited by cargo's fingerprint cache, leaving the `fn main() {}` stub binary as the published artifact. Fix: `touch` every `.rs` file between `COPY src/` and the second `cargo build` so cargo invalidates the application crate while the dep cache stays warm.

**Before** (this is what's currently on `ghcr.io/thijsvos/hnt:latest`):
- Binary size: **451 KB** (a `fn main() {}` Rust release binary)
- Build step: `Finished release profile [optimized] target(s) in 0.63s` — no `Compiling hnt` line, because cargo decided nothing changed
- Runtime: silent exit code 0, no output

**After** (local `docker build --no-cache` repro):
- Binary size: **12.6 MB**
- Build step: `Compiling hnt v0.4.5 (/app)` ✓ then `Finished release profile [optimized] target(s) in 5.66s`
- Runtime: actually launches the TUI (or surfaces a clear `Error: No such device or address` when no TTY is attached — expected crossterm behavior without `-it`)

## Why this fixes it

Docker COPY preserves source mtimes from the build context, which can be older than the cached stub binary written by the earlier `RUN cargo build --release` layer. Cargo's fingerprint check uses mtime among other inputs, sees the cached binary as "newer than" the sources, and skips compilation. `touch`-ing the .rs files updates their mtimes to "now", which is guaranteed to be newer than any cached artifact, forcing cargo to recompile main.rs and re-link with all the real dependencies.

The dep cache (built in the earlier stub-build layer) is unchanged, so the fix preserves the original intent of the cache trick.

## Test plan

- [x] Local `docker build --no-cache --platform linux/arm64 -t hnt-test .` shows `Compiling hnt v0.4.5` and the resulting `/usr/local/bin/hnt` is 12.6 MB (was 451 KB).
- [x] `docker run --rm hnt-test` produces a crossterm "No such device or address" error (expected without `-it`), not a silent exit.
- [ ] CI green.
- [ ] After merge: `docker.yml` workflow republishes `:latest` and `:main` to the corrected image.
- [ ] `docker pull ghcr.io/thijsvos/hnt:latest && docker run -it --rm ghcr.io/thijsvos/hnt:latest` from an unauthenticated machine drops into the TUI.

## Follow-up (out of scope)

- The current Dockerfile pattern is fragile. A future PR could replace the stub-build trick with BuildKit cache mounts (`--mount=type=cache,target=/usr/local/cargo/registry` + `--mount=type=cache,target=/app/target`), which interoperates cleanly with the existing `cache-from/to: type=gha` in `docker.yml`. That's a bigger Dockerfile rewrite; this PR is the minimal fix.
- `docker.yml` builds and pushes but never *runs* the resulting binary. Adding `docker run --rm ghcr.io/thijsvos/hnt:<sha>` as a final smoke step (asserting non-empty output or non-zero exit) would have caught this regression at PR time.
