### PR TITLE
docs: third-pass rustdoc audit fixes

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -295,6 +295,17 @@ pub fn validate_http_url(raw: &str) -> Option<String> {
     Some(raw.to_string())
 }
 
+/// Serde adaptor used by [`Item::url`] to drop non-`http(s)` URLs at
+/// decode time. Deserializes as `Option<String>` then runs each `Some(_)`
+/// through [`validate_http_url`] — rejected schemes and parse failures
+/// collapse to `None`, so the rest of the app can trust any `Some(url)`
+/// on an [`Item`] is safe to open.
+///
+/// # Errors
+///
+/// Propagates the underlying deserializer error if the field is
+/// structurally invalid (non-string, non-null). Rejected schemes are
+/// **not** an error — they round to `None`.
 fn deserialize_http_url<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -303,6 +314,9 @@ where
     Ok(opt.as_deref().and_then(validate_http_url))
 }
 
+/// Returns the host of `raw` with a leading `www.` stripped, or `None`
+/// if `raw` doesn't parse as an `http`/`https` URL with a host.
+/// Backs [`Item::domain`] for the source-domain badge in the story list.
 fn url_domain(raw: &str) -> Option<String> {
     let parsed = url::Url::parse(raw).ok()?;
     if !matches!(parsed.scheme(), "http" | "https") {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -77,8 +77,8 @@ pub enum Action {
     /// Enter search-input mode with an empty query buffer.
     EnterSearch,
     /// Cycle the comment-pane "what's new" filter: All → New since last
-    /// visit → Recent 24h → All. Falls through to All when the story has
-    /// never been visited (no `last_seen_at` to anchor `NewSince` to).
+    /// visit → Recent 24h → All. Stories never visited skip `NewSince`
+    /// (no `last_seen_at` to anchor it to) and cycle All → Recent 24h → All.
     CycleCommentFilter,
     /// Toggle the pinned state of the focused story (pin if not pinned,
     /// unpin if pinned). Pinned stories surface in the

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -133,8 +133,10 @@ pub struct CommentTreeState {
     /// "What's new" filter — composes with collapse to narrow the visible
     /// set. Reset to [`CommentFilter::All`] on every [`Self::set_comments`].
     pub filter: CommentFilter,
-    /// Cached plain-text rendering of the current story's text (id, width, text).
-    /// Invalidated automatically when story id or width changes.
+    /// Cached plain-text rendering of the current story's text, keyed by
+    /// `(story_id, width)`; the third tuple slot holds the rendered text.
+    /// Cleared lazily on key mismatch inside [`Self::story_plain_text`]
+    /// itself — `reset()` does not clear it explicitly.
     story_text_cache: Option<(u64, usize, String)>,
     /// Memoised output of [`Self::filter_visible_set`], keyed by the
     /// pair `(filter, comments.len())`. Cleared lazily on key mismatch
@@ -260,6 +262,11 @@ impl CommentTreeState {
         computed
     }
 
+    /// Inner O(n) builder for [`Self::filter_visible_set`] (the cached
+    /// caller). Returns `None` for [`CommentFilter::All`] so the cache layer
+    /// can short-circuit, otherwise walks the pre-order tree maintaining a
+    /// path-stack of ancestor indices and unions every passing comment's
+    /// path into `keep`.
     fn compute_filter_visible_set(&self) -> Option<HashSet<usize>> {
         let threshold = match self.filter {
             CommentFilter::All => return None,

--- a/src/state/link_registry.rs
+++ b/src/state/link_registry.rs
@@ -20,9 +20,9 @@ pub struct LinkRef {
     pub url: String,
     /// Line index within the rendered `Vec<Vec<StyledFragment>>`.
     pub line: usize,
-    /// Fragment index within that line; the label paints at this fragment's
-    /// first column. Kept for diagnostics — see `col` for the value the
-    /// renderer actually consumes.
+    /// Fragment index within that line. Kept for diagnostics — the renderer
+    /// paints labels at `col` (the visible-column offset captured at
+    /// registry-build time), not at this fragment's position.
     pub fragment: usize,
     /// Visible-column offset of the link's first character, computed
     /// once when the registry is built. Used by the hint-overlay paint


### PR DESCRIPTION
## Summary

Third-pass rustdoc audit across `src/` (follow-up to #203 / #205). A full
multi-agent docstring sweep of all 33 non-test source files surfaced six
findings — zero Critical/High; the codebase was already in excellent shape.

- **Drift fix (public API):** `Action::CycleCommentFilter` doc claimed the
  unvisited-story cycle "falls through to All". The code (`app.rs`
  `(CommentFilter::All, None) => recent`) actually cycles `All → Recent → All`.
  Corrected the wording to match the implementation and the existing
  `cycle_comment_filter` regression tests.
- **Self-contradiction fix:** `LinkRef::fragment`'s doc said "the label paints
  at this fragment's first column" and then said the renderer uses `col`
  instead. The renderer (`article_reader.rs`) uses `link.col`. Removed the
  misleading first clause.
- **Missing docs (consistency):** added rustdoc to the `deserialize_http_url`
  and `url_domain` URL-safety helpers (the `validate_http_url` sibling between
  them was already documented), and to `CommentTreeState::compute_filter_visible_set`.
- **Precision nit:** tightened the `story_text_cache` field doc to match the
  lazy-invalidation wording used by its neighbor `filter_cache`.

No code logic changes — docstrings only (+28/−7 across 4 files).

## Test plan

- [x] `cargo doc --no-deps` — zero warnings/errors (all intra-doc links resolve)
- [x] `cargo test --bins` — 403 passed, 0 failed