### PR TITLE
Add :command prompt and Ctrl+P command palette

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,10 @@ use crate::api::client::HnClient;
 use crate::api::types::{CommentId, CommentWithDepth, FeedKind, Item, StoryId};
 use crate::article::{fetch_and_extract_article, html_to_styled_lines};
 use crate::clipboard;
+use crate::command::{parser as cmd_parser, CommandRegistry, CommandResult};
 use crate::keys::{Action, InputMode};
+use crate::state::command_history_store;
+use crate::state::command_state::{CommandState, PaletteState};
 use crate::state::comment_state::{CommentFilter, CommentTreeState};
 use crate::state::hint_state::{HintAction, HintContext, HintState};
 use crate::state::link_registry::{LinkRegistry, MatchResult};
@@ -285,6 +288,25 @@ pub struct App {
     /// (e.g. `URL copied: …`) go through [`Self::set_info`] instead so
     /// they don't paint red.
     pub error: Option<String>,
+
+    /// `:`-command prompt state. `Some` while
+    /// [`InputMode::CommandInput`] is active. Mirrors [`Self::search_state`]
+    /// — `main.rs` routes raw chars into [`Self::command_input_char`]
+    /// rather than through `keys::map_key`.
+    pub command_state: Option<CommandState>,
+    /// Registry of all built-in `:`-commands, built once via
+    /// [`CommandRegistry::with_builtins`] in [`Self::new`].
+    pub command_registry: CommandRegistry,
+    /// Persisted command history — newest entries appended at the back.
+    /// Walked by [`Self::command_history_prev`] /
+    /// [`Self::command_history_next`] and rotated by [`Self::submit_command`].
+    pub command_history: Vec<String>,
+    /// Command-palette overlay state. `Some` while
+    /// [`InputMode::PaletteInput`] is active. `main.rs` routes raw chars
+    /// into [`Self::palette_input_char`] rather than through
+    /// `keys::map_key`. Rendered by
+    /// [`crate::ui::command_palette::render_command_palette`].
+    pub palette_state: Option<PaletteState>,
     /// Cached terminal height in rows. Updated on `Event::Resize`.
     pub terminal_height: u16,
     /// Cached terminal width in columns. Updated on `Event::Resize`.
@@ -404,6 +426,10 @@ impl App {
             input_mode: InputMode::Normal,
             show_help: false,
             error: None,
+            command_state: None,
+            command_registry: CommandRegistry::with_builtins(),
+            command_history: command_history_store::load(),
+            palette_state: None,
             terminal_height,
             terminal_width,
             tick_count: 0,
@@ -482,6 +508,15 @@ impl App {
         self.info_toast = Some((message, expires));
     }
 
+    /// Sets a status-bar error, first clearing any live info toast.
+    /// The status bar renders `info` before `error`, so without this a
+    /// fresh error would stay hidden behind an unexpired success toast
+    /// (e.g. `:yank url` then `:feed bogus`). Mirrors [`Self::set_info`].
+    pub fn set_error(&mut self, message: String) {
+        self.info_toast = None;
+        self.error = Some(message);
+    }
+
     /// Currently visible info-toast text, or `None` if no toast is set or
     /// the active toast has already expired. Called per-frame by the UI
     /// layer — cheap because it's a single `Instant::now()` plus pointer
@@ -518,6 +553,7 @@ impl App {
         self.snapshot_pinned_resume_if_any();
         self.read_store.save();
         self.pin_store.save();
+        command_history_store::save(&self.command_history);
     }
 
     /// If the currently-loaded story is pinned, capture its current
@@ -1035,6 +1071,12 @@ impl App {
             Action::EnterSearch => {
                 self.enter_search_mode();
             }
+            Action::EnterCommandMode => {
+                self.enter_command_mode();
+            }
+            Action::OpenCommandPalette => {
+                self.open_command_palette();
+            }
             Action::JumpTop => match self.focus {
                 Pane::Stories => self.story_state.jump_top(),
                 Pane::Comments => {
@@ -1122,11 +1164,16 @@ impl App {
         // comments filtered out as "older than now − 24h".
         let now = chrono::Utc::now().timestamp();
         let recent = CommentFilter::Recent(now - 86_400 - 60);
-        self.comment_state.filter = match (self.comment_state.filter, last_seen) {
+        // Borrow the filter rather than moving it — `CommentFilter` is
+        // no longer `Copy` because [`CommentFilter::Author`] owns a
+        // `String`. Pressing `n` while filtered by author exits to All
+        // (Author is a typed filter, not part of the round-trip cycle).
+        self.comment_state.filter = match (&self.comment_state.filter, last_seen) {
             (CommentFilter::All, Some(t)) => CommentFilter::NewSince(t),
             (CommentFilter::All, None) => recent,
             (CommentFilter::NewSince(_), _) => recent,
             (CommentFilter::Recent(_), _) => CommentFilter::All,
+            (CommentFilter::Author(_), _) => CommentFilter::All,
         };
         // Clamp selection to whatever is visible under the new filter.
         let visible = self.comment_state.visible_len();
@@ -1253,6 +1300,443 @@ impl App {
     pub fn search_input_backspace(&mut self) {
         if let Some(ref mut ss) = self.search_state {
             ss.input.pop();
+        }
+    }
+
+    /// Transitions into `:`-command input mode with an empty prompt.
+    /// Mirrors [`Self::enter_search_mode`] — the actual key routing
+    /// lives in `main.rs::InputMode::CommandInput`.
+    pub fn enter_command_mode(&mut self) {
+        self.input_mode = InputMode::CommandInput;
+        self.command_state = Some(CommandState::new());
+    }
+
+    /// Appends one typed character to the command-input buffer at the
+    /// cursor. No-op when no command prompt is active.
+    pub fn command_input_char(&mut self, c: char) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.insert_char(c);
+        }
+    }
+
+    /// Removes the char before the cursor in the command-input buffer.
+    /// No-op at column 0 or when no command prompt is active.
+    pub fn command_input_backspace(&mut self) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.backspace();
+        }
+    }
+
+    /// Moves the command-input cursor one char left. No-op when no command
+    /// prompt is active.
+    pub fn command_cursor_left(&mut self) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.move_left();
+        }
+    }
+
+    /// Moves the command-input cursor one char right. No-op when no command
+    /// prompt is active.
+    pub fn command_cursor_right(&mut self) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.move_right();
+        }
+    }
+
+    /// Moves the command-input cursor to the start of the line.
+    pub fn command_cursor_home(&mut self) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.move_home();
+        }
+    }
+
+    /// Moves the command-input cursor to the end of the line.
+    pub fn command_cursor_end(&mut self) {
+        if let Some(ref mut cs) = self.command_state {
+            cs.move_end();
+        }
+    }
+
+    /// Walks one step backward in [`Self::command_history`]. No-op when no
+    /// command prompt is active or when no older history exists. The
+    /// in-progress line is snapshotted on the first recall so cancelling
+    /// history navigation restores it.
+    pub fn command_history_prev(&mut self) {
+        let Some(cs) = self.command_state.as_mut() else {
+            return;
+        };
+        if self.command_history.is_empty() {
+            return;
+        }
+        let new_idx = match cs.history_idx {
+            None => {
+                cs.pre_history = cs.input.clone();
+                self.command_history.len() - 1
+            }
+            Some(0) => 0,
+            Some(i) => i - 1,
+        };
+        cs.history_idx = Some(new_idx);
+        let entry = self.command_history[new_idx].clone();
+        cs.set_input(entry);
+    }
+
+    /// Walks one step forward in [`Self::command_history`]. Stepping past
+    /// the newest entry restores the line captured at recall time.
+    pub fn command_history_next(&mut self) {
+        let Some(cs) = self.command_state.as_mut() else {
+            return;
+        };
+        match cs.history_idx {
+            None => {}
+            Some(i) if i + 1 < self.command_history.len() => {
+                cs.history_idx = Some(i + 1);
+                let entry = self.command_history[i + 1].clone();
+                cs.set_input(entry);
+            }
+            Some(_) => {
+                // Stepped past newest — restore the pre-history snapshot
+                // so the user gets back the line they had typed.
+                let snapshot = std::mem::take(&mut cs.pre_history);
+                cs.set_input(snapshot);
+                cs.history_idx = None;
+            }
+        }
+    }
+
+    /// Cancels the `:`-command prompt without running anything. Restores
+    /// [`InputMode::Normal`] and drops the buffered line.
+    pub fn cancel_command(&mut self) {
+        self.command_state = None;
+        self.input_mode = InputMode::Normal;
+    }
+
+    /// Submits the in-progress `:`-command. Parses it, looks up the
+    /// command in [`Self::command_registry`], validates arity, runs the
+    /// closure, and surfaces any result via [`Self::set_info`] or
+    /// [`Self::error`]. The line is appended to [`Self::command_history`]
+    /// unless it duplicates the last entry, then the prompt closes.
+    pub fn submit_command(&mut self) {
+        let Some(cs) = self.command_state.as_mut() else {
+            return;
+        };
+        let line = std::mem::take(&mut cs.input);
+        self.command_state = None;
+        self.input_mode = InputMode::Normal;
+        if line.trim().is_empty() {
+            return;
+        }
+        let (name, args) = match cmd_parser::parse(&line) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                self.set_error(e.to_string());
+                return;
+            }
+        };
+        // `resolve` validates the name + arity and hands back a `Copy` fn
+        // pointer, so no `&Command` borrow is held across the `&mut self`
+        // call below — no borrow-checker dance needed at the call site.
+        let run = match self.command_registry.resolve(&name, &args) {
+            Ok(run) => run,
+            Err(msg) => {
+                self.set_error(msg);
+                return;
+            }
+        };
+        // Only record runnable commands in history — malformed, unknown, and
+        // wrong-arity lines never reach here, so they don't pollute the
+        // persisted `commands.json`. A runtime `Err` is still worth recalling,
+        // so the push precedes the run.
+        if self.command_history.last().is_none_or(|prev| prev != &line) {
+            self.command_history.push(line.clone());
+        }
+        match run(self, &args) {
+            // A successful command clears any stale error so a previous
+            // failure's red message doesn't linger (`self.error` has no TTL).
+            CommandResult::Ok => self.error = None,
+            CommandResult::OkInfo(msg) => {
+                self.error = None;
+                self.set_info(msg);
+            }
+            CommandResult::Err(msg) => self.set_error(msg),
+        }
+    }
+
+    /// Returns the story under user attention — the highlighted row in
+    /// the stories pane when focused there, or the loaded story in the
+    /// comments pane when focused there. Used by `:yank`, `:pin`,
+    /// `:reader`, etc. so they target the same item the user is looking
+    /// at regardless of which pane is active.
+    pub fn focused_story(&self) -> Option<&Arc<Item>> {
+        match self.focus {
+            Pane::Stories => self.story_state.selected_story(),
+            Pane::Comments => self.comment_state.story.as_ref(),
+        }
+    }
+
+    /// Spawns an async fetch for the HN story `id` and opens its
+    /// comments. Mirrors the click-a-story-in-the-list path: resets the
+    /// comments pane, bumps `story_gen` for race-gating, focuses the
+    /// comments pane, then issues the fetch. A miss or network error
+    /// surfaces as a status-bar error via [`AppMessage::Error`].
+    pub fn spawn_open_story_by_id(&mut self, id: u64) {
+        // Mirror the click path (`load_selected_comments`): snapshot the
+        // outgoing pinned story's reading position before `reset()` wipes
+        // `comment_state`, and record this visit in the read store so the
+        // story renders as read and gets a `new`-comments anchor. The
+        // descendant count isn't known until the fetch lands, so seed it at
+        // 0; reopening from a feed list later re-marks it with the real
+        // count.
+        self.snapshot_pinned_resume_if_any();
+        self.read_store.mark(StoryId(id), 0);
+        self.focus = Pane::Comments;
+        self.comment_state.reset();
+        self.comment_state.loading = true;
+        self.pending_pinned_resume = None;
+        let gen = self.bump_story_gen();
+        let client = self.client.clone();
+        let tx = self.msg_tx.clone();
+        tokio::spawn(async move {
+            match client.fetch_item(id).await {
+                Ok(Some(item)) => {
+                    let needs_full_fetch = item.kids.is_none();
+                    run_comment_load(client, tx, item, needs_full_fetch, gen).await;
+                }
+                Ok(None) => {
+                    let _ = tx.send(AppMessage::Error(format!("Story {id} not found")));
+                }
+                Err(e) => {
+                    let _ = tx.send(AppMessage::Error(format!(
+                        "Failed to fetch story {id}: {e}"
+                    )));
+                }
+            }
+        });
+    }
+
+    /// Opens the command-palette overlay with no query, every command
+    /// matching. Flips [`InputMode`] to [`InputMode::PaletteInput`] so
+    /// `main.rs` routes raw chars into the palette query.
+    pub fn open_command_palette(&mut self) {
+        let mut state = PaletteState::new();
+        state.matches = (0..self.command_registry.all().len()).collect();
+        state.selected = 0;
+        self.palette_state = Some(state);
+        self.input_mode = InputMode::PaletteInput;
+    }
+
+    /// Closes the palette without running anything. Restores
+    /// [`InputMode::Normal`].
+    pub fn cancel_palette(&mut self) {
+        self.palette_state = None;
+        self.input_mode = InputMode::Normal;
+    }
+
+    /// Appends `c` to the palette query and recomputes the match list.
+    pub fn palette_input_char(&mut self, c: char) {
+        let Some(p) = self.palette_state.as_mut() else {
+            return;
+        };
+        p.push_query(c);
+        self.recompute_palette_matches();
+    }
+
+    /// Backspaces one char from the palette query and recomputes matches.
+    pub fn palette_input_backspace(&mut self) {
+        let Some(p) = self.palette_state.as_mut() else {
+            return;
+        };
+        p.pop_query();
+        self.recompute_palette_matches();
+    }
+
+    /// Moves palette selection up by one row.
+    pub fn palette_move_up(&mut self) {
+        if let Some(p) = self.palette_state.as_mut() {
+            p.move_up();
+        }
+    }
+
+    /// Moves palette selection down by one row.
+    pub fn palette_move_down(&mut self) {
+        if let Some(p) = self.palette_state.as_mut() {
+            p.move_down();
+        }
+    }
+
+    /// Runs the selected command and closes the palette. No-op when no
+    /// match is selected. A command that needs arguments can't be completed
+    /// from the palette, so instead of failing it hands off to the `:`
+    /// prompt pre-filled with the command name, ready for the user to type
+    /// the arguments and submit.
+    pub fn palette_submit(&mut self) {
+        // A freshly-opened palette pre-highlights row 0, which is whatever
+        // registered first (currently `:quit`). Running it on a bare Enter —
+        // before the user has typed a query or moved the selection — would be
+        // a destructive surprise, so require an explicit interaction first and
+        // otherwise leave the palette open.
+        match self.palette_state.as_ref() {
+            Some(p) if p.interacted => {}
+            _ => return,
+        }
+        let Some(idx) = self.palette_state.as_ref().and_then(|p| p.selected_index()) else {
+            self.cancel_palette();
+            return;
+        };
+        self.cancel_palette();
+        let (name, run, needs_args) = {
+            let cmd = &self.command_registry.all()[idx];
+            let needs_args = !matches!(
+                cmd.arity,
+                crate::command::Arity::Variadic | crate::command::Arity::Exact(0)
+            );
+            (cmd.name, cmd.run, needs_args)
+        };
+        if needs_args {
+            // Hand off to the `:` prompt pre-filled with `<name> ` so the
+            // user can supply the arguments — every arg-bearing command stays
+            // reachable from the palette instead of dead-ending in an error.
+            self.enter_command_mode();
+            if let Some(cs) = self.command_state.as_mut() {
+                cs.set_input(format!("{name} "));
+            }
+            return;
+        }
+        match run(self, &[]) {
+            CommandResult::Ok => self.error = None,
+            CommandResult::OkInfo(msg) => {
+                self.error = None;
+                self.set_info(msg);
+            }
+            CommandResult::Err(msg) => self.set_error(msg),
+        }
+    }
+
+    /// Rebuilds [`PaletteState::matches`] from the current query against
+    /// [`Self::command_registry`]. Resets `selected` to 0 so the new top
+    /// match is highlighted. No-op when the palette is closed.
+    pub fn recompute_palette_matches(&mut self) {
+        // `fuzzy` now returns registry indices directly, so this is O(n) and
+        // borrows `command_registry` (immutable) and `palette_state.query`
+        // (immutable, disjoint field) without a query clone or a ptr::eq
+        // round-trip. The owned `Vec` ends both borrows before the re-borrow.
+        let matches: Vec<usize> = match self.palette_state.as_ref() {
+            Some(p) => self
+                .command_registry
+                .fuzzy(&p.query)
+                .into_iter()
+                .map(|(idx, _score)| idx)
+                .collect(),
+            None => return,
+        };
+        if let Some(p) = self.palette_state.as_mut() {
+            p.matches = matches;
+            p.selected = 0;
+        }
+    }
+
+    /// Tab-completion against the command registry.
+    ///
+    /// - **Single prefix match**: replaces the in-progress line with the
+    ///   completed name and a trailing space (ready for an argument).
+    /// - **Multi-match**: extends the line to the longest common prefix
+    ///   (if longer than what's already typed) and surfaces the candidate
+    ///   list as a status-bar info toast so the user can keep narrowing.
+    /// - **No match / no prefix typed**: no-op.
+    ///
+    /// Tab-completion against the command registry.
+    ///
+    /// While still typing the first token, completes the **command name** —
+    /// preferring canonical names, falling back to aliases when no name
+    /// matches (`un` → `unpin`). Once the command name is followed by a
+    /// space, completes its **first positional argument** against
+    /// [`crate::command::Command::arg_completions`] (`feed t` → `feed top`,
+    /// `filter ` → candidate list). Later arguments (freeform IDs, queries,
+    /// usernames) are left alone.
+    pub fn complete_command_at_cursor(&mut self) {
+        let Some(cs) = self.command_state.as_mut() else {
+            return;
+        };
+        let line = cs.input.trim_start().to_string();
+        if line.is_empty() {
+            return;
+        }
+        let trailing_space = line.ends_with(|c: char| c.is_whitespace());
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+
+        // Still typing the first token → complete the command name.
+        if tokens.len() == 1 && !trailing_space {
+            let prefix = tokens[0];
+            let name_matches: Vec<&str> = self
+                .command_registry
+                .all()
+                .iter()
+                .filter(|c| c.name.starts_with(prefix))
+                .map(|c| c.name)
+                .collect();
+            // Names take precedence so canonical-name completion stays
+            // unsurprising; only when nothing matches by name do we offer
+            // aliases, which keeps short aliases (`q`, `r`) from poisoning the
+            // common-prefix of a name match like `re` → refresh/reader.
+            let matches: Vec<&str> = if name_matches.is_empty() {
+                self.command_registry
+                    .all()
+                    .iter()
+                    .flat_map(|c| c.aliases.iter().copied())
+                    .filter(|a| a.starts_with(prefix))
+                    .collect()
+            } else {
+                name_matches
+            };
+            match matches.as_slice() {
+                [] => {}
+                [single] => cs.set_input(format!("{single} ")),
+                many => {
+                    let common = longest_common_prefix(many);
+                    if common.len() > prefix.len() {
+                        cs.set_input(common);
+                    } else {
+                        // No further extension possible — show the candidates
+                        // so the user knows their options without losing the
+                        // typed prefix.
+                        let candidates = many.join("  :");
+                        self.set_info(format!("Matches: :{candidates}"));
+                    }
+                }
+            }
+            return;
+        }
+
+        // Command name typed; complete its first positional argument. Only the
+        // first arg is completed — later tokens may be freeform.
+        let on_first_arg =
+            (tokens.len() == 1 && trailing_space) || (tokens.len() == 2 && !trailing_space);
+        if !on_first_arg {
+            return;
+        }
+        let name = tokens[0];
+        let arg_prefix = if tokens.len() == 2 { tokens[1] } else { "" };
+        let Some(cmd) = self.command_registry.lookup(name) else {
+            return;
+        };
+        let cands: Vec<&str> = cmd
+            .arg_completions
+            .iter()
+            .copied()
+            .filter(|a| a.starts_with(arg_prefix))
+            .collect();
+        match cands.as_slice() {
+            [] => {}
+            [single] => cs.set_input(format!("{name} {single} ")),
+            many => {
+                let common = longest_common_prefix(many);
+                if common.len() > arg_prefix.len() {
+                    cs.set_input(format!("{name} {common}"));
+                } else {
+                    let candidates = many.join("  ");
+                    self.set_info(format!("Matches: {candidates}"));
+                }
+            }
         }
     }
 
