### PR TITLE
Harden terminal restore on error paths and sanitize search query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,10 @@ use std::time::Duration;
 
 /// Process entry point — installs the panic hook, brings up the terminal,
 /// constructs the [`App`] and [`EventHandler`], and drives the main loop
-/// until `app.running` is cleared, then persists session state and
-/// restores the terminal.
+/// until `app.running` is cleared, then persists session state. A
+/// `tui::TerminalGuard` restores the terminal on the way out — including a
+/// `?` early-return from `draw`/event polling, which the panic hook (panics
+/// only) does not cover.
 ///
 /// Each loop iteration drains async results from background tasks via
 /// `App::process_messages`, renders one frame, then `.await`s the next
@@ -37,13 +39,17 @@ use std::time::Duration;
 /// # Errors
 ///
 /// Propagates the first error from [`tui::init`], `terminal.size`,
-/// `terminal.draw`, [`EventHandler::next`], or [`tui::restore`]. Any of
-/// these aborts the loop and the process exits non-zero.
+/// `terminal.draw`, or [`EventHandler::next`]; the `TerminalGuard` still
+/// restores the terminal before the process exits non-zero.
 #[tokio::main]
 async fn main() -> Result<()> {
     tui::install_panic_hook();
 
     let mut terminal = tui::init()?;
+    // Restore the terminal on every exit from here on — including a `?`
+    // early-return below (a failed draw or event poll), which the panic hook
+    // does not cover.
+    let _guard = tui::TerminalGuard;
     let mut events = EventHandler::new(Duration::from_millis(250));
     let size = terminal.size()?;
     let mut app = App::new(size.width, size.height);
@@ -175,6 +181,6 @@ async fn main() -> Result<()> {
     }
 
     app.persist();
-    tui::restore()?;
+    // `_guard` is dropped as `main` returns, restoring the terminal.
     Ok(())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,10 +26,22 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 /// terminal construction fail.
 pub fn init() -> Result<Tui> {
     enable_raw_mode()?;
-    execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+    // Raw mode is now active. If a later step fails we must undo it before
+    // returning the error: `main` propagates this with `?` *before* it can
+    // install the `TerminalGuard`, so nothing else would restore the
+    // terminal otherwise.
+    if let Err(e) = execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture) {
+        let _ = disable_raw_mode();
+        return Err(e.into());
+    }
     let backend = CrosstermBackend::new(io::stdout());
-    let terminal = Terminal::new(backend)?;
-    Ok(terminal)
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(e) => {
+            let _ = restore();
+            Err(e.into())
+        }
+    }
 }
 
 /// Undoes [`init`]: disables raw mode, leaves the alternate screen, and
@@ -46,11 +58,33 @@ pub fn restore() -> Result<()> {
     Ok(())
 }
 
