### PR TITLE
test(ui): add unit tests for layout, header, spinner, theme

### DIFF
--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -61,3 +61,152 @@ impl Widget for Header {
         buf.set_line(area.left(), area.top(), &line, area.width);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+
+    fn render_header(current_feed: FeedKind, search_active: bool, area: Rect) -> Buffer {
+        let mut buf = Buffer::empty(area);
+        Header {
+            current_feed,
+            search_active,
+        }
+        .render(area, &mut buf);
+        buf
+    }
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+        }
+        s
+    }
+
+    fn count_cells_with_bg(buf: &Buffer, color: Color, y: u16) -> usize {
+        let mut n = 0;
+        for x in 0..buf.area.width {
+            if buf[(x, y)].bg == color {
+                n += 1;
+            }
+        }
+        n
+    }
+
+    #[test]
+    fn header_renders_brand_and_all_feed_labels() {
+        let buf = render_header(FeedKind::Top, false, Rect::new(0, 0, 120, 1));
+        let text = buffer_text(&buf);
+
+        assert!(text.contains("[Y]"), "brand missing: {text:?}");
+        assert!(
+            text.contains("Hacker News Terminal"),
+            "title missing: {text:?}"
+        );
+        for feed in FeedKind::ALL {
+            let label = feed.to_string();
+            assert!(
+                text.contains(&label),
+                "feed label {label:?} missing from header: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_active_tab_carries_orange_highlight() {
+        // For every feed, render with it as `current_feed` (no search)
+        // and confirm the count of HN_ORANGE-bg cells matches the
+        // active-tab label width — proving (a) the active tab is
+        // highlighted and (b) no other span uses HN_ORANGE bg.
+        for feed in FeedKind::ALL {
+            let buf = render_header(feed, false, Rect::new(0, 0, 120, 1));
+            let expected_width = format!(" {} ", feed).chars().count();
+            let actual = count_cells_with_bg(&buf, theme::HN_ORANGE, 0);
+            assert_eq!(
+                actual, expected_width,
+                "expected {expected_width} HN_ORANGE-bg cells for active tab {feed}, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_search_active_shows_chip_and_suppresses_feed_highlight() {
+        // With search_active=true and current_feed=Top, only the
+        // " Search " chip (8 cells) should carry the HN_ORANGE bg —
+        // the Top tab must NOT be highlighted.
+        let buf = render_header(FeedKind::Top, true, Rect::new(0, 0, 120, 1));
+        let text = buffer_text(&buf);
+        assert!(text.contains("Search"), "Search chip missing: {text:?}");
+        let orange = count_cells_with_bg(&buf, theme::HN_ORANGE, 0);
+        assert_eq!(
+            orange, 8,
+            "search-active mode should highlight only the 8-cell ' Search ' chip, got {orange} HN_ORANGE cells"
+        );
+    }
+
+    #[test]
+    fn header_search_chip_absent_in_normal_mode() {
+        let buf = render_header(FeedKind::Top, false, Rect::new(0, 0, 120, 1));
+        let text = buffer_text(&buf);
+        assert!(
+            !text.contains("Search"),
+            "Search chip must not appear when search_active=false: {text:?}"
+        );
+    }
+
+    #[test]
+    fn header_background_fill_paints_styled_bg_across_row() {
+        // The leading fill loop paints SURFACE across every cell at
+        // y=top; spans then override some cells to HN_ORANGE for the
+        // active tab. No cell should keep the default Color::Reset bg.
+        let buf = render_header(FeedKind::Top, false, Rect::new(0, 0, 120, 1));
+        for x in 0..120 {
+            let bg = buf[(x, 0)].bg;
+            assert_ne!(
+                bg,
+                Color::Reset,
+                "cell ({x},0) has default bg — background fill loop missed it"
+            );
+        }
+    }
+
+    #[test]
+    fn header_paints_only_top_row_on_multi_row_area() {
+        // Pins the contract that Header writes to area.top() only —
+        // rows below stay at Buffer::empty defaults.
+        let buf = render_header(FeedKind::Top, false, Rect::new(0, 0, 80, 3));
+        for y in 1..3 {
+            for x in 0..80 {
+                let cell = &buf[(x, y)];
+                assert_eq!(
+                    cell.bg,
+                    Color::Reset,
+                    "cell ({x},{y}) bg should be Reset, got {:?}",
+                    cell.bg
+                );
+                assert_eq!(
+                    cell.symbol(),
+                    " ",
+                    "cell ({x},{y}) symbol should be default ' ', got {:?}",
+                    cell.symbol()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn header_zero_size_area_does_not_panic() {
+        // Width=0 height=0 and width=0 height=1 — both should survive
+        // without panicking (the fill loop is empty and set_line
+        // returns immediately at max_width=0).
+        let _ = render_header(FeedKind::Top, false, Rect::new(0, 0, 0, 0));
+        let _ = render_header(FeedKind::Top, false, Rect::new(0, 0, 0, 1));
+        let _ = render_header(FeedKind::Top, true, Rect::new(0, 0, 0, 1));
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -48,3 +48,115 @@ pub fn build_layout(area: Rect) -> AppLayout {
         status: outer[2],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_layout_standard_80x24() {
+        let layout = build_layout(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(layout.header, Rect::new(0, 0, 80, 1));
+        assert_eq!(layout.status, Rect::new(0, 23, 80, 1));
+        assert_eq!(layout.stories.y, 1);
+        assert_eq!(layout.stories.height, 22);
+        assert_eq!(layout.comments.y, 1);
+        assert_eq!(layout.comments.height, 22);
+        assert_eq!(layout.stories.width + layout.comments.width, 80);
+        assert_eq!(layout.stories.x, 0);
+        assert_eq!(layout.comments.right(), 80);
+    }
+
+    #[test]
+    fn build_layout_wide_200x60() {
+        let layout = build_layout(Rect::new(0, 0, 200, 60));
+
+        assert_eq!(layout.header.height, 1);
+        assert_eq!(layout.status.height, 1);
+        assert_eq!(layout.stories.width + layout.comments.width, 200);
+        assert_eq!(
+            layout.stories.width, 70,
+            "stories should be 35% of 200 = 70, got {}",
+            layout.stories.width
+        );
+        assert_eq!(
+            layout.comments.width, 130,
+            "comments should be 65% of 200 = 130, got {}",
+            layout.comments.width
+        );
+    }
+
+    #[test]
+    fn build_layout_non_zero_origin() {
+        let layout = build_layout(Rect::new(5, 5, 20, 10));
+
+        assert_eq!(layout.header.x, 5);
+        assert_eq!(layout.header.y, 5);
+        assert_eq!(layout.header.width, 20);
+        assert_eq!(layout.status.y, 14);
+        assert_eq!(layout.stories.x, 5);
+        assert_eq!(layout.comments.right(), 25);
+        assert_eq!(layout.stories.width + layout.comments.width, 20);
+    }
+
+    #[test]
+    fn build_layout_no_left_right_gap() {
+        for width in [80u16, 100, 137] {
+            let area = Rect::new(0, 0, width, 24);
+            let layout = build_layout(area);
+            assert_eq!(
+                layout.stories.x, area.x,
+                "stories.x must equal area.x at width {width}"
+            );
+            assert_eq!(
+                layout.comments.right(),
+                area.right(),
+                "comments.right() must equal area.right() at width {width}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_layout_height_two_collapses_body() {
+        let layout = build_layout(Rect::new(0, 0, 80, 2));
+
+        assert_eq!(layout.header.height, 1);
+        assert_eq!(layout.status.height, 1);
+        assert_eq!(layout.stories.height, 0);
+        assert_eq!(layout.comments.height, 0);
+    }
+
+    #[test]
+    fn build_layout_height_one_does_not_panic() {
+        // With three constraints (Length(1) + Min(0) + Length(1)) but only
+        // one row available, ratatui's solver cannot satisfy both Length(1)
+        // constraints — it compromises. We don't pin a specific assignment
+        // (that's ratatui's prerogative); we just assert (a) no panic and
+        // (b) the row heights stay within the available area.
+        let layout = build_layout(Rect::new(0, 0, 80, 1));
+        let total = u32::from(layout.header.height)
+            + u32::from(layout.stories.height)
+            + u32::from(layout.status.height);
+        assert!(
+            total <= 1,
+            "total assigned vertical height ({total}) must not exceed area height (1)"
+        );
+        assert_eq!(layout.stories.y, layout.comments.y);
+        assert_eq!(layout.stories.height, layout.comments.height);
+    }
+
+    #[test]
+    fn build_layout_zero_area_does_not_panic() {
+        let layout = build_layout(Rect::new(0, 0, 0, 0));
+
+        assert_eq!(layout.header.width, 0);
+        assert_eq!(layout.header.height, 0);
+        assert_eq!(layout.stories.width, 0);
+        assert_eq!(layout.stories.height, 0);
+        assert_eq!(layout.comments.width, 0);
+        assert_eq!(layout.comments.height, 0);
+        assert_eq!(layout.status.width, 0);
+        assert_eq!(layout.status.height, 0);
+    }
+}

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -21,3 +21,50 @@ fn style() -> &'static ProgressStyle {
 pub fn frame(tick: u64) -> &'static str {
     style().get_tick_str(tick)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // indicatif's ProgressStyle::get_tick_str reserves the last entry of
+    // tick_strings as the "finished" glyph and cycles over the remaining
+    // N-1 entries: `tick_strings[idx % (len - 1)]`. With FRAMES of length
+    // 6, the animation cycle is 5 — only the first five glyphs ever
+    // appear during ticking; FRAMES[5] ("⠽") is the finished-state
+    // string and is only returned by get_final_tick_str. These tests pin
+    // that contract so a future refactor doesn't silently regress the
+    // animation length.
+    const CYCLED_FRAMES: &[&str] = &["⠾", "⠷", "⠯", "⠟", "⠻"];
+
+    #[test]
+    fn frame_returns_expected_glyphs_for_animated_cycle() {
+        let cycle: Vec<&'static str> = (0..5).map(frame).collect();
+        assert_eq!(cycle, CYCLED_FRAMES);
+    }
+
+    #[test]
+    fn frame_cycles_every_five_ticks() {
+        assert_eq!(frame(5), frame(0));
+        assert_eq!(frame(6), frame(1));
+        assert_eq!(frame(10), frame(0));
+        assert_eq!(frame(14), frame(4));
+    }
+
+    #[test]
+    fn frame_handles_u64_max_without_panic() {
+        let f = frame(u64::MAX);
+        assert!(
+            CYCLED_FRAMES.contains(&f),
+            "frame(u64::MAX) must return one of the cycled FRAMES, got {f:?}"
+        );
+    }
+
+    #[test]
+    fn frame_reuses_static_storage_across_calls() {
+        // OnceLock contract: ProgressStyle isn't rebuilt per call, so the
+        // returned &'static str is the same backing storage every time.
+        let a = frame(0);
+        let b = frame(0);
+        assert_eq!(a.as_ptr(), b.as_ptr());
+    }
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -157,3 +157,127 @@ pub const fn badge_style(badge: crate::api::types::StoryBadge) -> Style {
         .bg(SURFACE)
         .add_modifier(Modifier::BOLD)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::StoryBadge;
+    use std::collections::HashSet;
+
+    // --- depth_color ---
+
+    #[test]
+    fn depth_color_first_six_match_palette_in_order() {
+        assert_eq!(depth_color(0), HN_ORANGE);
+        assert_eq!(depth_color(1), BLUE);
+        assert_eq!(depth_color(2), GREEN);
+        assert_eq!(depth_color(3), MAUVE);
+        assert_eq!(depth_color(4), TEAL);
+        assert_eq!(depth_color(5), PEACH);
+    }
+
+    #[test]
+    fn depth_color_wraps_modulo_six() {
+        assert_eq!(depth_color(6), depth_color(0));
+        assert_eq!(depth_color(13), depth_color(1));
+        assert_eq!(depth_color(60), depth_color(0));
+    }
+
+    #[test]
+    fn depth_color_usize_max_does_not_panic() {
+        let c = depth_color(usize::MAX);
+        assert!(
+            DEPTH_COLORS.contains(&c),
+            "depth_color(usize::MAX) must return one of DEPTH_COLORS, got {c:?}"
+        );
+    }
+
+    // --- badge_style ---
+
+    const ALL_BADGES: [StoryBadge; 6] = [
+        StoryBadge::Ask,
+        StoryBadge::Show,
+        StoryBadge::Tell,
+        StoryBadge::Launch,
+        StoryBadge::Job,
+        StoryBadge::Poll,
+    ];
+
+    #[test]
+    fn badge_style_maps_each_variant_to_its_color() {
+        assert_eq!(badge_style(StoryBadge::Ask).fg, Some(BLUE));
+        assert_eq!(badge_style(StoryBadge::Show).fg, Some(GREEN));
+        assert_eq!(badge_style(StoryBadge::Tell).fg, Some(MAUVE));
+        assert_eq!(badge_style(StoryBadge::Launch).fg, Some(PEACH));
+        assert_eq!(badge_style(StoryBadge::Job).fg, Some(YELLOW));
+        assert_eq!(badge_style(StoryBadge::Poll).fg, Some(TEAL));
+    }
+
+    #[test]
+    fn badge_style_always_bold_on_surface() {
+        for badge in ALL_BADGES {
+            let s = badge_style(badge);
+            assert_eq!(
+                s.bg,
+                Some(SURFACE),
+                "badge_style({badge:?}).bg must be SURFACE"
+            );
+            assert!(
+                s.add_modifier.contains(Modifier::BOLD),
+                "badge_style({badge:?}) must set BOLD, got {:?}",
+                s.add_modifier
+            );
+        }
+    }
+
+    #[test]
+    fn badge_style_assigns_distinct_color_per_variant() {
+        let colors: HashSet<_> = ALL_BADGES.into_iter().map(|b| badge_style(b).fg).collect();
+        assert_eq!(
+            colors.len(),
+            6,
+            "all six badge variants must have distinct fg colors, got {colors:?}"
+        );
+    }
+
+    // --- *_style() helpers ---
+
+    #[test]
+    fn active_tab_style_swaps_fg_and_bg() {
+        // The deliberate swap (fg=BG, bg=HN_ORANGE) is what visually
+        // signals "selected" — assert it directly so an accidental
+        // re-swap doesn't silently invert contrast.
+        let s = active_tab_style();
+        assert_eq!(s.fg, Some(BG));
+        assert_eq!(s.bg, Some(HN_ORANGE));
+        assert!(s.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn pinned_style_uses_body_background_not_surface() {
+        // Pins paint in unselected story rows, so bg must be BG (not
+        // SURFACE) — easy to flip by accident when refactoring palette.
+        let s = pinned_style();
+        assert_eq!(s.fg, Some(HN_ORANGE));
+        assert_eq!(s.bg, Some(BG));
+        assert!(s.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn selected_style_is_bold_text_on_surface() {
+        let s = selected_style();
+        assert_eq!(s.fg, Some(TEXT));
+        assert_eq!(s.bg, Some(SURFACE));
+        assert!(s.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn hint_active_style_matches_active_tab_shape() {
+        // Two distinct call sites for the same visual intent — pin them
+        // together so future divergence becomes intentional.
+        let s = hint_active_style();
+        assert_eq!(s.fg, Some(BG));
+        assert_eq!(s.bg, Some(HN_ORANGE));
+        assert!(s.add_modifier.contains(Modifier::BOLD));
+    }
+}


### PR DESCRIPTION
Closes #206

## Summary
- 28 new unit tests across the four previously-untested UI primitive modules (`layout.rs`, `header.rs`, `spinner.rs`, `theme.rs`)
- No production code changes — pure `#[cfg(test)]` additions matching the project's existing convention (see `src/ui/status_bar.rs:168` for the buffer-rendering test pattern reused in `header.rs`)
- Test scope: `build_layout` Rect math (standard/wide/edge sizes), `Header::render` branching (per-feed active highlight, search-chip suppression, multi-row contract, zero-size safety), `spinner::frame` cycle / wraparound / OnceLock reuse, `theme::depth_color` / `badge_style` / style-helper invariants (fg/bg swap, BOLD-on-SURFACE, distinct-per-variant)
- Documents a quirk discovered while writing tests: `indicatif::ProgressStyle::get_tick_str` cycles `tick_strings.len() - 1` frames (reserving the last as the "finished" glyph), so the spinner animates 5 frames even though 6 are declared. The new tests pin this with a `CYCLED_FRAMES` constant; whether to revisit the source comment in `spinner.rs:12` is left for a follow-up.

## Test plan
- [x] `cargo test` — full suite passes (403/403)
- [x] `cargo fmt --all --check` — clean
- [x] CI green on PR
