### PR TITLE
fix(ui): URL-copied is an info toast, not an error; auto-expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to `hnt` are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] — 2026-05-15
+
+Fixes how the "URL copied" message renders after the 0.4.6 OSC 52
+fallback landed. The success message was going through `App::error`,
+which the status bar always prefixes with `Error:` in red — misleading,
+since the copy actually succeeded. It also stuck around forever.
+
+### Fixed
+
+- **`URL copied: …` is no longer styled as an error.** Introduces an
+  auto-expiring info toast (`App::info_toast`) distinct from `App::error`,
+  rendered without the red `Error:` prefix.
+- **Toast auto-clears after 4 seconds** so the normal keybinding hints
+  reappear without the user needing to press anything. Implemented as a
+  TTL check in `App::tick()`, which is now called on every
+  `Event::Tick` (every 250 ms) instead of the previous inline counter
+  bump in `main.rs`.
+
+### Internal
+
+- `StatusBar` widget gains an `info: Option<&str>` field that takes
+  precedence over `error` when set. Mirrors the existing C0/C1
+  sanitisation on the error path so a server-controlled URL can't smuggle
+  escape sequences through the new channel.
+
 ## [0.4.6] — 2026-05-15
 
 Makes `o` (open URL in browser) work usefully inside the published

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hnt"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hnt"
 description = "A dark-themed terminal client for Hacker News"
 license = "MIT"
 repository = "https://github.com/thijsvos/hnt"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 
 [dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -51,6 +51,13 @@ const PRIOR_RESULTS_CACHE: usize = 200;
 /// next tick picks up where this one left off.
 const PROCESS_MESSAGES_BUDGET: usize = 32;
 
+/// Lifetime of an info toast set via [`App::set_info`]. After this many
+/// seconds, [`App::tick`] clears the toast and the status bar reverts to
+/// its normal keybinding hints. 4 s is long enough to read a 60-80 char
+/// URL aloud and copy it, but short enough that it isn't perceived as a
+/// modal change to the bar.
+const INFO_TOAST_TTL: std::time::Duration = std::time::Duration::from_secs(4);
+
 /// Which content pane currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
@@ -307,6 +314,14 @@ pub struct App {
     /// see [`detect_no_browser_env`].
     no_browser_env: bool,
 
+    /// Transient, non-error status-bar message with auto-expiry — distinct
+    /// from [`Self::error`] so the rendered text isn't prefixed with
+    /// `Error:` and styled red. Stored as `(message, expires_at)`; the
+    /// status bar renders the message when `Instant::now() < expires_at`,
+    /// and [`Self::tick`] clears the entry once it's past its deadline so
+    /// the normal keybinding hints reappear. Set via [`Self::set_info`].
+    info_toast: Option<(String, std::time::Instant)>,
+
     client: HnClient,
     msg_tx: mpsc::UnboundedSender<AppMessage>,
     msg_rx: mpsc::UnboundedReceiver<AppMessage>,
@@ -350,6 +365,7 @@ impl App {
             story_gen: 0,
             article_gen: 0,
             no_browser_env: detect_no_browser_env(),
+            info_toast: None,
             client: HnClient::new(),
             msg_tx,
             msg_rx,
@@ -398,6 +414,43 @@ impl App {
     pub fn set_terminal_size(&mut self, w: u16, h: u16) {
         self.terminal_width = w;
         self.terminal_height = h;
+    }
+
+    /// Sets the auto-expiring info toast and returns the previous one (if
+    /// any). Distinct from [`Self::error`] so the status bar can pick a
+    /// non-red style and skip the `Error:` prefix. Lives `INFO_TOAST_TTL`
+    /// from now; [`Self::tick`] clears it once it's expired so the normal
+    /// keybinding hints reappear without the user pressing anything.
+    pub fn set_info(&mut self, message: String) {
+        let expires = std::time::Instant::now() + INFO_TOAST_TTL;
+        self.info_toast = Some((message, expires));
+    }
+
+    /// Currently visible info-toast text, or `None` if no toast is set or
+    /// the active toast has already expired. Called per-frame by the UI
+    /// layer — cheap because it's a single `Instant::now()` plus pointer
+    /// dereference. The expired-but-not-yet-cleared case is handled
+    /// transparently here so a frame rendered between two ticks doesn't
+    /// show a stale toast.
+    pub fn info_toast_message(&self) -> Option<&str> {
+        self.info_toast
+            .as_ref()
+            .filter(|(_, expires)| std::time::Instant::now() < *expires)
+            .map(|(msg, _)| msg.as_str())
+    }
+
+    /// Per-tick housekeeping: bumps the spinner counter and clears the
+    /// info toast once its deadline has passed. Called from the main loop
+    /// on every [`crate::event::Event::Tick`] (every 250 ms — see
+    /// [`crate::event::EventHandler`]). Replaces the inline tick-count
+    /// bump that used to live in `main.rs`.
+    pub fn tick(&mut self) {
+        self.tick_count = self.tick_count.wrapping_add(1);
+        if let Some((_, expires)) = &self.info_toast {
+            if std::time::Instant::now() >= *expires {
+                self.info_toast = None;
+            }
+        }
     }
 
     /// Flushes any in-memory persistent state (read-store, pin-store) to
@@ -1491,7 +1544,11 @@ impl App {
         if self.no_browser_env {
             match clipboard::copy(parsed.as_str()) {
                 Ok(()) => {
-                    self.error = Some(format!("URL copied: {}", parsed.as_str()));
+                    // Success is not an error — set the auto-expiring info
+                    // toast so the status bar renders without the red
+                    // `Error:` prefix and reverts to keybinding hints
+                    // after `INFO_TOAST_TTL` elapses.
+                    self.set_info(format!("URL copied: {}", parsed.as_str()));
                 }
                 Err(e) => {
                     self.error = Some(format!("Clipboard write failed: {}", e));
@@ -2606,12 +2663,39 @@ mod tests {
         let mut app = App::new(80, 24);
         app.no_browser_env = true;
         app.error = None;
+        app.info_toast = None;
         app.open_url("https://example.com/story");
-        let msg = app.error.as_deref().unwrap_or("");
+        let msg = app.info_toast_message().unwrap_or("");
         assert!(
             msg.starts_with("URL copied: ") && msg.ends_with("https://example.com/story"),
-            "expected `URL copied: …` status, got {:?}",
+            "expected `URL copied: …` info toast, got {:?}",
             msg
+        );
+        assert!(
+            app.error.is_none(),
+            "success path must not set the error channel; got {:?}",
+            app.error
+        );
+    }
+
+    #[test]
+    fn info_toast_expires_after_ttl() {
+        let mut app = App::new(80, 24);
+        app.set_info("hello".to_string());
+        assert_eq!(app.info_toast_message(), Some("hello"));
+        // Manually expire by rewriting the expiry to the past.
+        if let Some((_, expires)) = app.info_toast.as_mut() {
+            *expires = std::time::Instant::now() - std::time::Duration::from_secs(1);
+        }
+        assert_eq!(
+            app.info_toast_message(),
+            None,
+            "expired toast must not be returned"
+        );
+        app.tick();
+        assert!(
+            app.info_toast.is_none(),
+            "tick() must drop the expired toast"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
                 app.set_terminal_size(width, height);
             }
             Event::Tick => {
-                app.tick_count = app.tick_count.wrapping_add(1);
+                app.tick();
             }
         }
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -125,6 +125,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             feed: app.current_feed,
             position: &position,
             error: app.error.as_deref(),
+            info: app.info_toast_message(),
             focus_pane: match app.focus {
                 crate::app::Pane::Stories => "Stories",
                 crate::app::Pane::Comments => "Comments",

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -29,8 +29,15 @@ pub struct StatusBar<'a> {
     /// `ui::render`.
     pub position: &'a str,
     /// Last error to surface (sanitised at render time). `None` paints
-    /// the normal keybinding hint line instead.
+    /// the normal keybinding hint line instead (when `info` is also
+    /// `None`). Rendered with the `Error:` prefix and red foreground.
     pub error: Option<&'a str>,
+    /// Transient, non-error status message — auto-expiring toast set via
+    /// [`crate::app::App::set_info`]. Takes precedence over `error` and
+    /// over the keybinding hints; rendered without the `Error:` prefix
+    /// and in the theme's accent style (not red). Same C0/C1 sanitisation
+    /// applies — `URL copied: <url>` carries server-controlled bytes.
+    pub info: Option<&'a str>,
     /// Pane label for the right-aligned `[Stories]` / `[Comments]` tag.
     pub focus_pane: &'static str,
     /// Current input mode — drives the search-input vs normal layout
@@ -76,7 +83,13 @@ impl<'a> Widget for StatusBar<'a> {
             ));
             spans.push(Span::styled(" ", theme::status_style()));
 
-            if let Some(err) = self.error {
+            if let Some(info) = self.info {
+                let safe_info = sanitize_terminal(info);
+                spans.push(Span::styled(
+                    format!("{} ", safe_info),
+                    theme::accent_style().bg(theme::SURFACE),
+                ));
+            } else if let Some(err) = self.error {
                 // Errors can carry server-controlled bytes (URLs from
                 // Location headers, hostnames from DNS errors), so scrub
                 // C0/C1/DEL controls before they reach ratatui — same
@@ -103,7 +116,13 @@ impl<'a> Widget for StatusBar<'a> {
             ));
             spans.push(Span::styled(" ", theme::status_style()));
 
-            if let Some(err) = self.error {
+            if let Some(info) = self.info {
+                let safe_info = sanitize_terminal(info);
+                spans.push(Span::styled(
+                    format!("{} ", safe_info),
+                    theme::accent_style().bg(theme::SURFACE),
+                ));
+            } else if let Some(err) = self.error {
                 // Errors can carry server-controlled bytes (URLs from
                 // Location headers, hostnames from DNS errors), so scrub
                 // C0/C1/DEL controls before they reach ratatui — same
@@ -147,12 +166,17 @@ mod tests {
     use ratatui::layout::Rect;
 
     fn render_bar(err: Option<&str>) -> Buffer {
+        render_bar_with(err, None)
+    }
+
+    fn render_bar_with(err: Option<&str>, info: Option<&str>) -> Buffer {
         let area = Rect::new(0, 0, 120, 1);
         let mut buf = Buffer::empty(area);
         StatusBar {
             feed: FeedKind::Top,
             position: "1/1",
             error: err,
+            info,
             focus_pane: "Stories",
             input_mode: InputMode::Normal,
             search_input: None,
@@ -207,6 +231,7 @@ mod tests {
             feed: FeedKind::Top,
             position: "1/1",
             error: Some("hit\x1b[2Jclear"),
+            info: None,
             focus_pane: "Stories",
             input_mode: InputMode::Normal,
             search_input: None,
@@ -218,5 +243,29 @@ mod tests {
         assert!(!text.contains('\x1b'));
         assert!(text.contains("hit"));
         assert!(text.contains("clear"));
+    }
+
+    #[test]
+    fn info_toast_renders_without_error_prefix() {
+        let buf = render_bar_with(None, Some("URL copied: https://example.com"));
+        let text = buffer_text(&buf);
+        assert!(text.contains("URL copied:"));
+        assert!(text.contains("https://example.com"));
+        assert!(
+            !text.contains("Error:"),
+            "info toast must not be styled/prefixed as an error: {text:?}"
+        );
+    }
+
+    #[test]
+    fn info_toast_takes_precedence_over_error() {
+        let buf = render_bar_with(Some("network down"), Some("URL copied: https://x"));
+        let text = buffer_text(&buf);
+        assert!(text.contains("URL copied:"));
+        assert!(
+            !text.contains("Error:"),
+            "info should preempt error rendering: {text:?}"
+        );
+        assert!(!text.contains("network down"));
     }
 }


### PR DESCRIPTION
Closes #200

## Summary

- **New `App::info_toast` channel** distinct from `App::error`. Set via `App::set_info(String)`. Auto-expires after `INFO_TOAST_TTL` (4 s) and is cleared by `App::tick()` once expired.
- **`App::open_url` clipboard path** now routes through `set_info` on success — so `URL copied: …` is no longer red-Error-prefixed.
- **`App::tick()` replaces the inline `tick_count += 1` in `main.rs`** — same spinner counter behaviour, plus the toast-expiry check.
- **`StatusBar` widget gains an `info: Option<&str>` field** that takes precedence over `error`. Same C0/C1 sanitisation as the error channel — a server-controlled URL can't smuggle escape sequences through.
- Version bump 0.4.6 → 0.4.7. Auto-publishes via release.yml + docker.yml on merge.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` — 375/375 pass (3 new: `info_toast_renders_without_error_prefix`, `info_toast_takes_precedence_over_error`, `info_toast_expires_after_ttl`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- [ ] CI green
- [ ] After merge: pull the new ghcr image, press `o` on a story in `docker run -it`, status bar shows `URL copied: …` in accent style (not red, no `Error:` prefix), reverts to keybinding hints after ~4 s.