+/// RAII guard that restores the terminal when dropped.
+///
+/// `main` constructs one right after [`init`] succeeds, so the terminal
+/// leaves raw mode and the alternate screen on *every* exit path — including
+/// a `?` early-return from `terminal.draw` or event polling, which the panic
+/// hook does not catch (it fires on panics, not `Err` returns). A restore
+/// failure is reported to stderr but cannot be propagated out of `drop`.
+pub struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if let Err(e) = restore() {
+            eprintln!("hnt: failed to restore terminal: {e}");
+        }
+    }
+}
+
 /// Installs a panic hook that restores the terminal before panicking.
 pub fn install_panic_hook() {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        let _ = restore();
+        // Restore first so the panic message prints on the normal screen, not
+        // the alternate one. Surface a restore failure rather than dropping it
+        // silently.
+        if let Err(e) = restore() {
+            eprintln!("hnt: failed to restore terminal after panic: {e}");
+        }
         original_hook(panic_info);
     }));
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -146,9 +146,10 @@ impl<'a> Widget for StatusBar<'a> {
                 ));
             }
         } else if let Some(query) = self.search_query {
-            // Search results mode
+            // Search results mode. Sanitise the echoed query — defence-in-depth
+            // matching the search-input echo and command prompt above.
             spans.push(Span::styled(
-                format!(" Search: \"{}\" ", query),
+                format!(" Search: \"{}\" ", sanitize_terminal(query)),
                 theme::accent_style().bg(theme::SURFACE),
             ));
             spans.push(Span::styled(" ", theme::status_style()));
@@ -317,6 +318,33 @@ mod tests {
         assert!(!text.contains('\x1b'));
         assert!(text.contains("hit"));
         assert!(text.contains("clear"));
+    }
+
+    #[test]
+    fn status_bar_neutralises_escape_in_search_query() {
+        // The committed search query is echoed as the results-mode label; scrub
+        // C0/C1/OSC bytes there too — defence-in-depth matching the search-input
+        // echo and the command prompt.
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        StatusBar {
+            feed: FeedKind::Top,
+            position: "1/1",
+            error: None,
+            info: None,
+            focus_pane: "Stories",
+            input_mode: InputMode::Normal,
+            search_input: None,
+            search_query: Some("rust\x1b]0;OWNED\x07lang"),
+            command_input: None,
+            command_cursor: None,
+        }
+        .render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(!text.contains('\x1b'), "ESC must not survive: {text:?}");
+        assert!(!text.contains('\x07'), "BEL must not survive");
+        assert!(text.contains("rust"));
+        assert!(text.contains("lang"));
     }
 
     fn render_command_bar(input: &str) -> Buffer {

--- a/src/ui/story_list.rs
+++ b/src/ui/story_list.rs
@@ -6,6 +6,7 @@
 //! timestamps.
 
 use crate::api::types::{Item, StoryId};
+use crate::sanitize::sanitize_terminal;
 use crate::state::pin_store::PinStore;
 use crate::state::read_store::ReadStore;
 use crate::ui::theme;
@@ -54,8 +55,13 @@ impl<'a> Widget for StoryList<'a> {
             theme::dim_style()
         };
 
-        let title_span = if let Some(q) = &self.search_query {
-            Span::styled(format!(" Search: {} ", q), theme::title_style())
+        let title_span = if let Some(q) = self.search_query {
+            // Sanitise the echoed query — same defence-in-depth as the status
+            // bar; a pasted query could carry C0/C1 bytes.
+            Span::styled(
+                format!(" Search: {} ", sanitize_terminal(q)),
+                theme::title_style(),
+            )
         } else {
             Span::styled(" Stories ", theme::title_style())
         };
@@ -272,5 +278,51 @@ mod tests {
     fn large_diff_counts_days() {
         // ~30 days
         assert_eq!(format_time_ago_since(0, 86_400 * 30), "30d");
+    }
+
+    #[test]
+    fn search_title_sanitises_terminal_escapes() {
+        use super::StoryList;
+        use crate::state::pin_store::PinStore;
+        use crate::state::read_store::ReadStore;
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        use ratatui::widgets::Widget;
+
+        let read_store = ReadStore::empty();
+        let pin_store = PinStore::empty();
+        let area = Rect::new(0, 0, 80, 6);
+        let mut buf = Buffer::empty(area);
+        StoryList {
+            stories: &[],
+            domains: &[],
+            selected: 0,
+            focused: false,
+            loading: false,
+            // Committed query carries an OSC-0 title-rewrite sequence.
+            search_query: Some("rust\x1b]0;OWNED\x07lang"),
+            read_store: &read_store,
+            pin_store: &pin_store,
+        }
+        .render(area, &mut buf);
+
+        let mut text = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(
+            !text.contains('\x1b'),
+            "ESC must not survive in search title: {text:?}"
+        );
+        assert!(
+            !text.contains('\x07'),
+            "BEL must not survive in search title"
+        );
+        assert!(
+            text.contains("rust"),
+            "query text should still render: {text:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #214

## Summary
- Add `tui::TerminalGuard` (RAII `Drop` → `restore()`), created in `main` right after `init` succeeds, so the terminal is restored on *every* exit — including a `?` early-return from `terminal.size`/`draw`/event polling that the panic hook does not cover. Dropped the now-redundant explicit `tui::restore()?`.
- Harden `tui::init` to undo raw mode if `EnterAlternateScreen` or `Terminal::new` fail — the one window before the guard is in scope.
- Sanitize the committed search query at both render sites (`ui/story_list.rs`, `ui/status_bar.rs`) via `sanitize_terminal()`, matching the existing sibling paths (search-input echo, command prompt, errors).
- Surface `restore()` errors to stderr in the panic hook instead of discarding them.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 538 passed (incl. 2 new escape-neutralization tests)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --document-private-items`
- [ ] Manual: force an early error (e.g. a failed `draw`) and confirm the shell returns to cooked mode