@@ -2068,6 +2552,35 @@ fn detect_no_browser_env() -> bool {
     std::env::var_os("HNT_NO_BROWSER").is_some() || std::path::Path::new("/.dockerenv").exists()
 }
 
+/// Returns the longest string `s` such that every entry in `names`
+/// starts with `s`. Empty `names` yields `""`. Used by
+/// [`App::complete_command_at_cursor`] to extend a typed prefix up to
+/// the maximal common ground before showing candidates.
+fn longest_common_prefix(names: &[&str]) -> String {
+    let mut iter = names.iter();
+    let Some(first) = iter.next() else {
+        return String::new();
+    };
+    let mut end = first.len();
+    for s in iter {
+        let common = first
+            .bytes()
+            .zip(s.bytes())
+            .take_while(|(a, b)| a == b)
+            .count();
+        end = end.min(common);
+        if end == 0 {
+            break;
+        }
+    }
+    // Walk back to the nearest UTF-8 char boundary so we never split a
+    // multi-byte sequence.
+    while end > 0 && !first.is_char_boundary(end) {
+        end -= 1;
+    }
+    first[..end].to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2782,5 +3295,634 @@ mod tests {
         app.open_url("not a url at all");
         app.open_url("");
         assert!(app.error.is_none());
+    }
+
+    // --- Command mode ---
+
+    #[test]
+    fn enter_command_mode_installs_prompt_and_flips_input_mode() {
+        let mut app = App::new(80, 24);
+        assert!(app.command_state.is_none());
+        assert_eq!(app.input_mode, InputMode::Normal);
+        app.enter_command_mode();
+        assert_eq!(app.input_mode, InputMode::CommandInput);
+        let cs = app.command_state.as_ref().expect("command_state is Some");
+        assert_eq!(cs.input, "");
+        assert_eq!(cs.cursor, 0);
+    }
+
+    #[test]
+    fn command_input_char_appends_to_buffer() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "quit".chars() {
+            app.command_input_char(c);
+        }
+        assert_eq!(app.command_state.as_ref().unwrap().input, "quit");
+    }
+
+    #[test]
+    fn command_input_backspace_removes_last_char() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "quiz".chars() {
+            app.command_input_char(c);
+        }
+        app.command_input_backspace();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "qui");
+    }
+
+    #[test]
+    fn cancel_command_drops_prompt_without_running() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        app.command_input_char('q');
+        app.cancel_command();
+        assert!(app.command_state.is_none());
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.running, "cancel must not quit the app");
+    }
+
+    #[test]
+    fn submit_command_quit_sets_running_false() {
+        // The :quit milestone — full end-to-end path: enter command mode,
+        // type the command, submit, and confirm the app is scheduled to
+        // exit on the next main-loop iteration.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "quit".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(!app.running, ":quit must clear App::running");
+        assert!(app.command_state.is_none(), "prompt must close on submit");
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert_eq!(
+            app.command_history,
+            vec!["quit".to_string()],
+            "submitted command must be appended to history"
+        );
+    }
+
+    #[test]
+    fn submit_command_alias_q_also_quits() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        app.command_input_char('q');
+        app.submit_command();
+        assert!(!app.running, ":q alias must clear App::running");
+    }
+
+    #[test]
+    fn submit_unknown_command_sets_error() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "nope".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(app.running, "unknown command must not quit");
+        assert!(
+            app.error.as_deref().is_some_and(|e| e.contains("Unknown")),
+            "expected unknown-command error, got {:?}",
+            app.error
+        );
+    }
+
+    #[test]
+    fn submit_empty_command_is_noop() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        app.submit_command();
+        assert!(app.running);
+        assert!(app.error.is_none());
+        assert!(app.command_history.is_empty());
+    }
+
+    #[test]
+    fn submit_command_with_wrong_arity_errors() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "quit extra".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(app.running);
+        assert!(
+            app.error.as_deref().is_some_and(|e| e.contains("expects")),
+            "expected arity error, got {:?}",
+            app.error
+        );
+    }
+
+    #[test]
+    fn submit_command_dedups_consecutive_history_entries() {
+        let mut app = App::new(80, 24);
+        for _ in 0..3 {
+            app.enter_command_mode();
+            for c in "quit".chars() {
+                app.command_input_char(c);
+            }
+            // Use cancel + push manually to avoid actually quitting.
+            let line = std::mem::take(&mut app.command_state.as_mut().unwrap().input);
+            app.cancel_command();
+            if app.command_history.last().is_none_or(|p| p != &line) {
+                app.command_history.push(line);
+            }
+        }
+        assert_eq!(app.command_history, vec!["quit".to_string()]);
+    }
+
+    #[test]
+    fn history_prev_recalls_previous_entry() {
+        let mut app = App::new(80, 24);
+        app.command_history = vec!["feed best".to_string(), "refresh".to_string()];
+        app.enter_command_mode();
+        app.command_history_prev();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "refresh");
+        app.command_history_prev();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "feed best");
+    }
+
+    #[test]
+    fn history_next_restores_pre_history_snapshot() {
+        let mut app = App::new(80, 24);
+        app.command_history = vec!["refresh".to_string()];
+        app.enter_command_mode();
+        for c in "in-progress".chars() {
+            app.command_input_char(c);
+        }
+        app.command_history_prev();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "refresh");
+        app.command_history_next();
+        assert_eq!(
+            app.command_state.as_ref().unwrap().input,
+            "in-progress",
+            "stepping past newest restores the pre-history buffer"
+        );
+    }
+
+    #[test]
+    fn tab_completes_unique_prefix() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "qui".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        let cs = app.command_state.as_ref().unwrap();
+        assert_eq!(cs.input, "quit ");
+        assert_eq!(cs.cursor, 5);
+    }
+
+    #[test]
+    fn open_command_palette_flips_input_mode_and_lists_all_commands() {
+        let mut app = App::new(80, 24);
+        assert!(app.palette_state.is_none());
+        app.open_command_palette();
+        assert_eq!(app.input_mode, InputMode::PaletteInput);
+        let p = app.palette_state.as_ref().expect("palette open");
+        assert_eq!(
+            p.matches.len(),
+            app.command_registry.all().len(),
+            "no query → every command listed"
+        );
+        assert_eq!(p.selected, 0);
+    }
+
+    #[test]
+    fn palette_input_char_filters_matches() {
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        for c in "fee".chars() {
+            app.palette_input_char(c);
+        }
+        let p = app.palette_state.as_ref().unwrap();
+        // 'fee' subsequence-matches "feed" but not "quit"
+        let names: Vec<&str> = p
+            .matches
+            .iter()
+            .map(|&i| app.command_registry.all()[i].name)
+            .collect();
+        assert!(names.contains(&"feed"), "'fee' must match feed");
+        assert!(!names.contains(&"quit"), "'fee' must not match quit");
+    }
+
+    #[test]
+    fn palette_input_backspace_widens_matches() {
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        for c in "feed".chars() {
+            app.palette_input_char(c);
+        }
+        let narrow = app.palette_state.as_ref().unwrap().matches.len();
+        app.palette_input_backspace();
+        let wider = app.palette_state.as_ref().unwrap().matches.len();
+        assert!(wider >= narrow, "removing a char must widen matches");
+    }
+
+    #[test]
+    fn palette_move_navigates_selection() {
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        let initial = app.palette_state.as_ref().unwrap().selected;
+        assert_eq!(initial, 0);
+        app.palette_move_down();
+        assert_eq!(app.palette_state.as_ref().unwrap().selected, 1);
+        app.palette_move_up();
+        assert_eq!(app.palette_state.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn palette_submit_runs_zero_arity_command() {
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        // Type just enough to surface `:quit` as the unique top match.
+        for c in "quit".chars() {
+            app.palette_input_char(c);
+        }
+        app.palette_submit();
+        assert!(!app.running, ":quit must execute via palette");
+        assert!(app.palette_state.is_none(), "palette closes on submit");
+        assert_eq!(app.input_mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn palette_submit_arg_command_hands_off_to_command_prompt() {
+        // `:feed` needs an argument the palette can't collect, so submitting
+        // it drops into the `:` prompt pre-filled with `feed `, ready for the
+        // user to type the feed name — no dead-end error.
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        for c in "feed".chars() {
+            app.palette_input_char(c);
+        }
+        app.palette_submit();
+        assert!(app.running);
+        assert!(app.error.is_none(), "handoff must not surface an error");
+        assert!(app.palette_state.is_none(), "palette closes on handoff");
+        assert_eq!(app.input_mode, InputMode::CommandInput);
+        assert_eq!(
+            app.command_state.as_ref().map(|cs| cs.input.as_str()),
+            Some("feed "),
+            "command prompt pre-filled with the command name"
+        );
+    }
+
+    #[test]
+    fn cancel_palette_closes_without_running() {
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        for c in "quit".chars() {
+            app.palette_input_char(c);
+        }
+        app.cancel_palette();
+        assert!(app.running, "cancel must not run anything");
+        assert!(app.palette_state.is_none());
+        assert_eq!(app.input_mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn tab_extends_to_longest_common_prefix() {
+        // Typed 'r' — matches both 'refresh' and 'reader'. Their LCP
+        // is 're', so Tab extends the line to 're' (no trailing space
+        // since the user must still choose between candidates).
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        app.command_input_char('r');
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "re");
+    }
+
+    #[test]
+    fn tab_shows_candidates_when_no_further_extension_possible() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "re".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(
+            app.command_state.as_ref().unwrap().input,
+            "re",
+            "no LCP extension beyond what's typed"
+        );
+        let toast = app.info_toast_message().expect("candidate toast set");
+        assert!(toast.contains(":refresh"));
+        assert!(toast.contains(":reader"));
+    }
+
+    #[test]
+    fn longest_common_prefix_of_empty_is_empty() {
+        assert_eq!(longest_common_prefix(&[]), "");
+    }
+
+    #[test]
+    fn longest_common_prefix_of_single_returns_full() {
+        assert_eq!(longest_common_prefix(&["refresh"]), "refresh");
+    }
+
+    #[test]
+    fn longest_common_prefix_finds_shared_prefix() {
+        assert_eq!(longest_common_prefix(&["refresh", "reader"]), "re");
+        assert_eq!(
+            longest_common_prefix(&["filter", "fence", "feet"]),
+            "f",
+            "diverging at index 1"
+        );
+        assert_eq!(longest_common_prefix(&["alpha", "beta"]), "");
+    }
+
+    #[test]
+    fn longest_common_prefix_respects_utf8_boundaries() {
+        // Two-byte chars: 'é' is 0xC3 0xA9. LCP byte-wise would be 2 if
+        // both share the first byte but differ at the second — the
+        // function must walk back to a char boundary.
+        // 'é' = é, 'è' = è — both start with 0xC3 then differ.
+        assert_eq!(longest_common_prefix(&["éa", "èa"]), "");
+    }
+
+    #[test]
+    fn tab_does_nothing_on_ambiguous_prefix() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        app.command_input_char('q');
+        app.complete_command_at_cursor();
+        // 'q' matches the command name "quit" (names take precedence over the
+        // 'q' alias), so it completes to "quit " — unique since no other
+        // command name begins with 'q'.
+        assert_eq!(app.command_state.as_ref().unwrap().input, "quit ");
+    }
+
+    #[test]
+    fn tab_completes_alias_when_no_name_matches() {
+        // `un` matches no command *name*, but it's a prefix of the `unpin`
+        // alias of `pin`; completion falls back to aliases so it's reachable.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "un".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "unpin ");
+    }
+
+    #[test]
+    fn tab_completes_first_argument() {
+        // `feed t` → unique arg match `top` → `feed top `.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "feed t".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "feed top ");
+    }
+
+    #[test]
+    fn tab_arg_completion_unique_match_for_filter() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "filter au".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "filter author ");
+    }
+
+    #[test]
+    fn tab_arg_completion_shows_candidates_when_ambiguous() {
+        // `filter a` matches `all` and `author`; LCP is just `a` (already
+        // typed), so the candidate list is surfaced and the line is unchanged.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "filter a".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "filter a");
+        let toast = app.info_toast_message().expect("candidate toast set");
+        assert!(toast.contains("all"), "got {toast:?}");
+        assert!(toast.contains("author"), "got {toast:?}");
+    }
+
+    #[test]
+    fn tab_arg_completion_lists_all_on_empty_arg() {
+        // `goto ` (trailing space) → first arg, empty prefix → list all.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "goto ".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        let toast = app.info_toast_message().expect("candidate toast set");
+        assert!(toast.contains("top"), "got {toast:?}");
+        assert!(toast.contains("bottom"), "got {toast:?}");
+    }
+
+    #[test]
+    fn tab_no_arg_completion_for_freeform_or_later_args() {
+        // `:open` takes a freeform numeric id → no completion candidates.
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "open 12".chars() {
+            app.command_input_char(c);
+        }
+        app.complete_command_at_cursor();
+        assert_eq!(app.command_state.as_ref().unwrap().input, "open 12");
+        // A second argument (e.g. the username) is freeform → untouched.
+        let mut app2 = App::new(80, 24);
+        app2.enter_command_mode();
+        for c in "filter author da".chars() {
+            app2.command_input_char(c);
+        }
+        app2.complete_command_at_cursor();
+        assert_eq!(
+            app2.command_state.as_ref().unwrap().input,
+            "filter author da"
+        );
+    }
+
+    // --- Command-feature correctness fixes (review #1–#10) ---
+
+    fn item_with_id(id: u64) -> Item {
+        Item {
+            id,
+            title: Some("t".into()),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    #[test]
+    fn palette_bare_enter_on_untouched_palette_does_not_run_quit() {
+        // Ctrl+P preselects row 0 (registration order → :quit). A bare Enter
+        // before any typing/navigation must NOT fire it.
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        app.palette_submit();
+        assert!(app.running, "bare Enter on a fresh palette must not quit");
+        assert!(app.palette_state.is_some(), "palette stays open");
+        assert_eq!(app.input_mode, InputMode::PaletteInput);
+    }
+
+    #[test]
+    fn palette_enter_runs_after_navigation() {
+        // Once the user interacts (arrow down then back to 0), Enter runs the
+        // selected command as before.
+        let mut app = App::new(80, 24);
+        app.open_command_palette();
+        app.palette_move_down();
+        app.palette_move_up();
+        app.palette_submit();
+        assert!(
+            !app.running,
+            "Enter after navigating runs the selected command"
+        );
+    }
+
+    #[test]
+    fn command_error_clears_stale_info_toast() {
+        // A `:yank`-style success toast must not mask a following command
+        // error (the status bar renders info before error).
+        let mut app = App::new(80, 24);
+        app.set_info("Copied: https://example.com".to_string());
+        assert!(app.info_toast_message().is_some());
+        app.enter_command_mode();
+        for c in "feed bogus".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(
+            app.error
+                .as_deref()
+                .is_some_and(|e| e.contains("Unknown feed")),
+            "feed error expected, got {:?}",
+            app.error
+        );
+        assert!(
+            app.info_toast_message().is_none(),
+            "stale toast must be cleared so the error is visible"
+        );
+    }
+
+    #[test]
+    fn successful_command_clears_stale_error() {
+        let mut app = App::new(80, 24);
+        app.error = Some("Unknown command: nope".to_string());
+        app.enter_command_mode();
+        for c in "goto top".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(
+            app.error.is_none(),
+            "a successful command clears a stale error"
+        );
+    }
+
+    #[test]
+    fn palette_success_clears_stale_error() {
+        let mut app = App::new(80, 24);
+        app.error = Some("boom".to_string());
+        app.open_command_palette();
+        // `:help` is arg-less (palette-runnable) and synchronous — it returns
+        // OkInfo, which must also clear the stale error.
+        for c in "help".chars() {
+            app.palette_input_char(c);
+        }
+        app.palette_submit();
+        assert!(
+            app.error.is_none(),
+            "a successful palette command clears a stale error"
+        );
+    }
+
+    #[test]
+    fn invalid_commands_do_not_enter_history() {
+        let mut app = App::new(80, 24);
+        // Unknown command.
+        app.enter_command_mode();
+        for c in "nope".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(
+            app.command_history.is_empty(),
+            "unknown command must not be saved to history"
+        );
+        // Wrong arity.
+        app.enter_command_mode();
+        for c in "quit extra".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(app.running, "wrong-arity :quit must not quit");
+        assert!(
+            app.command_history.is_empty(),
+            "wrong-arity command must not be saved to history"
+        );
+        // Parse error (unterminated quote).
+        app.enter_command_mode();
+        for c in "search \"foo".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert!(
+            app.command_history.is_empty(),
+            "unparseable command must not be saved to history"
+        );
+    }
+
+    #[test]
+    fn valid_command_still_enters_history() {
+        let mut app = App::new(80, 24);
+        app.enter_command_mode();
+        for c in "goto top".chars() {
+            app.command_input_char(c);
+        }
+        app.submit_command();
+        assert_eq!(app.command_history, vec!["goto top".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn open_story_by_id_marks_read() {
+        let mut app = App::new(80, 24);
+        let id = 12_345u64;
+        assert!(!app.read_store.is_read(StoryId(id)));
+        app.spawn_open_story_by_id(id);
+        assert!(
+            app.read_store.is_read(StoryId(id)),
+            ":open must record the visit so the story isn't perpetually unread"
+        );
+        assert!(
+            app.read_store.last_seen_at(StoryId(id)).is_some(),
+            ":open must set a `new`-comments anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_story_by_id_snapshots_pinned_resume() {
+        let mut app = App::new(80, 24);
+        // Pin story 1 and load it with a non-default reading position.
+        app.pin_store.pin_at(StoryId(1), 1_700_000_000);
+        app.comment_state.story = Some(Arc::new(item_with_id(1)));
+        app.comment_state.selected = 5;
+        // Opening a different story by id must snapshot story 1's position
+        // before reset() wipes comment_state.
+        app.spawn_open_story_by_id(2);
+        assert_eq!(
+            app.pin_store.resume_for(StoryId(1)).map(|e| e.selected),
+            Some(5),
+            ":open must snapshot the outgoing pinned story's reading position"
+        );
     }
 }

--- a/src/command/builtin.rs
+++ b/src/command/builtin.rs
@@ -1,0 +1,671 @@
+//! Seed registration of all built-in `:`-commands.
+//!
+//! Each `register_*` helper takes a `&mut CommandRegistry` and pushes one
+//! [`Command`]. The full set is registered in dependency-free order by
+//! [`register_builtins`] — called once from
+//! [`crate::command::CommandRegistry::with_builtins`] during
+//! [`crate::app::App::new`].
+//!
+//! The function-pointer signature constrains each closure to direct
+//! [`crate::app::App`] mutation (no captured state). For commands whose
+//! effect is already an existing [`crate::keys::Action`], the closure
+//! just calls [`crate::app::App::dispatch`]; for richer effects (`:yank`,
+//! `:open`, `:filter`) the closure inlines the logic or delegates to a
+//! dedicated `App` helper method.
+
+use crate::api::types::{FeedKind, StoryId};
+use crate::clipboard;
+use crate::command::{Arity, Command, CommandRegistry, CommandResult};
+use crate::keys::Action;
+use crate::sanitize::sanitize_terminal;
+use crate::state::comment_state::CommentFilter;
+use crate::state::hint_state::HintAction;
+
+/// Registers every built-in command into `r`. Idempotent only if `r`
+/// starts empty — re-running on a populated registry stacks duplicates.
+pub fn register_builtins(r: &mut CommandRegistry) {
+    register_quit(r);
+    register_refresh(r);
+    register_help(r);
+    register_feed(r);
+    register_open(r);
+    register_search(r);
+    register_reader(r);
+    register_pin(r);
+    register_filter(r);
+    register_yank(r);
+    register_goto(r);
+    register_hint(r);
+}
+
+fn register_quit(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "quit",
+        aliases: &["q"],
+        description: "Quit hnt",
+        arity: Arity::Exact(0),
+        arg_completions: &[],
+        run: |app, _args| {
+            app.dispatch(Action::Quit);
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_refresh(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "refresh",
+        aliases: &["r"],
+        description: "Reload the current feed (or rerun the current search)",
+        arity: Arity::Exact(0),
+        arg_completions: &[],
+        run: |app, _args| {
+            app.dispatch(Action::Refresh);
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_help(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "help",
+        aliases: &["h"],
+        description: "List available commands",
+        arity: Arity::Variadic,
+        arg_completions: &[],
+        run: |app, _args| {
+            let names: Vec<&str> = app.command_registry.all().iter().map(|c| c.name).collect();
+            CommandResult::OkInfo(format!("Commands: :{}", names.join("  :")))
+        },
+    });
+}
+
+fn register_feed(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "feed",
+        aliases: &[],
+        description: "Switch feed: top, new, best, ask, show, jobs, pinned",
+        arity: Arity::Exact(1),
+        arg_completions: &["top", "new", "best", "ask", "show", "jobs", "pinned"],
+        run: |app, args| {
+            let name = args[0].to_lowercase();
+            let idx = match feed_index(&name) {
+                Some(i) => i,
+                None => {
+                    return CommandResult::Err(format!(
+                        "Unknown feed: {name}. Try: top, new, best, ask, show, jobs, pinned"
+                    ))
+                }
+            };
+            app.dispatch(Action::SwitchFeed(idx));
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_open(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "open",
+        aliases: &[],
+        description: "Open a story by HN item ID (e.g. :open 12345)",
+        arity: Arity::Exact(1),
+        arg_completions: &[],
+        run: |app, args| {
+            let id: u64 = match args[0].parse() {
+                Ok(n) => n,
+                Err(_) => return CommandResult::Err(format!("Invalid story ID: {}", args[0])),
+            };
+            app.spawn_open_story_by_id(id);
+            CommandResult::OkInfo(format!("Loading story {id}…"))
+        },
+    });
+}
+
+fn register_search(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "search",
+        aliases: &[],
+        description: "Algolia search across all of HN (e.g. :search rust async)",
+        arity: Arity::AtLeast(1),
+        arg_completions: &[],
+        run: |app, args| {
+            let query = args.join(" ");
+            if query.trim().is_empty() {
+                return CommandResult::Err("Empty search query".to_string());
+            }
+            app.enter_search_mode();
+            if let Some(ss) = app.search_state.as_mut() {
+                ss.input = query;
+            }
+            app.submit_search();
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_reader(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "reader",
+        aliases: &[],
+        description: "Open the focused story in the inline article reader",
+        arity: Arity::Exact(0),
+        arg_completions: &[],
+        run: |app, _args| {
+            app.dispatch(Action::OpenReader);
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_pin(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "pin",
+        // `b` is the existing key binding, kept as an alias for muscle memory.
+        // `:unpin` reaches the same toggle; the user just speaks the intent
+        // they have, and the toggle figures it out.
+        aliases: &["unpin", "b"],
+        description: "Toggle the pinned state of the focused story",
+        arity: Arity::Exact(0),
+        arg_completions: &[],
+        run: |app, _args| {
+            app.dispatch(Action::TogglePin);
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_filter(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "filter",
+        aliases: &[],
+        description: "Set comment filter: all, new, 24h, author <user>",
+        arity: Arity::AtLeast(1),
+        arg_completions: &["all", "new", "24h", "author"],
+        run: |app, args| {
+            let mode = args[0].to_lowercase();
+            let Some(story) = app.comment_state.story.as_ref() else {
+                return CommandResult::Err(
+                    "No story loaded — open a story's comments first".to_string(),
+                );
+            };
+            let story_id = StoryId(story.id);
+            let new_filter = match mode.as_str() {
+                "all" => CommentFilter::All,
+                "new" => match app.read_store.last_seen_at(story_id) {
+                    Some(t) => CommentFilter::NewSince(t),
+                    None => {
+                        return CommandResult::Err(
+                            "This story hasn't been visited before — no `new` anchor".to_string(),
+                        )
+                    }
+                },
+                "24h" => {
+                    // Match cycle_comment_filter's 60s skew tolerance so
+                    // typed and cycled filters behave identically.
+                    let cutoff = chrono::Utc::now().timestamp() - 86_400 - 60;
+                    CommentFilter::Recent(cutoff)
+                }
+                "author" => {
+                    if args.len() < 2 {
+                        return CommandResult::Err(
+                            ":filter author requires a username (e.g. :filter author dang)"
+                                .to_string(),
+                        );
+                    }
+                    // HN usernames are case-sensitive — preserve `args[1]`
+                    // as typed. Trim so a trailing space doesn't silently
+                    // break the match.
+                    let username = args[1].trim();
+                    if username.is_empty() {
+                        // A quoted empty/whitespace arg (`:filter author ""`)
+                        // satisfies the count guard but would install an
+                        // Author("") that matches nothing and blanks the
+                        // thread with no feedback — reject it explicitly.
+                        return CommandResult::Err(
+                            ":filter author requires a non-empty username".to_string(),
+                        );
+                    }
+                    CommentFilter::Author(username.to_string())
+                }
+                other => {
+                    return CommandResult::Err(format!(
+                        "Unknown filter: {other}. Try: all, new, 24h, author <user>"
+                    ))
+                }
+            };
+            app.comment_state.filter = new_filter;
+            let visible = app.comment_state.visible_len();
+            if visible == 0 {
+                app.comment_state.selected = 0;
+            } else if app.comment_state.selected >= visible {
+                app.comment_state.selected = visible - 1;
+            }
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_yank(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "yank",
+        aliases: &["y"],
+        description: "Copy to clipboard via OSC 52: url, title, or both",
+        arity: Arity::Exact(1),
+        arg_completions: &["url", "title", "both"],
+        run: |app, args| {
+            let field = args[0].to_lowercase();
+            let Some(story) = app.focused_story() else {
+                return CommandResult::Err("No focused story".to_string());
+            };
+            let title = story.title.clone().unwrap_or_default();
+            let url = story
+                .url
+                .clone()
+                .unwrap_or_else(|| format!("https://news.ycombinator.com/item?id={}", story.id));
+            let text = match field.as_str() {
+                "url" => url,
+                "title" => title,
+                "both" => format!("{title}\n{url}"),
+                other => {
+                    return CommandResult::Err(format!(
+                        "Unknown field: {other}. Try: url, title, both"
+                    ))
+                }
+            };
+            match clipboard::copy(&text) {
+                Ok(()) => {
+                    // Sanitise the echoed text — story titles/URLs are
+                    // server-controlled and we surface them in the status bar.
+                    CommandResult::OkInfo(format!("Copied: {}", sanitize_terminal(&text)))
+                }
+                Err(e) => CommandResult::Err(format!("Clipboard write failed: {e}")),
+            }
+        },
+    });
+}
+
+fn register_goto(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "goto",
+        aliases: &["g"],
+        description: "Jump in the focused pane: top, bottom",
+        arity: Arity::Exact(1),
+        arg_completions: &["top", "bottom"],
+        run: |app, args| {
+            let target = args[0].to_lowercase();
+            let action = match target.as_str() {
+                "top" => Action::JumpTop,
+                "bottom" => Action::JumpBottom,
+                other => {
+                    return CommandResult::Err(format!(
+                        "Unknown goto target: {other}. Try: top, bottom"
+                    ))
+                }
+            };
+            app.dispatch(action);
+            CommandResult::Ok
+        },
+    });
+}
+
+fn register_hint(r: &mut CommandRegistry) {
+    r.register(Command {
+        name: "hint",
+        aliases: &[],
+        description: "Enter Quickjump hint mode: open, reader, yank",
+        arity: Arity::Exact(1),
+        arg_completions: &["open", "reader", "yank"],
+        run: |app, args| {
+            let mode = args[0].to_lowercase();
+            let hint = match mode.as_str() {
+                "open" => HintAction::Open,
+                "reader" => HintAction::OpenInReader,
+                "yank" => HintAction::CopyUrl,
+                other => {
+                    return CommandResult::Err(format!(
+                        "Unknown hint action: {other}. Try: open, reader, yank"
+                    ))
+                }
+            };
+            app.dispatch(Action::EnterHintMode(hint));
+            CommandResult::Ok
+        },
+    });
+}
+
+/// Maps a feed name (case-folded by caller) to its index in
+/// [`FeedKind::ALL`]. Returns `None` for unknown names.
+fn feed_index(name: &str) -> Option<usize> {
+    FeedKind::ALL
+        .iter()
+        .position(|f| f.to_string().eq_ignore_ascii_case(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+
+    fn run_cmd(app: &mut App, line: &str) {
+        let registry = CommandRegistry::with_builtins();
+        let (name, args) = crate::command::parser::parse(line).expect("parse");
+        let cmd = registry.lookup(&name).expect("command registered");
+        registry
+            .check_arity(cmd, &args)
+            .expect("arity ok in test setup");
+        (cmd.run)(app, &args);
+    }
+
+    #[test]
+    fn feed_index_recognises_every_feedkind() {
+        for (i, f) in FeedKind::ALL.iter().enumerate() {
+            let name = f.to_string().to_lowercase();
+            assert_eq!(feed_index(&name), Some(i), "{name} should map to {i}");
+        }
+    }
+
+    #[test]
+    fn feed_index_rejects_unknown() {
+        assert_eq!(feed_index("nope"), None);
+    }
+
+    #[test]
+    fn feed_arg_completions_are_all_valid_feeds() {
+        // Drift guard: every Tab-completion candidate for `:feed` must be a
+        // real feed (resolve via feed_index), and the count must match
+        // FeedKind::ALL so a new feed isn't silently left uncompletable.
+        let registry = CommandRegistry::with_builtins();
+        let feed = registry.lookup("feed").unwrap();
+        assert_eq!(
+            feed.arg_completions.len(),
+            FeedKind::ALL.len(),
+            "feed completion list out of sync with FeedKind::ALL"
+        );
+        for cand in feed.arg_completions {
+            assert!(feed_index(cand).is_some(), "{cand:?} is not a valid feed");
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_command_dispatches_action_refresh() {
+        // Refresh triggers reset_panes_and_reload which spawns an async
+        // fetch — needs a running tokio runtime, same as the existing
+        // `reset_panes_and_reload_*` tests.
+        let mut app = App::new(80, 24);
+        run_cmd(&mut app, "refresh");
+        assert!(app.running);
+        assert!(app.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn feed_command_switches_current_feed() {
+        let mut app = App::new(80, 24);
+        assert_eq!(app.current_feed, FeedKind::Top);
+        run_cmd(&mut app, "feed best");
+        assert_eq!(app.current_feed, FeedKind::Best);
+    }
+
+    #[tokio::test]
+    async fn feed_command_is_case_insensitive() {
+        let mut app = App::new(80, 24);
+        run_cmd(&mut app, "feed BEST");
+        assert_eq!(app.current_feed, FeedKind::Best);
+    }
+
+    #[test]
+    fn feed_command_unknown_name_errors() {
+        let mut app = App::new(80, 24);
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("feed").unwrap();
+        let result = (cmd.run)(&mut app, &["xyz".to_string()]);
+        assert!(matches!(result, CommandResult::Err(_)));
+        assert_eq!(
+            app.current_feed,
+            FeedKind::Top,
+            "feed must not change on err"
+        );
+    }
+
+    #[test]
+    fn open_command_rejects_non_numeric_id() {
+        let mut app = App::new(80, 24);
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("open").unwrap();
+        let result = (cmd.run)(&mut app, &["abc".to_string()]);
+        match result {
+            CommandResult::Err(msg) => assert!(msg.contains("Invalid")),
+            _ => panic!("expected Err for non-numeric ID"),
+        }
+    }
+
+    #[test]
+    fn reader_command_dispatches_open_reader() {
+        let mut app = App::new(80, 24);
+        // No focused story → OpenReader is a no-op but does not crash.
+        run_cmd(&mut app, "reader");
+        assert!(app.running);
+    }
+
+    #[test]
+    fn pin_command_aliases_resolve() {
+        let registry = CommandRegistry::with_builtins();
+        assert!(registry.lookup("pin").is_some());
+        assert!(registry.lookup("unpin").is_some());
+        assert!(registry.lookup("b").is_some());
+    }
+
+    #[test]
+    fn filter_command_errors_when_no_story_loaded() {
+        let mut app = App::new(80, 24);
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("filter").unwrap();
+        let result = (cmd.run)(&mut app, &["all".to_string()]);
+        assert!(matches!(result, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn filter_command_author_sets_author_filter() {
+        let mut app = App::new(80, 24);
+        use crate::api::types::Item;
+        use std::sync::Arc;
+        app.comment_state.story = Some(Arc::new(Item {
+            id: 1,
+            title: Some("t".into()),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }));
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("filter").unwrap();
+        let result = (cmd.run)(&mut app, &["author".to_string(), "dang".to_string()]);
+        assert!(matches!(result, CommandResult::Ok));
+        assert_eq!(
+            app.comment_state.filter,
+            CommentFilter::Author("dang".into())
+        );
+    }
+
+    #[test]
+    fn filter_command_author_without_username_errors() {
+        let mut app = App::new(80, 24);
+        use crate::api::types::Item;
+        use std::sync::Arc;
+        app.comment_state.story = Some(Arc::new(Item {
+            id: 1,
+            title: Some("t".into()),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }));
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("filter").unwrap();
+        let result = (cmd.run)(&mut app, &["author".to_string()]);
+        match result {
+            CommandResult::Err(msg) => assert!(msg.contains("username")),
+            _ => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn filter_command_author_rejects_empty_username() {
+        // A quoted empty / whitespace-only arg (`:filter author "  "`)
+        // satisfies the count guard but must still be rejected rather than
+        // installing an Author("") that silently blanks the thread.
+        let mut app = App::new(80, 24);
+        use crate::api::types::Item;
+        use std::sync::Arc;
+        app.comment_state.story = Some(Arc::new(Item {
+            id: 1,
+            title: Some("t".into()),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }));
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("filter").unwrap();
+        let result = (cmd.run)(&mut app, &["author".to_string(), "   ".to_string()]);
+        match result {
+            CommandResult::Err(msg) => assert!(msg.contains("non-empty"), "got {msg}"),
+            _ => panic!("expected Err for empty username"),
+        }
+        assert_eq!(
+            app.comment_state.filter,
+            CommentFilter::All,
+            "filter must be unchanged on rejection"
+        );
+    }
+
+    #[test]
+    fn filter_command_unknown_mode_errors() {
+        let mut app = App::new(80, 24);
+        // Force a story loaded so we reach the mode-parse branch.
+        use crate::api::types::Item;
+        use std::sync::Arc;
+        app.comment_state.story = Some(Arc::new(Item {
+            id: 1,
+            title: Some("t".into()),
+            url: None,
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }));
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("filter").unwrap();
+        let result = (cmd.run)(&mut app, &["xyz".to_string()]);
+        assert!(matches!(result, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn yank_command_errors_when_no_focused_story() {
+        let mut app = App::new(80, 24);
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("yank").unwrap();
+        let result = (cmd.run)(&mut app, &["url".to_string()]);
+        assert!(matches!(result, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn yank_command_rejects_unknown_field() {
+        let mut app = App::new(80, 24);
+        use crate::api::types::Item;
+        use std::sync::Arc;
+        app.story_state.stories.push(Arc::new(Item {
+            id: 1,
+            title: Some("t".into()),
+            url: Some("https://example.com".into()),
+            text: None,
+            by: None,
+            score: None,
+            time: None,
+            kids: None,
+            descendants: None,
+            item_type: None,
+            dead: None,
+            deleted: None,
+        }));
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("yank").unwrap();
+        let result = (cmd.run)(&mut app, &["sideways".to_string()]);
+        assert!(matches!(result, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn goto_command_top_bottom_recognised() {
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("goto").unwrap();
+        let mut app = App::new(80, 24);
+        let r = (cmd.run)(&mut app, &["top".to_string()]);
+        assert!(matches!(r, CommandResult::Ok));
+        let r = (cmd.run)(&mut app, &["bottom".to_string()]);
+        assert!(matches!(r, CommandResult::Ok));
+        let r = (cmd.run)(&mut app, &["sideways".to_string()]);
+        assert!(matches!(r, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn hint_command_recognises_all_three_actions() {
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("hint").unwrap();
+        let mut app = App::new(80, 24);
+        for action in ["open", "reader", "yank"] {
+            let r = (cmd.run)(&mut app, &[action.to_string()]);
+            assert!(matches!(r, CommandResult::Ok), "{action} should be Ok");
+        }
+        let r = (cmd.run)(&mut app, &["unknown".to_string()]);
+        assert!(matches!(r, CommandResult::Err(_)));
+    }
+
+    #[test]
+    fn help_command_returns_command_list() {
+        let mut app = App::new(80, 24);
+        let registry = CommandRegistry::with_builtins();
+        let cmd = registry.lookup("help").unwrap();
+        let result = (cmd.run)(&mut app, &[]);
+        match result {
+            CommandResult::OkInfo(msg) => {
+                assert!(msg.contains(":quit"));
+                assert!(msg.contains(":feed"));
+                assert!(msg.contains(":filter"));
+            }
+            _ => panic!("help must return OkInfo with command list"),
+        }
+    }
+
+    #[test]
+    fn all_seeded_commands_registered() {
+        let registry = CommandRegistry::with_builtins();
+        for name in [
+            "quit", "refresh", "help", "feed", "open", "search", "reader", "pin", "filter", "yank",
+            "goto", "hint",
+        ] {
+            assert!(registry.lookup(name).is_some(), "{name} missing");
+        }
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,0 +1,336 @@
+//! Vim-style `:`-command registry.
+//!
+//! Each [`Command`] is a name + aliases + arity contract + closure that
+//! mutates [`crate::app::App`] directly. The [`CommandRegistry`] stores
+//! the built-in set seeded by [`builtin::register_builtins`] and is
+//! consulted by [`crate::app::App::submit_command`] and the
+//! command-palette overlay.
+//!
+//! The function-pointer signature on [`Command::run`] deliberately avoids
+//! capturing any closure state — every command's effect must be expressible
+//! as direct calls on [`crate::app::App`]. This keeps the registry
+//! `'static` and trivially `Send + Sync` without `Box<dyn Fn>` per
+//! command.
+
+use crate::app::App;
+
+pub mod builtin;
+pub mod parser;
+
+/// Signature every `:command` effect implements — a bare `fn` pointer (no
+/// captured state) so the registry stays `'static + Send + Sync`. Named so
+/// call sites and [`CommandRegistry::resolve`] can pass it around without
+/// repeating the (clippy-flagged) complex type.
+pub type CommandFn = fn(&mut App, &[String]) -> CommandResult;
+
+/// Per-command argument-count contract — enforced by
+/// [`CommandRegistry::check_arity`] before [`Command::run`] is invoked so
+/// each command's closure can index args without bounds checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arity {
+    /// Exactly this many positional arguments required.
+    Exact(usize),
+    /// At least this many arguments; trailing args are the command's
+    /// responsibility to join (e.g. `:search` joins them back into one query).
+    AtLeast(usize),
+    /// Any number of arguments, including zero.
+    Variadic,
+}
+
+/// Outcome of running a command — drives status-bar feedback in
+/// [`crate::app::App::submit_command`].
+#[non_exhaustive]
+pub enum CommandResult {
+    /// Command succeeded with no message — keep the status bar as-is.
+    Ok,
+    /// Command succeeded with a transient info toast (rendered via
+    /// [`crate::app::App::set_info`]).
+    OkInfo(String),
+    /// Command failed — the message is surfaced as a red status-bar error
+    /// via [`crate::app::App::error`].
+    Err(String),
+}
+
+/// A registered `:command` callable from the prompt or palette.
+///
+/// Stored by value in [`CommandRegistry::commands`]; all fields are
+/// `'static` so the registry as a whole is `'static + Send + Sync`.
+pub struct Command {
+    /// Canonical name typed after `:` (no leading colon).
+    pub name: &'static str,
+    /// Alternate names that resolve to the same command via
+    /// [`CommandRegistry::lookup`].
+    pub aliases: &'static [&'static str],
+    /// One-line description shown in `?`-help and the command palette.
+    pub description: &'static str,
+    /// Arity contract enforced before [`Self::run`] is invoked.
+    pub arity: Arity,
+    /// Static completion candidates for the **first** positional argument
+    /// (e.g. `feed` → `top, new, …`). Empty means no arg completion —
+    /// either the command takes no args or the arg is freeform (an ID, a
+    /// search query, a username). Consumed by
+    /// [`crate::app::App::complete_command_at_cursor`].
+    pub arg_completions: &'static [&'static str],
+    /// Effect closure — receives the [`App`] and parsed args by reference.
+    pub run: CommandFn,
+}
+
+/// In-process registry of all `:`-commands. Built once in
+/// [`crate::app::App::new`] via [`Self::with_builtins`].
+#[derive(Default)]
+pub struct CommandRegistry {
+    commands: Vec<Command>,
+}
+
+impl CommandRegistry {
+    /// Builds a registry seeded with every built-in command via
+    /// [`builtin::register_builtins`].
+    pub fn with_builtins() -> Self {
+        let mut r = Self::default();
+        builtin::register_builtins(&mut r);
+        r
+    }
+
+    /// Appends a command. Last-write-wins on name conflicts is
+    /// intentional — caller is responsible for not registering duplicates.
+    pub fn register(&mut self, cmd: Command) {
+        self.commands.push(cmd);
+    }
+
+    /// Resolves a typed name (or alias) to a registered command. `None`
+    /// if no match.
+    pub fn lookup(&self, name: &str) -> Option<&Command> {
+        self.commands
+            .iter()
+            .find(|c| c.name == name || c.aliases.contains(&name))
+    }
+
+    /// All registered commands, in registration order.
+    pub fn all(&self) -> &[Command] {
+        &self.commands
+    }
+
+    /// Validates `args.len()` against the registered [`Arity`].
+    /// Returns `Ok(())` if the count is acceptable, `Err(msg)` otherwise.
+    pub fn check_arity(&self, cmd: &Command, args: &[String]) -> Result<(), String> {
+        match cmd.arity {
+            Arity::Exact(n) if args.len() != n => Err(format!(
+                ":{} expects {n} arg(s), got {}",
+                cmd.name,
+                args.len()
+            )),
+            Arity::AtLeast(n) if args.len() < n => Err(format!(
+                ":{} expects at least {n} arg(s), got {}",
+                cmd.name,
+                args.len()
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    /// Resolves a typed name (or alias) to its [`CommandFn`], validating
+    /// arity in one step. Returns the fn pointer on success, or a
+    /// user-facing error message (unknown command / arity mismatch).
+    ///
+    /// Lets callers run the command with `&mut App` without holding a
+    /// `&Command` borrow across the call — folding the lookup + arity
+    /// check + borrow dance that otherwise repeats at every entry point.
+    pub fn resolve(&self, name: &str, args: &[String]) -> Result<CommandFn, String> {
+        let cmd = self
+            .lookup(name)
+            .ok_or_else(|| format!("Unknown command: {name}"))?;
+        self.check_arity(cmd, args)?;
+        Ok(cmd.run)
+    }
+
+    /// Subsequence-fuzzy match against `query`. Returns `(index, score)`
+    /// pairs into [`Self::all`], sorted by descending score: longer matches
+    /// and earlier matches score higher, with a prefix bonus.
+    ///
+    /// Returns indices rather than `&Command` so callers (the palette) don't
+    /// have to recover the index via a pointer-identity scan. Empty `query`
+    /// returns every command with a score of zero (stable registration
+    /// order) — the right behaviour for "opened palette with no input yet."
+    pub fn fuzzy(&self, query: &str) -> Vec<(usize, i64)> {
+        if query.is_empty() {
+            return (0..self.commands.len()).map(|i| (i, 0)).collect();
+        }
+        let q = query.to_lowercase();
+        let mut out: Vec<(usize, i64)> = self
+            .commands
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| score_subseq(&q, c.name).map(|s| (i, s)))
+            .collect();
+        out.sort_by(|a, b| b.1.cmp(&a.1));
+        out
+    }
+}
+
+/// Returns `Some(score)` if every char of `q` appears in `target` in
+/// order (subsequence match), else `None`.
+///
+/// Scoring rewards consecutive matches and prefix matches so `re` ranks
+/// `refresh` above `reader` above any subsequence-only match like
+/// `[unrelated]`. `q` must already be lowercased by the caller; `target`
+/// is matched case-insensitively via [`char::eq_ignore_ascii_case`], so
+/// command names need no per-call lowercasing allocation.
+fn score_subseq(q: &str, target: &str) -> Option<i64> {
+    let mut q_chars = q.chars();
+    let mut current = q_chars.next()?;
+    let mut score: i64 = 0;
+    let mut consec: i64 = 0;
+    let mut matched_at_start = false;
+    for (i, c) in target.chars().enumerate() {
+        if c.eq_ignore_ascii_case(&current) {
+            if i == 0 {
+                matched_at_start = true;
+            }
+            score += 10 + consec * 5;
+            consec += 1;
+            match q_chars.next() {
+                Some(next) => current = next,
+                None => {
+                    if matched_at_start {
+                        score += 50;
+                    }
+                    return Some(score);
+                }
+            }
+        } else {
+            consec = 0;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy(name: &'static str, aliases: &'static [&'static str], arity: Arity) -> Command {
+        Command {
+            name,
+            aliases,
+            description: "",
+            arity,
+            arg_completions: &[],
+            run: |_app, _args| CommandResult::Ok,
+        }
+    }
+
+    #[test]
+    fn lookup_resolves_name_and_aliases() {
+        let mut r = CommandRegistry::default();
+        r.register(dummy("quit", &["q"], Arity::Exact(0)));
+        assert_eq!(r.lookup("quit").map(|c| c.name), Some("quit"));
+        assert_eq!(r.lookup("q").map(|c| c.name), Some("quit"));
+        assert!(r.lookup("nope").is_none());
+    }
+
+    #[test]
+    fn fuzzy_finds_subsequence_matches() {
+        let mut r = CommandRegistry::default();
+        r.register(dummy("refresh", &[], Arity::Exact(0)));
+        r.register(dummy("reader", &[], Arity::Exact(0)));
+        r.register(dummy("filter", &[], Arity::AtLeast(1)));
+        let names: Vec<_> = r
+            .fuzzy("re")
+            .into_iter()
+            .map(|(i, _)| r.all()[i].name)
+            .collect();
+        assert!(names.contains(&"refresh"), "re ⊏ refresh");
+        assert!(names.contains(&"reader"), "re ⊏ reader");
+        // 'r' is at position 5 of "filter" with no 'e' after it → not a subsequence.
+        assert!(!names.contains(&"filter"), "re is NOT a subseq of filter");
+    }
+
+    #[test]
+    fn fuzzy_prefix_match_outranks_late_match() {
+        let mut r = CommandRegistry::default();
+        r.register(dummy("refresh", &[], Arity::Exact(0)));
+        r.register(dummy("preferred", &[], Arity::Exact(0))); // 're' appears at index 2
+        let ranked: Vec<_> = r
+            .fuzzy("re")
+            .into_iter()
+            .map(|(i, _)| r.all()[i].name)
+            .collect();
+        assert_eq!(ranked.first().copied(), Some("refresh"));
+    }
+
+    #[test]
+    fn fuzzy_empty_query_returns_all() {
+        let mut r = CommandRegistry::default();
+        r.register(dummy("a", &[], Arity::Exact(0)));
+        r.register(dummy("b", &[], Arity::Exact(0)));
+        assert_eq!(r.fuzzy("").len(), 2);
+    }
+
+    #[test]
+    fn fuzzy_is_case_insensitive() {
+        let mut r = CommandRegistry::default();
+        r.register(dummy("refresh", &[], Arity::Exact(0)));
+        assert_eq!(r.fuzzy("RE").len(), 1);
+        assert_eq!(r.fuzzy("Re").len(), 1);
+    }
+
+    #[test]
+    fn check_arity_exact_rejects_wrong_count() {
+        let r = CommandRegistry::default();
+        let cmd = dummy("x", &[], Arity::Exact(1));
+        assert!(r.check_arity(&cmd, &[]).is_err());
+        assert!(r
+            .check_arity(&cmd, &["a".to_string(), "b".to_string()])
+            .is_err());
+        assert!(r.check_arity(&cmd, &["a".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn check_arity_at_least_accepts_more() {
+        let r = CommandRegistry::default();
+        let cmd = dummy("x", &[], Arity::AtLeast(1));
+        assert!(r.check_arity(&cmd, &[]).is_err());
+        assert!(r.check_arity(&cmd, &["a".to_string()]).is_ok());
+        assert!(r
+            .check_arity(&cmd, &["a".to_string(), "b".to_string()])
+            .is_ok());
+    }
+
+    #[test]
+    fn check_arity_variadic_accepts_any_count() {
+        let r = CommandRegistry::default();
+        let cmd = dummy("x", &[], Arity::Variadic);
+        assert!(r.check_arity(&cmd, &[]).is_ok());
+        assert!(r
+            .check_arity(&cmd, &["a".to_string(), "b".to_string()])
+            .is_ok());
+    }
+
+    #[test]
+    fn builtins_register_quit() {
+        let r = CommandRegistry::with_builtins();
+        assert!(r.lookup("quit").is_some(), "quit must be registered");
+        assert!(r.lookup("q").is_some(), "q alias must resolve");
+    }
+
+    #[test]
+    fn resolve_returns_fn_for_name_and_alias() {
+        let r = CommandRegistry::with_builtins();
+        assert!(r.resolve("quit", &[]).is_ok());
+        assert!(r.resolve("q", &[]).is_ok(), "alias must resolve");
+    }
+
+    #[test]
+    fn resolve_unknown_command_errors() {
+        let r = CommandRegistry::with_builtins();
+        let err = r.resolve("nope", &[]).unwrap_err();
+        assert!(err.contains("Unknown command"), "got {err}");
+    }
+
+    #[test]
+    fn resolve_wrong_arity_errors() {
+        let r = CommandRegistry::with_builtins();
+        let err = r.resolve("quit", &["extra".to_string()]).unwrap_err();
+        assert!(err.contains("expects"), "got {err}");
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -162,7 +162,7 @@ impl CommandRegistry {
             .enumerate()
             .filter_map(|(i, c)| score_subseq(&q, c.name).map(|s| (i, s)))
             .collect();
-        out.sort_by(|a, b| b.1.cmp(&a.1));
+        out.sort_by_key(|b| std::cmp::Reverse(b.1));
         out
     }
 }

--- a/src/command/parser.rs
+++ b/src/command/parser.rs
@@ -1,0 +1,182 @@
+//! Tokeniser for the `:`-command line.
+//!
+//! Splits a typed line (sans leading `:`) into a command name and zero or
+//! more whitespace-separated arguments. Double-quoted spans allow embedded
+//! whitespace; backslash escapes a quote or backslash inside them.
+//! No glob expansion, no variable substitution — this is a deliberately
+//! minimal lexer.
+
+/// Parses a typed command line (without the leading `:`) into a
+/// command name and a list of positional arguments.
+///
+/// # Errors
+///
+/// - [`ParseError::Empty`] — empty or whitespace-only input.
+/// - [`ParseError::UnterminatedQuote`] — opening `"` with no matching close.
+pub fn parse(line: &str) -> Result<(String, Vec<String>), ParseError> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Err(ParseError::Empty);
+    }
+
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+    // Tracks whether the current token has started — distinct from
+    // `current.is_empty()` so an empty quoted span `""` still pushes one
+    // (deliberately empty) arg.
+    let mut token_started = false;
+
+    for c in trimmed.chars() {
+        if escape {
+            current.push(c);
+            escape = false;
+            token_started = true;
+            continue;
+        }
+        if c == '\\' && in_quotes {
+            escape = true;
+            continue;
+        }
+        if c == '"' {
+            in_quotes = !in_quotes;
+            token_started = true;
+            continue;
+        }
+        if c.is_whitespace() && !in_quotes {
+            if token_started {
+                tokens.push(std::mem::take(&mut current));
+                token_started = false;
+            }
+            continue;
+        }
+        current.push(c);
+        token_started = true;
+    }
+
+    if in_quotes {
+        return Err(ParseError::UnterminatedQuote);
+    }
+    if token_started {
+        tokens.push(current);
+    }
+    if tokens.is_empty() {
+        return Err(ParseError::Empty);
+    }
+    let name = tokens.remove(0);
+    Ok((name, tokens))
+}
+
+/// Failure modes for [`parse`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseError {
+    /// Line was empty or only whitespace.
+    Empty,
+    /// Line had an opening `"` with no matching close.
+    UnterminatedQuote,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("empty command"),
+            Self::UnterminatedQuote => f.write_str("unterminated quote"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_ok(line: &str) -> (String, Vec<String>) {
+        parse(line).expect("expected parse to succeed")
+    }
+
+    #[test]
+    fn parses_command_with_no_args() {
+        assert_eq!(parse_ok("quit"), ("quit".to_string(), vec![]));
+    }
+
+    #[test]
+    fn parses_command_with_one_arg() {
+        let (cmd, args) = parse_ok("feed top");
+        assert_eq!(cmd, "feed");
+        assert_eq!(args, vec!["top".to_string()]);
+    }
+
+    #[test]
+    fn parses_multiple_args() {
+        let (cmd, args) = parse_ok("filter author dang");
+        assert_eq!(cmd, "filter");
+        assert_eq!(args, vec!["author".to_string(), "dang".to_string()]);
+    }
+
+    #[test]
+    fn parses_quoted_arg_with_spaces() {
+        let (cmd, args) = parse_ok(r#"search "hello world""#);
+        assert_eq!(cmd, "search");
+        assert_eq!(args, vec!["hello world".to_string()]);
+    }
+
+    #[test]
+    fn parses_escaped_quote_inside_quoted_span() {
+        let (cmd, args) = parse_ok(r#"x "a\"b""#);
+        assert_eq!(cmd, "x");
+        assert_eq!(args, vec![r#"a"b"#.to_string()]);
+    }
+
+    #[test]
+    fn parses_escaped_backslash_inside_quoted_span() {
+        let (cmd, args) = parse_ok(r#"x "a\\b""#);
+        assert_eq!(cmd, "x");
+        assert_eq!(args, vec![r"a\b".to_string()]);
+    }
+
+    #[test]
+    fn trims_leading_and_trailing_whitespace() {
+        assert_eq!(
+            parse_ok("  feed   top  "),
+            ("feed".into(), vec!["top".into()])
+        );
+    }
+
+    #[test]
+    fn collapses_internal_whitespace_between_tokens() {
+        assert_eq!(
+            parse_ok("a\t\tb   c"),
+            ("a".into(), vec!["b".into(), "c".into()])
+        );
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert_eq!(parse(""), Err(ParseError::Empty));
+        assert_eq!(parse("   "), Err(ParseError::Empty));
+        assert_eq!(parse("\t\n  "), Err(ParseError::Empty));
+    }
+
+    #[test]
+    fn rejects_unterminated_quote() {
+        assert_eq!(parse(r#"search "foo"#), Err(ParseError::UnterminatedQuote));
+    }
+
+    #[test]
+    fn empty_quoted_span_yields_empty_arg() {
+        let (cmd, args) = parse_ok(r#"x """#);
+        assert_eq!(cmd, "x");
+        assert_eq!(args, vec!["".to_string()]);
+    }
+
+    #[test]
+    fn display_messages_are_meaningful() {
+        assert_eq!(ParseError::Empty.to_string(), "empty command");
+        assert_eq!(
+            ParseError::UnterminatedQuote.to_string(),
+            "unterminated quote"
+        );
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -25,6 +25,20 @@ pub enum InputMode {
     /// Active during Quickjump label selection — `main.rs` routes raw
     /// chars to [`Action::HintKey`] and Esc to [`Action::ExitHintMode`].
     HintMode,
+    /// Active while the user is typing a `:command`. `main.rs` routes
+    /// raw chars to `App::command_input_char`, Enter to
+    /// `App::submit_command`, Esc to `App::cancel_command`, Tab to
+    /// `App::complete_command_at_cursor`, and Up/Down to
+    /// `App::command_history_prev` / `App::command_history_next`.
+    /// Entered via [`Action::EnterCommandMode`] (the `:` key in normal
+    /// mode); mirrors the [`Self::SearchInput`] dispatch pattern.
+    CommandInput,
+    /// Active while the command palette overlay is open (`Ctrl+P`).
+    /// `main.rs` routes raw chars into `App::palette_input_char`,
+    /// Backspace into `App::palette_input_backspace`, Up/Down into
+    /// `App::palette_move_up` / `App::palette_move_down`, Enter into
+    /// `App::palette_submit`, and Esc into `App::cancel_palette`.
+    PaletteInput,
 }
 
 /// A keybinding-independent operation the app may perform.
@@ -98,6 +112,14 @@ pub enum Action {
     /// pane back to stories → quit. The comments-pane back path also
     /// snapshots any pinned-resume state and bumps `story_gen`.
     Back,
+    /// Enter [`InputMode::CommandInput`] — emitted when the user
+    /// presses `:` in normal mode. The actual mode flip and prompt
+    /// initialisation live in `App::enter_command_mode`; this variant
+    /// is the dispatch trigger.
+    EnterCommandMode,
+    /// Open the command-palette overlay — fuzzy-searchable popup of
+    /// every registered `:`-command. Emitted by `Ctrl+P` in normal mode.
+    OpenCommandPalette,
 }
 
 /// Translates a [`KeyEvent`] into an [`Action`] for the current UI
@@ -116,8 +138,16 @@ pub fn map_key(
     prior_visible: bool,
     input_mode: InputMode,
 ) -> Option<Action> {
-    // SearchInput and HintMode both consume raw chars in main.rs.
-    if matches!(input_mode, InputMode::SearchInput | InputMode::HintMode) {
+    // SearchInput, HintMode, CommandInput, and PaletteInput all consume
+    // raw chars in main.rs — return None so the typed character reaches
+    // the input buffer instead of being remapped.
+    if matches!(
+        input_mode,
+        InputMode::SearchInput
+            | InputMode::HintMode
+            | InputMode::CommandInput
+            | InputMode::PaletteInput
+    ) {
         return None;
     }
 
@@ -171,6 +201,12 @@ pub fn map_key(
         KeyCode::Char('k') | KeyCode::Up => Some(Action::MoveUp),
         KeyCode::Enter => Some(Action::Select),
         KeyCode::Char('o') => Some(Action::OpenInBrowser),
+        // Ctrl+P is the palette — guarded arm must come BEFORE the plain
+        // `'p'` arm so the guarded match takes precedence over the bare
+        // OpenReader binding.
+        KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(Action::OpenCommandPalette)
+        }
         KeyCode::Char('p') => Some(Action::OpenReader),
         KeyCode::Char('h') => Some(Action::TogglePriorDiscussions),
         KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => {
@@ -188,6 +224,7 @@ pub fn map_key(
         }
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageUp),
         KeyCode::Char('/') => Some(Action::EnterSearch),
+        KeyCode::Char(':') => Some(Action::EnterCommandMode),
         KeyCode::Char('?') => Some(Action::ToggleHelp),
         // Quickjump entry — comments-pane variant. Reader-overlay variant
         // is handled in the reader_visible block above.
@@ -607,5 +644,72 @@ mod tests {
         assert_eq!(s('f'), None);
         assert_eq!(s('F'), None);
         assert_eq!(s('y'), None);
+    }
+
+    // --- Command mode ---
+
+    #[test]
+    fn normal_colon_enters_command_mode() {
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char(':')), Some(Action::EnterCommandMode));
+    }
+
+    #[test]
+    fn normal_ctrl_p_opens_palette() {
+        assert_eq!(
+            map_key(ctrl('p'), false, false, false, InputMode::Normal),
+            Some(Action::OpenCommandPalette)
+        );
+    }
+
+    #[test]
+    fn normal_p_without_modifier_still_opens_reader() {
+        // The reader is bound to plain `p`; the palette uses `Ctrl+P`.
+        // Confirm the modifier disambiguates correctly.
+        let n = |code| map_key(key(code), false, false, false, InputMode::Normal);
+        assert_eq!(n(KeyCode::Char('p')), Some(Action::OpenReader));
+    }
+
+    #[test]
+    fn command_input_returns_none_for_all_keys() {
+        // CommandInput must consume raw chars in main.rs — every key
+        // returns None just like SearchInput.
+        let c = |code| map_key(key(code), false, false, false, InputMode::CommandInput);
+        assert_eq!(c(KeyCode::Char('q')), None);
+        assert_eq!(c(KeyCode::Char(':')), None);
+        assert_eq!(c(KeyCode::Char('j')), None);
+        assert_eq!(c(KeyCode::Enter), None);
+        assert_eq!(c(KeyCode::Esc), None);
+    }
+
+    #[test]
+    fn command_input_ignores_help_and_overlay_state() {
+        // Same dominance rule as SearchInput — even with overlays open,
+        // CommandInput consumes the key into the input buffer.
+        assert_eq!(
+            map_key(
+                key(KeyCode::Char('q')),
+                true,
+                true,
+                true,
+                InputMode::CommandInput
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn reader_overlay_does_not_consume_colon() {
+        // Reader overlay has its own reduced keymap — `:` should be
+        // ignored there (not silently treated as EnterCommandMode), so the
+        // user can't accidentally drop into command mode while reading.
+        let r = |code| map_key(key(code), false, true, false, InputMode::Normal);
+        assert_eq!(r(KeyCode::Char(':')), None);
+    }
+
+    #[test]
+    fn prior_overlay_does_not_consume_colon() {
+        let p = |code| map_key(key(code), false, false, true, InputMode::Normal);
+        assert_eq!(p(KeyCode::Char(':')), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod api;
 mod app;
 mod article;
 mod clipboard;
+mod command;
 mod event;
 mod keys;
 mod sanitize;
@@ -90,6 +91,51 @@ async fn main() -> Result<()> {
                         app.dispatch(Action::ExitHintMode);
                     }
                     KeyCode::Char(c) => app.dispatch(Action::HintKey(c)),
+                    _ => {}
+                },
+                InputMode::CommandInput => match key.code {
+                    KeyCode::Enter => app.submit_command(),
+                    KeyCode::Esc => app.cancel_command(),
+                    KeyCode::Backspace => app.command_input_backspace(),
+                    KeyCode::Tab => app.complete_command_at_cursor(),
+                    KeyCode::Up => app.command_history_prev(),
+                    KeyCode::Down => app.command_history_next(),
+                    KeyCode::Left => app.command_cursor_left(),
+                    KeyCode::Right => app.command_cursor_right(),
+                    KeyCode::Home => app.command_cursor_home(),
+                    KeyCode::End => app.command_cursor_end(),
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        app.cancel_command();
+                    }
+                    // Only insert unmodified (or shift-modified) characters —
+                    // a Ctrl/Alt chord (Ctrl+U, Ctrl+W, …) must not type its
+                    // literal letter into the buffer.
+                    KeyCode::Char(c)
+                        if !key.modifiers.contains(KeyModifiers::CONTROL)
+                            && !key.modifiers.contains(KeyModifiers::ALT) =>
+                    {
+                        app.command_input_char(c)
+                    }
+                    _ => {}
+                },
+                InputMode::PaletteInput => match key.code {
+                    KeyCode::Enter => app.palette_submit(),
+                    KeyCode::Esc => app.cancel_palette(),
+                    KeyCode::Backspace => app.palette_input_backspace(),
+                    KeyCode::Up => app.palette_move_up(),
+                    KeyCode::Down => app.palette_move_down(),
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        app.cancel_palette();
+                    }
+                    // Only feed unmodified (or shift-modified) characters into
+                    // the query — pressing Ctrl+P again (or any Ctrl/Alt chord)
+                    // must not type its literal letter.
+                    KeyCode::Char(c)
+                        if !key.modifiers.contains(KeyModifiers::CONTROL)
+                            && !key.modifiers.contains(KeyModifiers::ALT) =>
+                    {
+                        app.palette_input_char(c)
+                    }
                     _ => {}
                 },
                 InputMode::Normal => {

--- a/src/state/command_history_store.rs
+++ b/src/state/command_history_store.rs
@@ -1,0 +1,154 @@
+//! Persisted command history for the `:`-command prompt.
+//!
+//! Sibling to [`crate::state::read_store`] and
+//! [`crate::state::pin_store`]: same atomic-rename-0600 write discipline
+//! (via [`crate::state::persist::write_atomic`]), same XDG path
+//! resolution. Differs only in shape — command history is an ordered
+//! flat `Vec<String>` rather than a `HashMap<StoryId, _>`, so it lives
+//! outside [`crate::state::persist::JsonStore`].
+//!
+//! On save, entries are tail-truncated to [`MAX_ENTRIES`] so a runaway
+//! power-user session can't grow the file unboundedly.
+//!
+//! Failures on load and save are silently swallowed — command history
+//! is a convenience, not a correctness boundary.
+
+use crate::state::persist::{write_json_atomic, xdg_data_path};
+
+/// Maximum retained history entries. Matches the user-visible scrollback
+/// affordance most shells expose by default; deeper recall isn't useful
+/// for a TUI command palette.
+pub const MAX_ENTRIES: usize = 100;
+
+const FILE: &str = "commands.json";
+
+/// Loads persisted command history. Empty `Vec` on missing/corrupt file
+/// or when no XDG path could be resolved. Thin wrapper over [`load_from`]
+/// that resolves the XDG path.
+pub fn load() -> Vec<String> {
+    match xdg_data_path(FILE) {
+        Some(path) => load_from(&path),
+        None => Vec::new(),
+    }
+}
+
+/// Writes `entries` to the XDG history file. No-op when the path can't be
+/// resolved (e.g. headless containers with no `HOME`). Thin wrapper over
+/// [`save_to`] that resolves the XDG path.
+pub fn save(entries: &[String]) {
+    if let Some(path) = xdg_data_path(FILE) {
+        save_to(entries, &path);
+    }
+}
+
+/// Writes `entries` to an explicit path via the shared
+/// [`write_json_atomic`] discipline (0700 dir, 0600 tmp + rename). Trims to
+/// the most recent [`MAX_ENTRIES`] entries — older ones dropped. This is the
+/// single write core; [`save`] just resolves the XDG path and delegates here
+/// (tests pass an explicit temp path).
+pub fn save_to(entries: &[String], path: &std::path::Path) {
+    let tail: &[String] = if entries.len() > MAX_ENTRIES {
+        &entries[entries.len() - MAX_ENTRIES..]
+    } else {
+        entries
+    };
+    let Ok(json) = serde_json::to_string(tail) else {
+        return;
+    };
+    let _ = write_json_atomic(path, &json);
+}
+
+/// Reads command history from an explicit path. Empty `Vec` on
+/// missing/corrupt file. The single read core; [`load`] resolves the XDG
+/// path and delegates here (tests pass an explicit temp path).
+pub fn load_from(path: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "hnt_cmdhist_test_{}_{}.json",
+            name,
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn roundtrip_through_disk() {
+        let p = tmp("roundtrip");
+        let _ = std::fs::remove_file(&p);
+        save_to(
+            &[
+                "quit".to_string(),
+                "feed best".to_string(),
+                "filter author dang".to_string(),
+            ],
+            &p,
+        );
+        let loaded = load_from(&p);
+        assert_eq!(
+            loaded,
+            vec![
+                "quit".to_string(),
+                "feed best".to_string(),
+                "filter author dang".to_string()
+            ]
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn corrupt_file_loads_as_empty() {
+        let p = tmp("corrupt");
+        std::fs::write(&p, "{not valid json").unwrap();
+        assert!(load_from(&p).is_empty());
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn save_trims_to_max_entries() {
+        let p = tmp("trim");
+        let _ = std::fs::remove_file(&p);
+        let many: Vec<String> = (0..MAX_ENTRIES + 50).map(|i| format!("cmd-{i}")).collect();
+        save_to(&many, &p);
+        let loaded = load_from(&p);
+        assert_eq!(loaded.len(), MAX_ENTRIES);
+        assert_eq!(loaded.first().map(String::as_str), Some("cmd-50"));
+        assert_eq!(
+            loaded.last().map(String::as_str),
+            Some(format!("cmd-{}", MAX_ENTRIES + 49)).as_deref()
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn missing_file_loads_as_empty() {
+        let p = tmp("missing");
+        let _ = std::fs::remove_file(&p);
+        assert!(load_from(&p).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_creates_file_with_user_only_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let p = tmp("perms");
+        let _ = std::fs::remove_file(&p);
+        save_to(&["secret".to_string()], &p);
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "saved file mode should be 0o600, got {:o}",
+            mode
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/src/state/command_state.rs
+++ b/src/state/command_state.rs
@@ -1,0 +1,341 @@
+//! Command-line (`:`) UI state and the command palette overlay state.
+//!
+//! [`CommandState`] mirrors [`crate::state::search_state::SearchState`]:
+//! a single struct holding the in-progress typed line plus
+//! history-navigation bookkeeping. The persisted history list lives on
+//! [`crate::app::App`] directly so
+//! [`crate::state::command_history_store`] can round-trip it
+//! independently of whether the user is currently in command mode.
+//!
+//! [`PaletteState`] is the fuzzy-searchable popup variant — opened via
+//! `Ctrl+P`, it holds the query, the filtered-and-ranked indices into
+//! [`crate::command::CommandRegistry`], and the selected row.
+
+/// State for an active `:command` prompt.
+///
+/// `input` is the line typed so far; `cursor` is the byte offset of
+/// the insertion point (always at a UTF-8 char boundary —
+/// [`Self::set_input`] enforces this). `history_idx` is `Some(i)`
+/// while the user is walking through prior commands via `Up`/`Down`;
+/// `pre_history` snapshots the in-progress line so cancelling history
+/// navigation restores it verbatim.
+#[derive(Debug, Default, Clone)]
+pub struct CommandState {
+    /// Current typed line (without the leading `:`).
+    pub input: String,
+    /// Byte offset of the insertion point in [`Self::input`]. Always at
+    /// a char boundary.
+    pub cursor: usize,
+    /// Index into the persisted history list (newest=last) while the
+    /// user is walking through prior commands; `None` when typing fresh.
+    pub history_idx: Option<usize>,
+    /// In-progress line saved when entering history navigation so the
+    /// user can return to it without losing what they had typed.
+    pub pre_history: String,
+}
+
+impl CommandState {
+    /// Fresh empty state — used when [`crate::app::App::enter_command_mode`]
+    /// installs the prompt.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the line and pin the cursor to the end. Used by history
+    /// navigation and tab-completion.
+    pub fn set_input(&mut self, s: String) {
+        self.cursor = s.len();
+        self.input = s;
+    }
+
+    /// Append `c` at the cursor and advance.
+    pub fn insert_char(&mut self, c: char) {
+        let mut buf = [0u8; 4];
+        let s = c.encode_utf8(&mut buf);
+        self.input.insert_str(self.cursor, s);
+        self.cursor += s.len();
+        // Typing exits history-navigation mode — anything past this is
+        // the user's own edit, not a recalled command.
+        self.history_idx = None;
+    }
+
+    /// Remove the char before the cursor. No-op if cursor is at 0.
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        // Walk back to the previous char boundary.
+        let mut new_cursor = self.cursor - 1;
+        while new_cursor > 0 && !self.input.is_char_boundary(new_cursor) {
+            new_cursor -= 1;
+        }
+        self.input.replace_range(new_cursor..self.cursor, "");
+        self.cursor = new_cursor;
+        self.history_idx = None;
+    }
+
+    /// Moves the cursor one char left, stopping at column 0. UTF-8 aware.
+    pub fn move_left(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let mut c = self.cursor - 1;
+        while c > 0 && !self.input.is_char_boundary(c) {
+            c -= 1;
+        }
+        self.cursor = c;
+    }
+
+    /// Moves the cursor one char right, stopping at the end. UTF-8 aware.
+    pub fn move_right(&mut self) {
+        if self.cursor >= self.input.len() {
+            return;
+        }
+        let mut c = self.cursor + 1;
+        while c < self.input.len() && !self.input.is_char_boundary(c) {
+            c += 1;
+        }
+        self.cursor = c;
+    }
+
+    /// Moves the cursor to the start of the line.
+    pub fn move_home(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Moves the cursor to the end of the line.
+    pub fn move_end(&mut self) {
+        self.cursor = self.input.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_char_advances_cursor() {
+        let mut s = CommandState::new();
+        s.insert_char('q');
+        s.insert_char('u');
+        assert_eq!(s.input, "qu");
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn backspace_removes_previous_char() {
+        let mut s = CommandState::new();
+        s.set_input("quit".to_string());
+        s.backspace();
+        assert_eq!(s.input, "qui");
+        assert_eq!(s.cursor, 3);
+    }
+
+    #[test]
+    fn backspace_at_zero_is_noop() {
+        let mut s = CommandState::new();
+        s.backspace();
+        assert_eq!(s.input, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn backspace_respects_utf8_boundaries() {
+        let mut s = CommandState::new();
+        s.insert_char('é'); // 2 bytes
+        s.insert_char('a');
+        assert_eq!(s.cursor, 3);
+        s.backspace();
+        assert_eq!(s.input, "é");
+        assert_eq!(s.cursor, 2);
+        s.backspace();
+        assert_eq!(s.input, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn typing_after_recall_clears_history_index() {
+        let mut s = CommandState::new();
+        s.history_idx = Some(3);
+        s.insert_char('x');
+        assert_eq!(s.history_idx, None);
+    }
+
+    #[test]
+    fn set_input_pins_cursor_to_end() {
+        let mut s = CommandState::new();
+        s.set_input("filter author dang".to_string());
+        assert_eq!(s.cursor, 18);
+    }
+
+    #[test]
+    fn move_left_right_walk_one_char() {
+        let mut s = CommandState::new();
+        s.set_input("feed".to_string());
+        assert_eq!(s.cursor, 4);
+        s.move_left();
+        assert_eq!(s.cursor, 3);
+        s.move_left();
+        s.move_left();
+        s.move_left();
+        s.move_left(); // saturates at 0
+        assert_eq!(s.cursor, 0);
+        s.move_right();
+        assert_eq!(s.cursor, 1);
+    }
+
+    #[test]
+    fn move_right_saturates_at_end() {
+        let mut s = CommandState::new();
+        s.set_input("hi".to_string());
+        s.move_home();
+        assert_eq!(s.cursor, 0);
+        s.move_right();
+        s.move_right();
+        s.move_right(); // past end → clamps
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn move_left_right_respect_utf8_boundaries() {
+        let mut s = CommandState::new();
+        s.set_input("éb".to_string()); // 'é' is 2 bytes, cursor at 3
+        assert_eq!(s.cursor, 3);
+        s.move_left(); // onto 'b' boundary at byte 2
+        assert_eq!(s.cursor, 2);
+        s.move_left(); // skip over the 2-byte 'é' to byte 0
+        assert_eq!(s.cursor, 0);
+        s.move_right(); // forward across 'é' to byte 2
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn insert_at_cursor_after_move_left() {
+        // The cursor must drive insertion, not just sit at the end.
+        let mut s = CommandState::new();
+        s.set_input("fed".to_string());
+        s.move_left(); // between 'e' and 'd'
+        s.insert_char('e');
+        assert_eq!(s.input, "feed");
+        assert_eq!(s.cursor, 3);
+    }
+
+    #[test]
+    fn home_and_end_jump_to_extremes() {
+        let mut s = CommandState::new();
+        s.set_input("filter".to_string());
+        s.move_home();
+        assert_eq!(s.cursor, 0);
+        s.move_end();
+        assert_eq!(s.cursor, 6);
+    }
+}
+
+/// State for the command-palette overlay (`Ctrl+P`).
+///
+/// `query` is the in-progress filter string; `matches` is the
+/// registry-index list emitted by
+/// [`crate::command::CommandRegistry::fuzzy`], rebuilt on every keystroke
+/// via [`crate::app::App::recompute_palette_matches`]; `selected` is the
+/// row within `matches` the user is about to run.
+#[derive(Debug, Default, Clone)]
+pub struct PaletteState {
+    /// Typed query — filters the matches list.
+    pub query: String,
+    /// Indices into the [`crate::command::CommandRegistry`] command list
+    /// that pass the current fuzzy filter, sorted by descending score.
+    pub matches: Vec<usize>,
+    /// Selected position within `matches`. Reset to 0 by
+    /// [`crate::app::App::recompute_palette_matches`] on every query change,
+    /// so it always indexes the current top match.
+    pub selected: usize,
+    /// Whether the user has typed a query or moved the selection since the
+    /// palette opened. A bare Enter on an *untouched* palette must not run
+    /// the pre-highlighted row-0 command (see
+    /// [`crate::app::App::palette_submit`]).
+    pub interacted: bool,
+}
+
+impl PaletteState {
+    /// Empty palette — no query, no matches, no selection. Populated by
+    /// [`crate::app::App::open_command_palette`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the currently-selected match's registry index, if any.
+    pub fn selected_index(&self) -> Option<usize> {
+        self.matches.get(self.selected).copied()
+    }
+
+    /// Moves the selection cursor down one row, saturating at the last
+    /// match.
+    pub fn move_down(&mut self) {
+        self.interacted = true;
+        if self.matches.is_empty() {
+            return;
+        }
+        if self.selected + 1 < self.matches.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Moves the selection cursor up one row, saturating at 0.
+    pub fn move_up(&mut self) {
+        self.interacted = true;
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Appends `c` to the query string.
+    pub fn push_query(&mut self, c: char) {
+        self.interacted = true;
+        self.query.push(c);
+    }
+
+    /// Removes the last char of the query string.
+    pub fn pop_query(&mut self) {
+        self.interacted = true;
+        self.query.pop();
+    }
+}
+
+#[cfg(test)]
+mod palette_tests {
+    use super::*;
+
+    #[test]
+    fn empty_palette_has_no_selection() {
+        let p = PaletteState::new();
+        assert!(p.selected_index().is_none());
+    }
+
+    #[test]
+    fn move_down_saturates_at_end() {
+        let mut p = PaletteState::new();
+        p.matches = vec![0, 1, 2];
+        p.move_down();
+        p.move_down();
+        p.move_down();
+        p.move_down();
+        assert_eq!(p.selected, 2, "selection must clamp at len-1");
+    }
+
+    #[test]
+    fn move_up_saturates_at_zero() {
+        let mut p = PaletteState::new();
+        p.matches = vec![0, 1, 2];
+        p.selected = 1;
+        p.move_up();
+        p.move_up();
+        p.move_up();
+        assert_eq!(p.selected, 0);
+    }
+
+    #[test]
+    fn move_on_empty_list_is_noop() {
+        let mut p = PaletteState::new();
+        p.move_down();
+        p.move_up();
+        assert_eq!(p.selected, 0);
+    }
+}

--- a/src/state/comment_state.rs
+++ b/src/state/comment_state.rs
@@ -28,8 +28,14 @@ type FilterCache = Option<((CommentFilter, usize), Option<Rc<HashSet<usize>>>)>;
 /// former from `read_store.last_seen_at(story_id)`, the latter from a
 /// rolling clock window — but their semantics are identical: keep every
 /// comment whose `time > t`, plus every ancestor of such a comment so the
-/// thread reads coherently.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// thread reads coherently. [`Self::Author`] applies the same
+/// ancestor-keep rule against a username predicate — useful for
+/// finding a specific commenter's contributions to a thread without
+/// losing the reply context they were responding to.
+///
+/// Not `Copy` — [`Self::Author`] owns a `String`. Sites that previously
+/// moved the filter by value now [`Clone`] it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum CommentFilter {
     /// No filter — every comment in the loaded tree is visible (modulo
     /// collapse). Default state and reset target on `set_comments`.
@@ -42,6 +48,28 @@ pub enum CommentFilter {
     /// Show comments newer than `now - 24h - 60s skew` (Unix seconds).
     /// Same ancestor-keep rule as [`Self::NewSince`].
     Recent(i64),
+    /// Show comments whose author (HN `by` field) matches the stored
+    /// username exactly (case-sensitive — HN usernames are
+    /// case-sensitive). Same ancestor-keep rule as [`Self::NewSince`]
+    /// so each match is readable in its reply context.
+    Author(String),
+}
+
+impl CommentFilter {
+    /// Does this comment pass the current filter? `All` always passes;
+    /// the timestamped variants check the comment's Unix time against
+    /// the threshold; [`Self::Author`] checks the `by` field for an
+    /// exact match. Ancestor-keep is handled separately by
+    /// [`CommentTreeState::compute_filter_visible_set`].
+    pub fn passes(&self, comment: &FlatComment) -> bool {
+        match self {
+            CommentFilter::All => true,
+            CommentFilter::NewSince(t) | CommentFilter::Recent(t) => {
+                comment.item.time.is_some_and(|ts| ts > *t)
+            }
+            CommentFilter::Author(name) => comment.item.by.as_deref() == Some(name.as_str()),
+        }
+    }
 }
 
 /// One comment in the flattened, depth-tagged comment tree.
@@ -248,7 +276,9 @@ impl CommentTreeState {
     /// (the only allocation, ~O(1)) so the comments pane render path
     /// doesn't pay O(n) per frame when the filter sits unchanged.
     fn filter_visible_set(&self) -> Option<Rc<HashSet<usize>>> {
-        let key = (self.filter, self.comments.len());
+        // Clone the filter into the cache key — `CommentFilter` is no
+        // longer `Copy` because [`CommentFilter::Author`] owns a `String`.
+        let key = (self.filter.clone(), self.comments.len());
         {
             let cache = self.filter_cache.borrow();
             if let Some((cached_key, cached_set)) = cache.as_ref() {
@@ -266,12 +296,13 @@ impl CommentTreeState {
     /// caller). Returns `None` for [`CommentFilter::All`] so the cache layer
     /// can short-circuit, otherwise walks the pre-order tree maintaining a
     /// path-stack of ancestor indices and unions every passing comment's
-    /// path into `keep`.
+    /// path into `keep`. The per-comment predicate lives on
+    /// [`CommentFilter::passes`] so adding a new variant changes one
+    /// site rather than every walker.
     fn compute_filter_visible_set(&self) -> Option<HashSet<usize>> {
-        let threshold = match self.filter {
-            CommentFilter::All => return None,
-            CommentFilter::NewSince(t) | CommentFilter::Recent(t) => t,
-        };
+        if matches!(self.filter, CommentFilter::All) {
+            return None;
+        }
         let mut keep: HashSet<usize> = HashSet::new();
         let mut path: Vec<usize> = Vec::with_capacity(16);
         for (i, c) in self.comments.iter().enumerate() {
@@ -283,7 +314,7 @@ impl CommentTreeState {
             {
                 path.pop();
             }
-            if c.item.time.is_some_and(|t| t > threshold) {
+            if self.filter.passes(c) {
                 for &p in &path {
                     keep.insert(p);
                 }
@@ -992,5 +1023,96 @@ mod tests {
         state.set_comments(vec![]);
         // No comments → no counts to verify, just no panic.
         assert!(state.comments.is_empty());
+    }
+
+    // --- Author filter ---
+
+    fn cwd_by(id: u64, depth: usize, by: &str) -> CommentWithDepth {
+        let mut item = make_item(id);
+        item.by = Some(by.to_string());
+        CommentWithDepth { item, depth }
+    }
+
+    #[test]
+    fn author_filter_matches_exactly() {
+        let dang = cwd_by(1, 0, "dang");
+        let other = cwd_by(2, 0, "patio11");
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![dang, other]);
+        state.filter = CommentFilter::Author("dang".into());
+        let visible = state.visible_indices();
+        assert_eq!(visible, vec![0], "only dang's comment is visible");
+    }
+
+    #[test]
+    fn author_filter_keeps_ancestors_of_matches() {
+        // Tree:
+        //   root(1, by=alice) depth 0
+        //     child(2, by=bob) depth 1
+        //       grand(3, by=dang) depth 2   ← match
+        //   sibling(4, by=carol) depth 0
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![
+            cwd_by(1, 0, "alice"),
+            cwd_by(2, 1, "bob"),
+            cwd_by(3, 2, "dang"),
+            cwd_by(4, 0, "carol"),
+        ]);
+        state.filter = CommentFilter::Author("dang".into());
+        let visible = state.visible_indices();
+        // alice + bob are ancestors of dang's reply, so they stay; carol
+        // is a sibling root with no dang descendant, so she's filtered.
+        assert_eq!(visible, vec![0, 1, 2], "ancestors of match are kept");
+    }
+
+    #[test]
+    fn author_filter_is_case_sensitive() {
+        // HN usernames are case-sensitive — `Dang` != `dang`.
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![cwd_by(1, 0, "dang")]);
+        state.filter = CommentFilter::Author("Dang".into());
+        assert!(state.visible_indices().is_empty());
+    }
+
+    #[test]
+    fn author_filter_no_match_yields_empty_visible() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![cwd_by(1, 0, "alice"), cwd_by(2, 0, "bob")]);
+        state.filter = CommentFilter::Author("dang".into());
+        assert!(state.visible_indices().is_empty());
+    }
+
+    #[test]
+    fn author_filter_cache_invalidates_when_username_changes() {
+        let mut state = CommentTreeState::new();
+        state.set_comments(vec![cwd_by(1, 0, "alice"), cwd_by(2, 0, "bob")]);
+        state.filter = CommentFilter::Author("alice".into());
+        let first = state.filter_visible_set().expect("set");
+        state.filter = CommentFilter::Author("bob".into());
+        let second = state.filter_visible_set().expect("set");
+        assert!(
+            !Rc::ptr_eq(&first, &second),
+            "username change must invalidate cache"
+        );
+        assert!(second.contains(&1), "bob is now the match");
+        assert!(!second.contains(&0));
+    }
+
+    #[test]
+    fn comment_filter_passes_method_matches_predicate() {
+        // Direct test of the CommentFilter::passes API — the predicate
+        // that compute_filter_visible_set delegates to.
+        let comment = FlatComment::new(make_item(1), 0);
+        assert!(CommentFilter::All.passes(&comment));
+
+        // Author filter on a comment with no `by` field → no match.
+        assert!(!CommentFilter::Author("dang".into()).passes(&comment));
+
+        // With `by` populated, exact match passes.
+        let mut item = make_item(2);
+        item.by = Some("dang".into());
+        let dang_comment = FlatComment::new(item, 0);
+        assert!(CommentFilter::Author("dang".into()).passes(&dang_comment));
+        assert!(!CommentFilter::Author("other".into()).passes(&dang_comment));
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,6 +11,8 @@
 //! resume-position snapshots, and [`link_registry::LinkRegistry`] +
 //! [`hint_state::HintState`] for the Quickjump label-hint mode.
 
+pub mod command_history_store;
+pub mod command_state;
 pub mod comment_state;
 pub mod hint_state;
 pub mod link_registry;

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -116,30 +116,8 @@ impl<E: PersistedEntry> JsonStore<E> {
         let Ok(json) = serde_json::to_string(&disk) else {
             return;
         };
-
-        // Best-effort dir creation. On Unix tighten to 0700 so per-user
-        // history isn't world-readable on shared hosts.
-        if let Some(parent) = path.parent() {
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::DirBuilderExt;
-                let _ = std::fs::DirBuilder::new()
-                    .recursive(true)
-                    .mode(0o700)
-                    .create(parent);
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = std::fs::create_dir_all(parent);
-            }
-        }
-
-        let tmp = path.with_extension("json.tmp");
-        if write_atomic(&tmp, &json).is_ok() && std::fs::rename(&tmp, path).is_ok() {
+        if write_json_atomic(path, &json).is_ok() {
             self.dirty = false;
-        } else {
-            // Clean up a stranded tmp on failure so we don't leak files.
-            let _ = std::fs::remove_file(&tmp);
         }
     }
 
@@ -159,10 +137,49 @@ impl<E: PersistedEntry> JsonStore<E> {
     }
 }
 
+/// Atomically persists `json` to `path`: best-effort creates the parent
+/// directory (mode 0700 on Unix), writes to a sibling `.json.tmp` via
+/// [`write_atomic`] (mode 0600), then renames it over `path`. A stranded
+/// tmp file is removed on any failure so we don't leak it. Returns the
+/// rename/​write error on failure (callers swallow it — both stores are
+/// non-critical).
+///
+/// Shared by [`JsonStore::save`] and sibling stores such as
+/// [`crate::state::command_history_store`] so the dir-create +
+/// tmp/rename/cleanup discipline lives in exactly one place.
+pub(crate) fn write_json_atomic(path: &std::path::Path, json: &str) -> std::io::Result<()> {
+    // Best-effort dir creation. On Unix tighten to 0700 so per-user history
+    // isn't world-readable on shared hosts.
+    if let Some(parent) = path.parent() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            let _ = std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(parent);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::create_dir_all(parent);
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    match write_atomic(&tmp, json).and_then(|()| std::fs::rename(&tmp, path)) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Clean up a stranded tmp on failure so we don't leak files.
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
 /// Writes `json` to `path` with mode 0600 on Unix (so other users on a
 /// shared host can't read pinned/read history). Existing files are
-/// truncated.
-fn write_atomic(path: &std::path::Path, json: &str) -> std::io::Result<()> {
+/// truncated. Most callers want the higher-level [`write_json_atomic`],
+/// which adds parent-dir creation and the tmp+rename discipline on top.
+pub(crate) fn write_atomic(path: &std::path::Path, json: &str) -> std::io::Result<()> {
     use std::io::Write;
     #[cfg(unix)]
     {

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -1,0 +1,271 @@
+//! Command-palette overlay rendering.
+//!
+//! [`render_command_palette`] draws a centred popup listing every
+//! command in [`crate::command::CommandRegistry`] (filtered by the typed
+//! query, ranked by [`crate::command::CommandRegistry::fuzzy`]). Follows
+//! the same visual pattern as [`crate::ui::prior_overlay`] for
+//! consistency: `Clear` over a centred [`Rect`], `Block` with title
+//! chrome, dim footer hint line.
+//!
+//! Every dynamic string (the query echo, command names, descriptions)
+//! is sanitised at the render boundary via
+//! [`crate::sanitize::sanitize_terminal`]. Command metadata is
+//! `'static` today — but the palette also echoes the user's query, and
+//! future paste / `:source` paths could surface server bytes; the
+//! defence-in-depth pass keeps the boundary uniform.
+
+use crate::command::CommandRegistry;
+use crate::sanitize::sanitize_terminal;
+use crate::state::command_state::PaletteState;
+use crate::ui::theme;
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+/// Renders the command palette overlay.
+///
+/// The overlay occupies up to 70% of the area's width and ~60% of its
+/// height, centred. Layout from top to bottom:
+/// - 1-row title bar ("Command Palette · N matches")
+/// - 1-row query echo with block cursor
+/// - n-row match list, selected row highlighted
+/// - 1-row footer hint
+///
+/// Renders nothing when the available area is too small to be usable.
+pub fn render_command_palette(
+    frame: &mut Frame,
+    area: Rect,
+    palette: &PaletteState,
+    registry: &CommandRegistry,
+) {
+    // Early-return for terminals too small to fit the minimum palette
+    // (40 col × 8 row) with a 2-col / 2-row margin — clamping below
+    // would otherwise underflow when the area is smaller than the
+    // declared minimum.
+    if area.width < 44 || area.height < 12 {
+        return;
+    }
+    // Centred rect, capped at 70%x60% with absolute floors so a tall
+    // narrow terminal still gets a usable popup.
+    let max_w = (area.width as u32 * 70 / 100) as u16;
+    let max_h = (area.height as u32 * 60 / 100) as u16;
+    let width = max_w.max(40).min(area.width.saturating_sub(4));
+    let height = max_h.max(8).min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let overlay = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, overlay);
+
+    let title = format!(
+        " Command Palette · {} match{} ",
+        palette.matches.len(),
+        if palette.matches.len() == 1 { "" } else { "es" }
+    );
+    let footer = Line::from(Span::styled(
+        " ↑/↓:nav  Enter:run  Esc:close ",
+        theme::dim_style(),
+    ))
+    .centered();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent_style())
+        .title(Span::styled(title, theme::title_style()))
+        .title_bottom(footer)
+        .style(theme::base_style());
+
+    let inner = block.inner(overlay);
+    frame.render_widget(block, overlay);
+
+    if inner.height < 3 || inner.width < 10 {
+        return;
+    }
+
+    // Row 0: query echo with block cursor. Sanitised because future
+    // paste / `:source` paths could surface server bytes through this
+    // widget; today the typed chars come straight from the user but the
+    // boundary is kept uniform with `status_bar`'s CommandInput branch.
+    let query_area = Rect::new(inner.x, inner.y, inner.width, 1);
+    let safe_query = sanitize_terminal(&palette.query);
+    let query_line = Line::from(vec![
+        Span::styled("❯ ", theme::accent_style()),
+        Span::styled(format!("{}\u{2588}", safe_query), theme::base_style()),
+    ]);
+    frame.render_widget(Paragraph::new(query_line), query_area);
+
+    // Row 1: separator.
+    let sep_area = Rect::new(inner.x, inner.y + 1, inner.width, 1);
+    let sep = "─".repeat(inner.width as usize);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(sep, theme::dim_style()))),
+        sep_area,
+    );
+
+    // Remaining rows: match list.
+    let list_area = Rect::new(
+        inner.x,
+        inner.y + 2,
+        inner.width,
+        inner.height.saturating_sub(2),
+    );
+    if list_area.height == 0 {
+        return;
+    }
+
+    // Compute the visible window — keep the selected row in view via a
+    // simple top-bias scroll. The list itself is short (≤ ~15 commands)
+    // so a smarter scroll isn't needed yet.
+    let visible_rows = list_area.height as usize;
+    let scroll = palette
+        .selected
+        .saturating_sub(visible_rows.saturating_sub(1));
+
+    let commands = registry.all();
+    let items: Vec<ListItem> = palette
+        .matches
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(visible_rows)
+        .map(|(i, &cmd_idx)| {
+            let cmd = &commands[cmd_idx];
+            let is_selected = i == palette.selected;
+            let name = sanitize_terminal(cmd.name);
+            let desc = sanitize_terminal(cmd.description);
+            let style = if is_selected {
+                theme::accent_style().add_modifier(Modifier::BOLD)
+            } else {
+                theme::base_style()
+            };
+            let prefix = if is_selected { "▌ " } else { "  " };
+            let line = Line::from(vec![
+                Span::styled(prefix, style),
+                Span::styled(format!(":{name}"), style),
+                Span::raw("  "),
+                Span::styled(desc, dim_or_active(is_selected)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    if items.is_empty() {
+        // Empty-state placeholder
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "  No commands match this query.",
+            theme::dim_style(),
+        )));
+        frame.render_widget(empty, list_area);
+    } else {
+        frame.render_widget(List::new(items), list_area);
+    }
+}
+
+fn dim_or_active(selected: bool) -> Style {
+    if selected {
+        theme::accent_style()
+    } else {
+        theme::dim_style()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render(palette: &PaletteState, registry: &CommandRegistry, w: u16, h: u16) -> String {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| {
+                render_command_palette(f, f.area(), palette, registry);
+            })
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn palette_renders_with_no_query_lists_all_commands() {
+        let registry = CommandRegistry::with_builtins();
+        let mut p = PaletteState::new();
+        p.matches = (0..registry.all().len()).collect();
+        let text = render(&p, &registry, 80, 24);
+        assert!(text.contains("Command Palette"));
+        assert!(text.contains(":quit"));
+        assert!(text.contains(":feed"));
+        assert!(text.contains(":filter"));
+    }
+
+    #[test]
+    fn palette_highlights_selected_row() {
+        let registry = CommandRegistry::with_builtins();
+        let mut p = PaletteState::new();
+        p.matches = (0..registry.all().len()).collect();
+        p.selected = 2;
+        let text = render(&p, &registry, 80, 24);
+        // The selected row has the ▌ marker before its name.
+        assert!(text.contains("\u{258c}"));
+    }
+
+    #[test]
+    fn palette_empty_matches_shows_placeholder() {
+        let registry = CommandRegistry::with_builtins();
+        let p = PaletteState::new();
+        let text = render(&p, &registry, 80, 24);
+        assert!(text.contains("No commands match"));
+    }
+
+    #[test]
+    fn palette_renders_match_count_in_title() {
+        let registry = CommandRegistry::with_builtins();
+        let mut p = PaletteState::new();
+        p.matches = vec![0];
+        let text = render(&p, &registry, 80, 24);
+        assert!(text.contains("1 match "), "singular: {text:?}");
+        p.matches = vec![0, 1, 2];
+        let text = render(&p, &registry, 80, 24);
+        assert!(text.contains("3 matches"), "plural: {text:?}");
+    }
+
+    #[test]
+    fn palette_sanitises_query_echo() {
+        // Defence in depth: even though `query` is normally typed by the
+        // user today, a future paste / `:source` path could surface
+        // server bytes through this widget. The boundary must stay
+        // uniform with the status_bar's CommandInput branch.
+        let registry = CommandRegistry::with_builtins();
+        let mut p = PaletteState::new();
+        p.query = "feed\x1b]0;OWNED\x07top".to_string();
+        p.matches = vec![0];
+        let text = render(&p, &registry, 80, 24);
+        assert!(!text.contains('\x1b'), "ESC must not survive: {text:?}");
+        assert!(!text.contains('\x07'), "BEL must not survive: {text:?}");
+    }
+
+    #[test]
+    fn palette_skips_render_when_area_too_small() {
+        let registry = CommandRegistry::with_builtins();
+        let mut p = PaletteState::new();
+        p.matches = vec![0];
+        // 20x4 is below the 40x8 minimum.
+        let text = render(&p, &registry, 20, 4);
+        assert!(
+            !text.contains("Command Palette"),
+            "tiny area should suppress overlay: {text:?}"
+        );
+    }
+}

--- a/src/ui/comment_tree.rs
+++ b/src/ui/comment_tree.rs
@@ -106,7 +106,7 @@ impl<'a> Widget for CommentTree<'a> {
                 theme::dim_style(),
             ));
         }
-        match self.state.filter {
+        match &self.state.filter {
             CommentFilter::All => {}
             CommentFilter::NewSince(_) => title_spans.push(Span::styled(
                 "· New since last visit (n) ",
@@ -114,6 +114,16 @@ impl<'a> Widget for CommentTree<'a> {
             )),
             CommentFilter::Recent(_) => {
                 title_spans.push(Span::styled("· Recent 24h (n) ", theme::accent_style()));
+            }
+            CommentFilter::Author(name) => {
+                // Scrub the username — it's user-supplied via `:filter author`
+                // and reaches ratatui here, so strip C0/C1/OSC bytes like
+                // every other dynamic string at this render boundary.
+                let safe_name = crate::sanitize::sanitize_terminal(name);
+                title_spans.push(Span::styled(
+                    format!("· Author: {safe_name} (n) "),
+                    theme::accent_style(),
+                ));
             }
         }
 
@@ -638,5 +648,48 @@ mod tests {
         let story = make_story(None, None);
         let label = build_block_title_label(&story);
         assert!(label.contains("[no title]"));
+    }
+
+    // --- Author-filter title chip ---
+
+    #[test]
+    fn author_filter_title_sanitises_username() {
+        // `:filter author <name>` interpolates a user-supplied username into
+        // the pane title; it must be scrubbed like every other dynamic
+        // string at this render boundary.
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut state = CommentTreeState::new();
+        state.filter = CommentFilter::Author("dang\x1b]0;OWNED\x07".to_string());
+        let visible = state.visible_indices();
+        let backend = TestBackend::new(80, 10);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                f.render_widget(
+                    CommentTree {
+                        state: &mut state,
+                        visible: &visible,
+                        focused: true,
+                        tick: 0,
+                        prior_count: 0,
+                        now_secs: 0,
+                    },
+                    area,
+                );
+            })
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(!text.contains('\x1b'), "ESC must not survive: {text:?}");
+        assert!(!text.contains('\x07'), "BEL must not survive: {text:?}");
+        assert!(text.contains("Author:"), "author chip present: {text:?}");
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@
 //! shared [`theme`] palette.
 
 pub mod article_reader;
+pub mod command_palette;
 pub mod comment_tree;
 pub mod header;
 pub mod layout;
@@ -133,6 +134,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             input_mode: app.input_mode,
             search_input: app.search_state.as_ref().map(|ss| ss.input.as_str()),
             search_query: if search_active { search_query } else { None },
+            command_input: app.command_state.as_ref().map(|cs| cs.input.as_str()),
+            command_cursor: app.command_state.as_ref().map(|cs| cs.cursor),
         },
         layout.status,
     );
@@ -154,6 +157,14 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         if let Some(ref prior_state) = app.prior_state {
             prior_overlay::render_prior_overlay(frame, area, prior_state);
         }
+    }
+
+    // Command palette overlay — rendered last so it sits on top of every
+    // other widget. The user explicitly opened it with Ctrl+P; any other
+    // overlay underneath stays visible at the edges so the context is
+    // preserved while typing.
+    if let Some(ref palette) = app.palette_state {
+        command_palette::render_command_palette(frame, area, palette, &app.command_registry);
     }
 }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -10,6 +10,7 @@ use crate::ui::theme;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
+    style::Modifier,
     text::{Line, Span},
     widgets::Widget,
 };
@@ -49,6 +50,18 @@ pub struct StatusBar<'a> {
     /// Committed search query — rendered as the `Search: "<q>"` chip
     /// while results are shown.
     pub search_query: Option<&'a str>,
+    /// In-progress `:command` input — rendered with a `:` chip and block
+    /// cursor when `input_mode == CommandInput`. Sanitised at the render
+    /// boundary the same way `error` and `info` are, even though the
+    /// content originates from the user — defence in depth, since a
+    /// future paste path or `:source <file>` could surface server-bytes
+    /// through this widget.
+    pub command_input: Option<&'a str>,
+    /// Byte offset of the command-input cursor within [`Self::command_input`]
+    /// (always at a char boundary). Drives where the block cursor is drawn
+    /// so Left/Right/Home/End line editing is visible. `None` (or out of
+    /// range) falls back to end-of-line.
+    pub command_cursor: Option<usize>,
 }
 
 impl<'a> Widget for StatusBar<'a> {
@@ -63,18 +76,75 @@ impl<'a> Widget for StatusBar<'a> {
         if self.input_mode == InputMode::SearchInput {
             // Search input mode
             let input = self.search_input.unwrap_or("");
+            // Sanitise the echoed buffer — same defence-in-depth as the
+            // CommandInput branch; a pasted query could carry C0/C1 bytes.
+            let safe_input = sanitize_terminal(input);
             spans.push(Span::styled(
                 " / ",
                 theme::accent_style().bg(theme::SURFACE),
             ));
             spans.push(Span::styled(
-                format!("{}\u{2588}", input),
+                format!("{}\u{2588}", safe_input),
                 theme::status_style(),
             ));
             spans.push(Span::styled(
                 " (Enter:search  Esc:cancel)",
                 theme::dim_style(),
             ));
+        } else if self.input_mode == InputMode::CommandInput {
+            // `:`-command input mode
+            let input = self.command_input.unwrap_or("");
+            spans.push(Span::styled(
+                " : ",
+                theme::accent_style().bg(theme::SURFACE),
+            ));
+            // Draw the block cursor at its actual byte offset so Left/Right/
+            // Home/End editing is visible: split at the cursor, reverse-video
+            // the char under it (or a trailing full block at end-of-line).
+            // Each piece is sanitised independently — splitting on a char
+            // boundary keeps that safe.
+            let cursor = self.command_cursor.unwrap_or(input.len()).min(input.len());
+            let cursor = if input.is_char_boundary(cursor) {
+                cursor
+            } else {
+                input.len()
+            };
+            let (before, after) = input.split_at(cursor);
+            spans.push(Span::styled(
+                sanitize_terminal(before).into_owned(),
+                theme::status_style(),
+            ));
+            let mut after_chars = after.chars();
+            match after_chars.next() {
+                Some(ch) => {
+                    spans.push(Span::styled(
+                        sanitize_terminal(&ch.to_string()).into_owned(),
+                        theme::status_style().add_modifier(Modifier::REVERSED),
+                    ));
+                    let rest: String = after_chars.collect();
+                    spans.push(Span::styled(
+                        sanitize_terminal(&rest).into_owned(),
+                        theme::status_style(),
+                    ));
+                }
+                None => spans.push(Span::styled("\u{2588}", theme::status_style())),
+            }
+            // Tab-completion surfaces its candidate list via an info toast
+            // (`Matches: :refresh  :reader`). Show it here when present —
+            // otherwise this branch swallowed it and the feature was
+            // invisible. Falls back to the key hint once the toast expires.
+            if let Some(info) = self.info {
+                let safe_info = sanitize_terminal(info);
+                spans.push(Span::styled(
+                    format!("  {} ", safe_info),
+                    theme::accent_style().bg(theme::SURFACE),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    " (Enter:run  Tab:complete  ↑/↓:history  Esc:cancel)",
+                    theme::dim_style(),
+                ));
+            }
         } else if let Some(query) = self.search_query {
             // Search results mode
             spans.push(Span::styled(
@@ -181,6 +251,8 @@ mod tests {
             input_mode: InputMode::Normal,
             search_input: None,
             search_query: None,
+            command_input: None,
+            command_cursor: None,
         }
         .render(area, &mut buf);
         buf
@@ -237,12 +309,141 @@ mod tests {
             search_input: None,
             // Force the search-results error branch.
             search_query: Some("rust"),
+            command_input: None,
+            command_cursor: None,
         }
         .render(area, &mut buf);
         let text = buffer_text(&buf);
         assert!(!text.contains('\x1b'));
         assert!(text.contains("hit"));
         assert!(text.contains("clear"));
+    }
+
+    fn render_command_bar(input: &str) -> Buffer {
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        StatusBar {
+            feed: FeedKind::Top,
+            position: "1/1",
+            error: None,
+            info: None,
+            focus_pane: "Stories",
+            input_mode: InputMode::CommandInput,
+            search_input: None,
+            search_query: None,
+            command_input: Some(input),
+            command_cursor: None,
+        }
+        .render(area, &mut buf);
+        buf
+    }
+
+    #[test]
+    fn command_input_renders_prompt_and_buffer() {
+        let buf = render_command_bar("filter author");
+        let text = buffer_text(&buf);
+        assert!(text.contains(':'), "command prompt missing: {text:?}");
+        assert!(
+            text.contains("filter author"),
+            "typed line missing: {text:?}"
+        );
+    }
+
+    #[test]
+    fn command_input_renders_hint_line() {
+        let buf = render_command_bar("");
+        let text = buffer_text(&buf);
+        assert!(text.contains("Enter:run"), "hint line missing: {text:?}");
+        assert!(text.contains("Esc:cancel"));
+    }
+
+    #[test]
+    fn command_input_renders_cursor_mid_line() {
+        // With the cursor in the middle of the line, every character still
+        // renders (the cursor cell carries the char under it, reverse-styled).
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        StatusBar {
+            feed: FeedKind::Top,
+            position: "1/1",
+            error: None,
+            info: None,
+            focus_pane: "Stories",
+            input_mode: InputMode::CommandInput,
+            search_input: None,
+            search_query: None,
+            command_input: Some("feed top"),
+            command_cursor: Some(4),
+        }
+        .render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("feed top"), "full line missing: {text:?}");
+    }
+
+    #[test]
+    fn search_input_neutralises_terminal_escapes() {
+        // The search prompt echoes a user buffer too — scrub C0/C1/OSC bytes
+        // the same way the command prompt does.
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        StatusBar {
+            feed: FeedKind::Top,
+            position: "1/1",
+            error: None,
+            info: None,
+            focus_pane: "Stories",
+            input_mode: InputMode::SearchInput,
+            search_input: Some("rust\x1b]0;OWNED\x07lang"),
+            search_query: None,
+            command_input: None,
+            command_cursor: None,
+        }
+        .render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(!text.contains('\x1b'), "ESC must not survive: {text:?}");
+        assert!(!text.contains('\x07'), "BEL must not survive");
+        assert!(text.contains("rust"));
+        assert!(text.contains("lang"));
+    }
+
+    #[test]
+    fn command_input_renders_info_toast_over_hint() {
+        // Tab-completion delivers its candidate list as an info toast; it must
+        // be visible while the `:` prompt is open (previously swallowed).
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        StatusBar {
+            feed: FeedKind::Top,
+            position: "1/1",
+            error: None,
+            info: Some("Matches: :refresh  :reader"),
+            focus_pane: "Stories",
+            input_mode: InputMode::CommandInput,
+            search_input: None,
+            search_query: None,
+            command_input: Some("re"),
+            command_cursor: None,
+        }
+        .render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Matches: :refresh"),
+            "info toast must render in command mode: {text:?}"
+        );
+    }
+
+    #[test]
+    fn command_input_neutralises_terminal_escapes() {
+        // Defence in depth: even though the user types this themselves
+        // today, a future `:source <file>` or paste path could surface
+        // server-bytes through this widget — same C0/C1 stripping as the
+        // error branches.
+        let buf = render_command_bar("feed \x1b]0;OWNED\x07top");
+        let text = buffer_text(&buf);
+        assert!(!text.contains('\x1b'), "ESC must not survive: {text:?}");
+        assert!(!text.contains('\x07'), "BEL must not survive");
+        assert!(text.contains("feed"));
+        assert!(text.contains("top"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #211

## Summary
- New `command` module: a registry of 12 arity-checked built-in `:`-commands (`quit`, `refresh`, `help`, `feed`, `open`, `search`, `reader`, `pin`, `filter`, `yank`, `goto`, `hint`) plus a minimal quote-aware line parser.
- `:`-command prompt (`InputMode::CommandInput`): persisted history (↑/↓), Tab-completion of names, aliases (`un`→`unpin`) and first arguments (`feed t`→`feed top`), and UTF-8-aware mid-line editing (←/→/Home/End).
- `Ctrl+P` fuzzy command palette overlay; arg-bearing commands hand off to a pre-filled `:` prompt, and a bare Enter on an untouched palette is a no-op (no accidental `:quit`).
- Author comment filter (`:filter author <user>`, ancestor-keep) and a persisted command-history store (XDG path, 0600, atomic writes via a shared `persist::write_json_atomic`).
- User/echoed strings sanitized at the render boundary; status-bar feedback (errors vs. auto-expiring info toasts) reconciled so failures and successes both surface correctly.

## Test plan
- [ ] `cargo test` — 536 tests pass
- [ ] `cargo clippy --all-targets` — clean (no new warnings)
- [ ] `cargo fmt --check` — clean
- [ ] `:` prompt: `:quit`, `:feed best`, `:filter author dang`; ↑/↓ recalls history; Tab completes names/aliases/args; ←/→/Home/End edit mid-line
- [ ] `Ctrl+P` palette: fuzzy-filter, Enter runs an arg-less command, an arg-bearing command drops into the `:` prompt, bare Enter does not quit
