### PR TITLE
Apply second-pass rustdoc audit fixes

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -70,14 +70,15 @@ pub struct Item {
 }
 
 impl Item {
-    /// Whether this item was removed by moderators or its author — either
-    /// flag suppresses rendering.
+    /// Returns `true` when the item was killed by moderators or removed
+    /// by its author. Either flag suppresses rendering.
     pub fn is_dead_or_deleted(&self) -> bool {
         self.dead.unwrap_or(false) || self.deleted.unwrap_or(false)
     }
 
-    /// Host component of `url` (with a leading `www.` stripped), or `None`
-    /// for HN-native posts and non-http(s) schemes.
+    /// Returns the host component of `url` (with a leading `www.`
+    /// stripped), or `None` for HN-native posts and items whose URL was
+    /// rejected by the http(s) deserializer.
     pub fn domain(&self) -> Option<String> {
         self.url.as_ref().and_then(|u| url_domain(u))
     }
@@ -115,21 +116,31 @@ impl Item {
 /// and appear contiguously after their parent in pre-order.
 #[derive(Debug, Clone)]
 pub struct CommentWithDepth {
+    /// Decoded HN comment item; always [`ItemType::Comment`] by
+    /// construction.
     pub item: Item,
+    /// Tree depth — `0` is a root comment under the story; children
+    /// have strictly greater depth than their parent.
     pub depth: usize,
 }
 
 /// Newtype wrapper for a story's HN item ID. Distinct from [`CommentId`]
 /// at the type level so story-keyed maps (`prior_results`, `read_store`
 /// entries, in-flight query tracking) can't accidentally hold comment
-/// IDs, or vice versa. `Item::id` stays as `u64` for serde simplicity —
+/// IDs, or vice versa. [`Item::id`] stays as `u64` for serde simplicity —
 /// the newtypes apply where different ID kinds share scope.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StoryId(pub u64);
+pub struct StoryId(
+    /// Raw HN item ID — same numeric space as [`Item::id`].
+    pub u64,
+);
 
 /// Newtype wrapper for a comment's HN item ID. See [`StoryId`].
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CommentId(pub u64);
+pub struct CommentId(
+    /// Raw HN item ID — same numeric space as [`Item::id`].
+    pub u64,
+);
 
 /// Firebase `type` field — tags an [`Item`] as story / comment / job /
 /// poll / poll option. Unknown future strings deserialize to

--- a/src/app.rs
+++ b/src/app.rs
@@ -130,12 +130,17 @@ pub enum AppMessage {
     /// pointer travels straight into the story list with no deep clone
     /// at the boundary (closes #140 on the story side).
     StoriesLoaded {
+        /// `App::feed_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
         gen: u64,
+        /// Story batch — either the initial page or a paginated tail.
         stories: Vec<Arc<Item>>,
         /// Only populated on initial load; subsequent paginated loads
         /// reuse the cached ID list to avoid drift when the feed changes
         /// mid-session.
         all_ids: Option<Vec<u64>>,
+        /// Whether this batch replaces the current window
+        /// ([`LoadMode::Replace`]) or appends to it ([`LoadMode::Append`]).
         mode: LoadMode,
     },
     /// Root-level comments for a story are available; deeper descendants
@@ -145,27 +150,50 @@ pub enum AppMessage {
     /// stays small and `clippy::large_enum_variant` is happy). Gated
     /// by [`App::story_gen`].
     CommentsLoaded {
+        /// `App::story_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
         gen: u64,
+        /// Story whose comment tree is being loaded, ready to install
+        /// into `comment_state.story`.
         story: Arc<Item>,
+        /// Root-level comments resolved so far (may include partial
+        /// subtrees for roots that fetched fully on the first pass).
         comments: Vec<CommentWithDepth>,
+        /// Root comment IDs still awaiting their descendants — each will
+        /// arrive later as a [`Self::CommentsAppended`].
         pending_roots: HashSet<CommentId>,
     },
     /// Progressive update — append more child comments into the tree.
     /// Gated by [`App::story_gen`].
     CommentsAppended {
+        /// `App::story_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
         gen: u64,
+        /// Root comment ID these children belong under — used to splice
+        /// them into the flat tree.
         parent_id: CommentId,
+        /// Descendant comments to insert under `parent_id` in pre-order.
         children: Vec<CommentWithDepth>,
     },
     /// All outstanding comment fetches finished; clear any "loading"
     /// spinners. Gated by [`App::story_gen`].
-    CommentsDone { gen: u64 },
+    CommentsDone {
+        /// `App::story_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
+        gen: u64,
+    },
     /// Article reader content extracted and ready to render. `links`
     /// carries every hyperlink in the body (with assigned hint labels)
     /// for Quickjump. Gated by [`App::article_gen`].
     ArticleLoaded {
+        /// `App::article_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
         gen: u64,
+        /// Pre-rendered styled lines, ready to install in
+        /// `reader_state.lines`.
         lines: Vec<Vec<StyledFragment>>,
+        /// Every hyperlink in `lines`, with assigned Quickjump hint
+        /// labels.
         links: LinkRegistry,
     },
     /// Algolia search returned a page of results. Gated by
@@ -174,15 +202,31 @@ pub enum AppMessage {
     /// constructed locally (the `Arc` is fresh in this path; the
     /// downstream `StoryListState` doesn't care).
     SearchResultsLoaded {
+        /// `App::feed_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
         gen: u64,
+        /// Result batch for this page.
         stories: Vec<Arc<Item>>,
+        /// Total number of pages reported by Algolia — drives the
+        /// lazy-pagination cap in [`SearchState`].
         total_pages: usize,
+        /// Total hit count reported by Algolia — surfaced in the status
+        /// bar.
         total_hits: usize,
+        /// Whether this batch replaces the current window
+        /// ([`LoadMode::Replace`]) or appends to it ([`LoadMode::Append`]).
         mode: LoadMode,
     },
     /// Article fetch/extract failed; surface in the reader overlay.
     /// Gated by [`App::article_gen`].
-    ArticleError { gen: u64, msg: String },
+    ArticleError {
+        /// `App::article_gen` snapshot captured at spawn — see the
+        /// enum-level note on race-gating.
+        gen: u64,
+        /// Human-readable error description, rendered inside the reader
+        /// overlay.
+        msg: String,
+    },
     /// Generic error to surface in the status bar. Ungated — late
     /// errors from stale spawns are mildly confusing but never
     /// dangerous, and the wider blast radius of dropping them is worse
@@ -192,7 +236,11 @@ pub enum AppMessage {
     /// by Algolia. `story_id` identifies the originating query so stale
     /// results (user has since deselected the story) can be dropped.
     PriorDiscussionsLoaded {
+        /// Story whose URL was queried — checked against the currently
+        /// selected story so stale results are dropped.
         story_id: StoryId,
+        /// Prior HN submissions of `story_id`'s URL, in Algolia default
+        /// order (most recent first).
         submissions: Vec<Item>,
     },
 }
@@ -232,7 +280,10 @@ pub struct App {
     /// Whether the help overlay (`?`) is open.
     pub show_help: bool,
     /// Last user-facing error from a feed/search/comment spawn. Rendered
-    /// by [`crate::ui::status_bar`]; sanitised at the render boundary.
+    /// by [`crate::ui::status_bar`] with a red `Error:` prefix; sanitised
+    /// at the render boundary. Non-error transient messages
+    /// (e.g. `URL copied: …`) go through [`Self::set_info`] instead so
+    /// they don't paint red.
     pub error: Option<String>,
     /// Cached terminal height in rows. Updated on `Event::Resize`.
     pub terminal_height: u16,
@@ -240,6 +291,8 @@ pub struct App {
     pub terminal_width: u16,
     /// Monotonic frame counter used by [`crate::ui::spinner::frame`];
     /// wraps on overflow (so the spinner sequence is u64-cyclic).
+    /// Advanced once per tick by [`Self::tick`], which also expires the
+    /// info toast when its deadline has passed.
     pub tick_count: u64,
 
     /// Prior-discussions overlay state. `Some` while the overlay is open;
@@ -288,6 +341,9 @@ pub struct App {
     /// and torn down by [`Action::ExitHintMode`] or a unique-match dispatch.
     pub hint_state: Option<HintState>,
 
+    /// Most-recent click on a comment row — `(when, visible_index)`.
+    /// Drives the 400 ms double-click-to-collapse heuristic in
+    /// [`Self::handle_click`].
     last_comment_click: Option<(std::time::Instant, usize)>,
 
     /// Monotonic generation counter for feed/search loads. Bumped on
@@ -416,8 +472,8 @@ impl App {
         self.terminal_height = h;
     }
 
-    /// Sets the auto-expiring info toast and returns the previous one (if
-    /// any). Distinct from [`Self::error`] so the status bar can pick a
+    /// Sets the auto-expiring info toast, replacing any previous one.
+    /// Distinct from [`Self::error`] so the status bar can pick a
     /// non-red style and skip the `Error:` prefix. Lives `INFO_TOAST_TTL`
     /// from now; [`Self::tick`] clears it once it's expired so the normal
     /// keybinding hints reappear without the user pressing anything.
@@ -1525,10 +1581,11 @@ impl App {
 
     /// http(s)-only URL opener with auto-fallback to OSC 52 clipboard
     /// when [`Self::no_browser_env`] is true (Docker container, SSH, or
-    /// `HNT_NO_BROWSER` explicitly set). On the clipboard path, a
-    /// transient status message is surfaced through [`Self::error`]
-    /// — same channel and pattern as the quickjump-hint `y` key
-    /// ([`Self::execute_hint_action`]). On a real desktop the call
+    /// `HNT_NO_BROWSER` explicitly set). On the clipboard success path
+    /// the `URL copied: <url>` message is surfaced through the
+    /// auto-expiring info toast ([`Self::set_info`]) so it doesn't paint
+    /// red with the `Error:` prefix; an OSC 52 write failure still
+    /// falls through to [`Self::error`]. On a real desktop the call
     /// flows through [`open::that`] as before. Silently drops `None`,
     /// parse failures, and non-http(s) schemes so `file://`,
     /// `javascript:`, and `data:` URIs can never reach the underlying
@@ -1872,6 +1929,9 @@ struct PriorInFlightGuard {
 }
 
 impl Drop for PriorInFlightGuard {
+    /// Removes the in-flight entry on drop, including via panic
+    /// propagation. Tolerates a poisoned mutex by taking the inner guard
+    /// rather than panicking again.
     fn drop(&mut self) {
         // Recover from a poisoned mutex — same rationale as the
         // `HnClient::cache` guard: a transient task panic shouldn't

--- a/src/event.rs
+++ b/src/event.rs
@@ -23,8 +23,9 @@ pub enum Event {
     /// Terminal resize. New dimensions are cached on `App` via
     /// `App::set_terminal_size`; widgets pick them up on the next draw.
     Resize { width: u16, height: u16 },
-    /// Fixed-rate timer pulse; drives the loading-spinner animation.
-    /// Does not imply user activity.
+    /// Fixed-rate timer pulse routed into [`crate::app::App::tick`];
+    /// drives the loading-spinner animation and expires the
+    /// auto-clearing info toast. Does not imply user activity.
     Tick,
 }
 
@@ -39,6 +40,12 @@ impl EventHandler {
     ///
     /// The task runs until the channel is dropped or the crossterm stream
     /// errors/ends. Ticks fire every `tick_rate`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a Tokio runtime (`tokio::spawn` requires
+    /// one) or if `tick_rate` is zero (`tokio::time::interval` rejects
+    /// zero durations).
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
 

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -49,7 +49,10 @@ pub enum CommentFilter {
 /// `depth == 0` is a root-level comment; children have strictly greater
 /// depth and are stored contiguously after their parent in pre-order.
 pub struct FlatComment {
+    /// Decoded HN comment item (or the story body for the root).
     pub item: Item,
+    /// Tree depth — `0` is a root-level comment under the story; children
+    /// have strictly greater depth than their parent.
     pub depth: usize,
     /// Number of descendants — the count of contiguously-following
     /// comments at strictly greater depth. Precomputed by

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -56,8 +56,8 @@ pub struct LinkRegistry {
 }
 
 impl LinkRegistry {
-    /// Empty registry. Use [`Self::push`] to add links, then
-    /// [`Self::assign_labels`] to populate the `label` field.
+    /// Constructs an empty registry. Add links via [`Self::push`] then
+    /// call [`Self::assign_labels`] to populate each entry's `label` field.
     pub fn new() -> Self {
         Self::default()
     }
@@ -103,7 +103,10 @@ impl LinkRegistry {
         }
     }
 
-    /// Looks up `prefix` against every link's label. See [`MatchResult`].
+    /// Looks up `prefix` against every link's label and reports whether
+    /// zero, one, or more labels start with it. An empty `prefix` matches
+    /// every label, so on a multi-link registry it returns
+    /// [`MatchResult::Multiple`]. See [`MatchResult`] for the variants.
     #[must_use]
     pub fn match_prefix(&self, prefix: &str) -> MatchResult<'_> {
         let mut iter = self.links.iter().filter(|l| l.label.starts_with(prefix));

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -29,8 +29,11 @@ struct DiskStore<E> {
 /// count and atomic disk writes. Domain wrappers ([`crate::state::read_store::ReadStore`],
 /// [`crate::state::pin_store::PinStore`]) compose around this.
 pub(crate) struct JsonStore<E: PersistedEntry> {
+    /// Loaded entries keyed by [`StoryId`].
     pub entries: HashMap<StoryId, E>,
+    /// Save target — `None` for in-memory-only stores.
     pub path: Option<PathBuf>,
+    /// Set on every mutating call; cleared by a successful [`Self::save`].
     pub dirty: bool,
     max_entries: usize,
     schema_version: u32,

--- a/src/state/prior_state.rs
+++ b/src/state/prior_state.rs
@@ -23,7 +23,8 @@ pub struct PriorDiscussionsState {
     /// Prior HN submissions of `story_id`'s URL, in Algolia default order
     /// (most recent first). May be empty when the URL has no prior submissions.
     pub submissions: Vec<Item>,
-    /// Cursor into `submissions`. Clamps at `submissions.len() - 1`.
+    /// Cursor into `submissions`. Navigation methods saturate at
+    /// `submissions.len() - 1`.
     pub selected: usize,
 }
 

--- a/src/state/reader_state.rs
+++ b/src/state/reader_state.rs
@@ -14,8 +14,14 @@ use ratatui::style::Style;
 
 /// A run of text sharing one ratatui [`Style`]. Multiple fragments compose
 /// one rendered line (see `Vec<Vec<StyledFragment>>`).
+///
+/// Constructors are responsible for passing `text` through
+/// [`sanitize_terminal`] before building a fragment — the rendering
+/// pipeline forwards `text` to ratatui verbatim and assumes the bytes are
+/// already terminal-safe.
 pub struct StyledFragment {
-    /// Visible text content of this fragment (UTF-8).
+    /// Visible text content of this fragment (UTF-8). Must already be
+    /// terminal-safe — see the type-level doc.
     pub text: String,
     /// Ratatui style applied uniformly across `text`.
     pub style: Style,

--- a/src/state/search_state.rs
+++ b/src/state/search_state.rs
@@ -12,14 +12,16 @@
 #[derive(Default)]
 pub struct SearchState {
     /// Committed search query — what pagination spawns send to Algolia.
-    /// Empty until `App::submit_search` copies from `input`.
+    /// Empty until [`crate::app::App::submit_search`] copies from `input`.
     pub query: String,
     /// In-progress typed input buffer. Driven by
-    /// `App::search_input_char` / `_backspace` while
+    /// [`crate::app::App::search_input_char`] /
+    /// [`crate::app::App::search_input_backspace`] while
     /// [`crate::keys::InputMode::SearchInput`] is active.
     pub input: String,
     /// Last-fetched Algolia page index (0-based). Bumped by
-    /// `App::check_lazy_load` when the user nears the loaded tail.
+    /// `App::check_lazy_load` when the user nears the loaded tail
+    /// (private method).
     pub current_page: usize,
     /// Total pages reported by the most recent Algolia response —
     /// drives the lazy-pagination cap.

--- a/src/state/story_state.rs
+++ b/src/state/story_state.rs
@@ -31,7 +31,7 @@ pub struct StoryListState {
     pub stories: Vec<Arc<Item>>,
     /// Pre-computed `story.domain()` for each story at the same index.
     /// Avoids the per-frame `url::Url::parse` that
-    /// [`StoryList`](crate::ui::story_list::StoryList) used to do.
+    /// [`crate::ui::story_list::StoryList`] used to do.
     pub domains: Vec<Option<String>>,
     /// Full ID list from the initial feed fetch — used as a stable
     /// pagination index so a feed that gains stories mid-session
@@ -108,6 +108,8 @@ impl StoryListState {
         self.selected = self.selected.saturating_sub(page_size);
     }
 
+    /// Returns the currently-highlighted story, if any. `None` when
+    /// `stories` is empty.
     #[must_use]
     pub fn selected_story(&self) -> Option<&Arc<Item>> {
         self.stories.get(self.selected)

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -486,8 +486,11 @@ fn measure_comments(
     result
 }
 
-/// Counts descendants of `all[parent_idx]` in the flat list — the
-/// contiguous run of comments with strictly greater depth that follow it.
+/// Returns the precomputed descendant count for `all[parent_idx]` — the
+/// contiguous run of comments with strictly greater depth that follow it
+/// in pre-order. Callers paint this as the "(N hidden)" annotation on a
+/// collapsed comment, hence the legacy name; the count itself does not
+/// depend on the collapse set.
 ///
 /// O(1): reads the precomputed `descendant_count` field maintained by
 /// [`crate::state::comment_state::CommentTreeState::recompute_descendant_counts`].
@@ -518,6 +521,9 @@ const INDENT_BARS: [&str; 11] = [
     "                    │ ",
 ];
 
+/// Returns the precomputed indent-plus-thread-bar string for `depth`,
+/// clamping at `INDENT_BARS.len() - 1` so deeper subtrees keep the same
+/// indent rather than allocating per-depth. See [`INDENT_BARS`].
 fn indent_bar_for(depth: usize) -> &'static str {
     INDENT_BARS[depth.min(INDENT_BARS.len() - 1)]
 }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,4 +1,9 @@
 //! Top header bar: app brand, feed tabs, and search-mode indicator.
+//!
+//! Renders one row spanning the terminal width; tab order mirrors
+//! [`crate::api::types::FeedKind::ALL`] so the `1`-`7` keymap stays
+//! consistent with what the user sees. A `search_active` flag suppresses
+//! the feed-tab highlight in favour of a "Search" chip.
 
 use crate::api::types::FeedKind;
 use crate::ui::theme;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -11,9 +11,13 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 /// [`stories`](Self::stories) / [`comments`](Self::comments) side-by-side,
 /// [`status`](Self::status).
 pub struct AppLayout {
+    /// 1-row top header bar.
     pub header: Rect,
+    /// Left content pane — 35% of the body width.
     pub stories: Rect,
+    /// Right content pane — 65% of the body width.
     pub comments: Rect,
+    /// 1-row bottom status bar.
     pub status: Rect,
 }
 

--- a/src/ui/prior_overlay.rs
+++ b/src/ui/prior_overlay.rs
@@ -103,6 +103,9 @@ pub fn render_prior_overlay(frame: &mut Frame, area: Rect, state: &PriorDiscussi
 }
 
 /// Formats one submission as two styled lines (main + byline).
+/// Title and author are scrubbed through
+/// [`crate::sanitize::sanitize_terminal`] before they reach a `Span` so an
+/// HN-supplied string can't smuggle ANSI escapes through ratatui.
 fn format_submission(item: &Item, selected: bool, width: usize) -> [Line<'static>; 2] {
     let points = item.score.unwrap_or(0);
     let comments = item.descendants.unwrap_or(0);

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,4 +1,9 @@
 //! Small UI helpers shared across widgets.
+//!
+//! Currently a single home for [`truncate_to`], used by the story list,
+//! prior-discussions overlay, and article reader so multi-byte titles
+//! truncate at a `char` boundary (appending `...`) rather than at a byte
+//! boundary that would panic when slicing into a `Span`.
 
 /// Truncates `s` to at most `max` characters (operating on `char`s to
 /// stay UTF-8-safe), appending `...` when truncation occurs. Returns


### PR DESCRIPTION
Closes #202

## Summary

- **Drift** — `App::open_url` and `App::set_info` docs now reflect the post-PR-#201 channel split (success via `set_info` → info toast, failures still via `error`); `Event::Tick` and `App::tick_count` now mention info-toast TTL housekeeping; `App::error` peer-links to `set_info`.
- **Missing on public API** — `StoryListState::selected_story` documented; `AppMessage` struct-variant `pub` fields (15 across 8 variants) all carry per-field docs; `FlatComment`, `CommentWithDepth`, `StoryId`/`CommentId` newtype inner fields, and `AppLayout` fields documented.
- **`# Panics`** added to `EventHandler::new` (Tokio runtime + non-zero tick rate requirements).
- **Internal helpers** — `App::last_comment_click`, `Drop for PriorInFlightGuard`, `indent_bar_for`, and `JsonStore` pub-fields documented.
- **Style polish** — sentence-fragment openers fixed on `Item::is_dead_or_deleted` / `Item::domain`; bare-backtick `App::*` references in `SearchState` / `StoryListState::domains` converted to real intra-doc links; thin `//!` on `ui/util.rs` / `ui/header.rs` expanded; sanitisation notes surfaced on `StyledFragment` and `format_submission`; `LinkRegistry::new` / `match_prefix` rewritten to lead with a declarative.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean (verified locally)
- [x] `cargo test --quiet` — 375 passing (verified locally)
- [x] `cargo fmt --check` — clean (verified locally)
- [ ] CI re-runs the same three checks
- [ ] Spot-check rendered rustdoc for the touched intra-doc links
