### PR TITLE
Add headless, scriptable CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Browse stories, read threaded comments, and open links — all from your termina
 - **Open in browser** — Press `o` to open the story URL
 - **Progressive loading** — Root comments appear instantly, children load in the background
 - **Lazy pagination** — Stories load automatically as you scroll
+- **Scriptable** — a headless CLI mode (`hnt top --json`, `hnt thread <id>`, `hnt article <id>`) pipes Hacker News into `jq`, `fzf`, `cron`, or a pager. No arguments still launches the TUI — see [Scripting](#scripting-headless-mode)
 
 ## Installation
 
@@ -123,6 +124,48 @@ cargo build --release
 | `q` | Quit |
 | `Esc` | Back / close |
 | `?` | Help overlay |
+
+## Scripting (headless mode)
+
+Give `hnt` a subcommand and it prints to stdout and exits instead of opening
+the TUI — so Hacker News composes with the rest of your shell (`jq`, `fzf`,
+`cron`, `mail`, a pager, your editor). It talks to the same Hacker News API
+and Algolia the TUI uses and nothing else; output is local-only. With **no**
+arguments, `hnt` still launches the full-screen reader.
+
+| Command | Description |
+|---|---|
+| `hnt <feed>` · `hnt feed <name>` | List a feed: `top` `new` `best` `ask` `show` `jobs` `pinned` |
+| `hnt thread <id>` | Print a story's comment thread (alias: `comments`) |
+| `hnt open <id>` | Print a single item (alias: `item`) |
+| `hnt search <query…>` | Algolia full-text search |
+| `hnt article <id\|url>` | Print extracted article text (alias: `read`) |
+| `hnt --help` · `hnt --version` | Usage / version |
+
+Options: `--json` (a stable JSON contract), `--digest` (one compact line per
+story; feeds only), `--limit N` (default 30), `--max-depth N` (comment nesting
+for `thread`; default 12).
+
+```bash
+# Top 10 titles via jq
+hnt top --limit 10 --json | jq -r '.[].title'
+
+# Save a thread; read an article in your pager
+hnt thread 38911 > thread.txt
+hnt article 38911 | less
+
+# Email yourself a daily front-page digest (cron-friendly)
+hnt top --digest | mail -s "HN today" you@example.com
+
+# Pick a story with fzf, then open its comments
+id=$(hnt top --limit 30 --json | jq -r '.[] | "\(.id)\t\(.title)"' | fzf | cut -f1)
+[ -n "$id" ] && hnt thread "$id" | less
+```
+
+Text output is plain (no ANSI) and HN-supplied strings are stripped of
+terminal control sequences, so it's safe to pipe anywhere. Exit status: `0`
+success, `1` item not found, `2` usage error. See the
+[scripting reference](docs/scripting.md) for the full JSON field list.
 
 ## Configuration & state
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ Supplementary documentation for `hnt`. The main README at the repository
 root is the canonical starting point — these files exist to keep deeper
 explanations out of it.
 
+- [Scripting (headless mode)](scripting.md) — the non-interactive CLI:
+  `hnt top --json`, `hnt thread <id>`, `hnt article <id>`, the JSON contract,
+  and exit codes.
 - [Configuration & state](configuration.md) — where `read.json` and
   `pinned.json` live per platform; how state is persisted and reset.
 - [Internals](internals.md) — load-bearing-but-non-obvious mechanisms:

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,0 +1,111 @@
+# Scripting (headless mode)
+
+`hnt` runs as a non-interactive CLI whenever it's given a subcommand: it
+fetches, prints to stdout, and exits without ever entering raw mode or the
+alternate screen. With **no** arguments it launches the interactive TUI as
+before. This makes Hacker News scriptable — pipe it into `jq`, `fzf`, `cron`,
+`mail`, a pager, or your editor.
+
+There is no new network surface: headless mode reuses the same Firebase
+Hacker News API and Algolia search the TUI uses, with the same 15-second
+request timeout and SSRF guard for `article`. There is no config file and no
+API key — output is local-only.
+
+## Commands
+
+| Command | Aliases | Description |
+|---|---|---|
+| `hnt <feed>` / `hnt feed <name>` | — | List a feed (`top` `new` `best` `ask` `show` `jobs` `pinned`) |
+| `hnt thread <id>` | `comments` | Print a story header and its comment tree |
+| `hnt open <id>` | `item` | Print a single item (story or comment) |
+| `hnt search <query…>` | — | Algolia full-text search across all of HN |
+| `hnt article <id\|url>` | `read` | Extract and print article text |
+| `hnt --help` | `-h`, `help` | Usage |
+| `hnt --version` | `-V`, `version` | Version |
+
+`pinned` reads ids from your local pin store (`pinned.json`) — the same pins
+you star with `b` in the TUI — then fetches them, so it works fully offline of
+any feed endpoint.
+
+## Options
+
+| Option | Applies to | Meaning |
+|---|---|---|
+| `--json` | feeds, `thread`, `open`, `search` | Emit JSON (see contract below) instead of text |
+| `--digest` | feeds | One compact line per story |
+| `--limit N` | feeds, `search`, `thread` | Max items; for `thread`, caps top-level comments. Default 30 for listings |
+| `--max-depth N` | `thread` | Max comment nesting. `0` = root comments only. Default 12 |
+
+`--limit` and `--max-depth` also accept `--flag=N`. `--json` and `--digest`
+are mutually exclusive.
+
+## JSON contract
+
+The `--json` shapes are deliberately decoupled from the internal wire types,
+so scripts that depend on them won't break when internals change. Unset
+optional fields are **omitted** rather than emitted as `null`.
+
+**Story** (feed listings, `open`, and `search` results — an array):
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | number | HN item id |
+| `title` | string | Full title (badge prefix preserved) |
+| `by` | string? | Submitter |
+| `score` | number? | Points |
+| `comments` | number? | Total comment count (HN `descendants`) |
+| `time` | number? | Unix seconds |
+| `url` | string? | External link; omitted for text posts |
+| `domain` | string? | Host of `url`, `www.` stripped |
+| `hn_url` | string | Discussion permalink (always present) |
+| `type` | string? | `story` / `comment` / `job` / `poll` / … |
+
+**Thread** (`hnt thread <id> --json`): `{ "story": <Story>, "comments": [<Comment>] }`,
+where each **Comment** is `{ id, depth, by?, time?, text }` in pre-order
+(`depth` 0 = a top-level reply). `text` is the HTML body rendered to plain
+text.
+
+## Exit status
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | A requested item/story was not found, or a runtime (network) error |
+| `2` | Usage error (unknown command, bad flag, malformed value) |
+
+Errors print to stderr. Running `hnt` with no subcommand while stdout is not a
+terminal (a pipe or file) is treated as a usage error rather than dumping TUI
+escape sequences into the stream.
+
+## Safety
+
+All text output is plain — no ANSI styling — and every Hacker-News-supplied
+string is scrubbed of terminal control sequences before printing (the same
+sanitisation the TUI applies on render). A title or comment can't smuggle an
+escape sequence through a pipe into a later `cat`, pager, or editor.
+
+## Examples
+
+```bash
+# Front-page titles, newline-separated
+hnt top --limit 10 --json | jq -r '.[].title'
+
+# Stories above 200 points right now
+hnt best --limit 50 --json | jq -r '.[] | select(.score > 200) | "\(.score)\t\(.title)"'
+
+# Read an article without leaving the terminal
+hnt article 38911 | less
+
+# Dump a whole thread to a file (full depth)
+hnt thread 38911 --max-depth 99 > thread.txt
+
+# Daily digest by email (cron)
+hnt top --digest | mail -s "HN $(date +%F)" you@example.com
+
+# fzf story picker → comments
+id=$(hnt top --limit 30 --json | jq -r '.[] | "\(.id)\t\(.title)"' | fzf | cut -f1)
+[ -n "$id" ] && hnt thread "$id" | less
+
+# Who's hiring this month, as JSON
+hnt jobs --limit 100 --json > jobs.json
+```

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -383,6 +383,19 @@ impl FeedKind {
             FeedKind::Pinned => None,
         }
     }
+
+    /// Resolves a feed name (case-insensitive) to its [`FeedKind`], or
+    /// `None` for an unrecognized name. Accepts the short names shown in the
+    /// header tab bar and `:feed` completion (`top`, `new`, `best`, `ask`,
+    /// `show`, `jobs`, `pinned`). Backs both the `:feed` command (via
+    /// `feed_index`) and the headless CLI's feed argument, so the accepted
+    /// spellings can't drift between the two entry points.
+    pub fn from_name(name: &str) -> Option<FeedKind> {
+        FeedKind::ALL
+            .iter()
+            .copied()
+            .find(|f| f.to_string().eq_ignore_ascii_case(name))
+    }
 }
 
 impl fmt::Display for FeedKind {
@@ -678,6 +691,22 @@ mod tests {
         assert_eq!(format!("{}", FeedKind::Show), "Show");
         assert_eq!(format!("{}", FeedKind::Jobs), "Jobs");
         assert_eq!(format!("{}", FeedKind::Pinned), "Pinned");
+    }
+
+    #[test]
+    fn from_name_resolves_every_feed_case_insensitively() {
+        for f in FeedKind::ALL {
+            let name = f.to_string();
+            assert_eq!(FeedKind::from_name(&name), Some(f));
+            assert_eq!(FeedKind::from_name(&name.to_lowercase()), Some(f));
+            assert_eq!(FeedKind::from_name(&name.to_uppercase()), Some(f));
+        }
+    }
+
+    #[test]
+    fn from_name_rejects_unknown() {
+        assert_eq!(FeedKind::from_name("nope"), None);
+        assert_eq!(FeedKind::from_name(""), None);
     }
 
     // --- TryFrom<SearchHit> for Item ---

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,743 @@
+//! Headless / scriptable command-line mode.
+//!
+//! When `hnt` is invoked with a subcommand (`hnt top --json`, `hnt thread
+//! 123`, `hnt article 123`, …) it runs **headless**: it prints to stdout and
+//! exits without ever entering raw mode or the alternate screen. With no
+//! arguments, [`parse`] returns `Ok(None)` and `main` falls through to the
+//! interactive TUI.
+//!
+//! The surface deliberately mirrors the in-app `:`-commands (`feed`, `open`,
+//! `search`, `reader`/`article`) so the two interfaces stay consistent. All
+//! network access reuses [`crate::api::client::HnClient`] and
+//! `crate::article` — headless mode adds no new endpoints and stays
+//! local-only, exactly like the TUI.
+
+mod output;
+mod render;
+
+use crate::api::client::HnClient;
+use crate::api::types::{CommentWithDepth, FeedKind, Item};
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::sync::Arc;
+
+/// Default item cap for feed listings and search results.
+const DEFAULT_LIMIT: usize = 30;
+/// Default maximum comment nesting fetched by `thread` — generous enough for
+/// a one-shot print without unbounded fan-out on pathological threads.
+const DEFAULT_MAX_DEPTH: usize = 12;
+/// Render width for comment/article bodies in the text output.
+const TEXT_WIDTH: usize = 80;
+
+/// `--help` / `--version` body and the short usage line shown on errors.
+const HELP_TEXT: &str = "\
+hnt — a dark-themed terminal Hacker News reader
+
+USAGE:
+    hnt                          Launch the interactive TUI (default)
+    hnt <feed> [options]         List a feed: top new best ask show jobs pinned
+    hnt feed <name> [options]    Same, explicit form
+    hnt thread <id> [options]    Print a story's comment thread (alias: comments)
+    hnt open <id> [options]      Print a single item (alias: item)
+    hnt search <query…> [opts]   Search Hacker News via Algolia
+    hnt article <id|url>         Print extracted article text (alias: read)
+    hnt --help | --version
+
+OPTIONS:
+    --json            Emit JSON (a stable contract) instead of text
+    --digest          One compact line per story (feed listings only)
+    --limit N         Max items (feeds/search default 30; thread: top-level cap)
+    --max-depth N     Max comment nesting for `thread` (default 12)
+
+EXAMPLES:
+    hnt top --limit 10 --json | jq -r '.[].title'
+    hnt thread 38911 > thread.txt
+    hnt article 38911 | less
+    hnt search rust async --json
+    hnt top --digest | mail -s 'HN today' me
+
+No arguments launches the full-screen reader. Output is local-only — hnt
+talks only to the Hacker News API and Algolia, exactly like the TUI.
+";
+
+/// A user-facing argument/usage error. Rendered to stderr by `main`, which
+/// then exits with code 2.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UsageError(pub String);
+
+impl std::fmt::Display for UsageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Builds a [`UsageError`] from anything string-like.
+fn ue(msg: impl Into<String>) -> UsageError {
+    UsageError(msg.into())
+}
+
+/// Output format for a listing command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// Multi-line human-readable text (default).
+    Text,
+    /// JSON via the [`output`] contract.
+    Json,
+    /// One compact line per story.
+    Digest,
+}
+
+/// A fully-parsed headless invocation. `main` runs it via [`run`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum Invocation {
+    /// Print `--help`.
+    Help,
+    /// Print the version.
+    Version,
+    /// List a feed.
+    Feed {
+        /// Which feed to list.
+        kind: FeedKind,
+        /// Maximum rows.
+        limit: usize,
+        /// Output format.
+        format: Format,
+    },
+    /// Print a story's comment thread.
+    Thread {
+        /// HN story id.
+        id: u64,
+        /// Maximum comment nesting depth.
+        max_depth: usize,
+        /// Optional cap on top-level comments.
+        limit: Option<usize>,
+        /// Emit JSON instead of text.
+        json: bool,
+    },
+    /// Print a single item (story or comment).
+    Item {
+        /// HN item id.
+        id: u64,
+        /// Emit JSON instead of text.
+        json: bool,
+    },
+    /// Search Hacker News.
+    Search {
+        /// Space-joined query.
+        query: String,
+        /// Maximum results.
+        limit: usize,
+        /// Emit JSON instead of text.
+        json: bool,
+    },
+    /// Extract and print article text for an id or URL.
+    Article {
+        /// An HN item id (numeric) or a direct URL.
+        target: String,
+    },
+}
+
+/// Collected flags + positionals from a subcommand's argument tail.
+#[derive(Default)]
+struct Flags {
+    json: bool,
+    digest: bool,
+    limit: Option<usize>,
+    max_depth: Option<usize>,
+    positionals: Vec<String>,
+}
+
+impl Flags {
+    /// Scans `tokens`, recognizing `--json`, `--digest`, `--limit[ =]N`,
+    /// `--max-depth[ =]N`; anything else starting with `-` is an error and
+    /// bare tokens are collected as positionals.
+    fn parse(tokens: &[String]) -> Result<Self, UsageError> {
+        let mut f = Flags::default();
+        let mut i = 0;
+        while i < tokens.len() {
+            let t = tokens[i].as_str();
+            match t {
+                "--json" => f.json = true,
+                "--digest" => f.digest = true,
+                "--limit" => {
+                    i += 1;
+                    f.limit = Some(num_from_next(tokens.get(i), "--limit", false)?);
+                }
+                "--max-depth" => {
+                    i += 1;
+                    f.max_depth = Some(num_from_next(tokens.get(i), "--max-depth", true)?);
+                }
+                _ if t.starts_with("--limit=") => {
+                    f.limit = Some(parse_num(&t["--limit=".len()..], "--limit", false)?);
+                }
+                _ if t.starts_with("--max-depth=") => {
+                    f.max_depth = Some(parse_num(&t["--max-depth=".len()..], "--max-depth", true)?);
+                }
+                _ if t.starts_with('-') => return Err(ue(format!("unknown flag: {t}"))),
+                _ => f.positionals.push(tokens[i].clone()),
+            }
+            i += 1;
+        }
+        Ok(f)
+    }
+
+    /// Resolves `--json`/`--digest` into a [`Format`], rejecting the
+    /// combination.
+    fn format(&self) -> Result<Format, UsageError> {
+        match (self.json, self.digest) {
+            (true, true) => Err(ue("--json and --digest are mutually exclusive")),
+            (true, false) => Ok(Format::Json),
+            (false, true) => Ok(Format::Digest),
+            (false, false) => Ok(Format::Text),
+        }
+    }
+}
+
+/// Parses a numeric flag value supplied as the next token.
+fn num_from_next(tok: Option<&String>, flag: &str, allow_zero: bool) -> Result<usize, UsageError> {
+    match tok {
+        Some(v) => parse_num(v, flag, allow_zero),
+        None => Err(ue(format!("{flag} requires a number"))),
+    }
+}
+
+/// Parses a numeric flag value. Always rejects non-numeric input; rejects
+/// `0` unless `allow_zero` — true for `--max-depth` (0 means "root comments
+/// only"), false for `--limit` (0 would request an empty listing, almost
+/// always a mistake).
+fn parse_num(v: &str, flag: &str, allow_zero: bool) -> Result<usize, UsageError> {
+    let n = v
+        .parse::<usize>()
+        .map_err(|_| ue(format!("{flag} expects a number, got {v:?}")))?;
+    if n == 0 && !allow_zero {
+        return Err(ue(format!("{flag} must be greater than 0")));
+    }
+    Ok(n)
+}
+
+/// Extracts exactly one numeric id from a command's positionals.
+fn single_id(positionals: &[String], cmd: &str) -> Result<u64, UsageError> {
+    match positionals {
+        [one] => one
+            .parse::<u64>()
+            .map_err(|_| ue(format!("{cmd}: invalid id {one:?}"))),
+        [] => Err(ue(format!("{cmd} requires an item id"))),
+        _ => Err(ue(format!("{cmd} takes a single id"))),
+    }
+}
+
+/// Parses the process arguments (everything after the program name) into an
+/// [`Invocation`].
+///
+/// Returns `Ok(None)` when there are no arguments — the signal for `main` to
+/// launch the interactive TUI. Returns `Err` with a user-facing message for
+/// unknown commands, bad flags, or malformed values. This function performs
+/// no I/O so it is fully unit-testable.
+pub fn parse(args: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let Some(first) = args.first() else {
+        return Ok(None);
+    };
+    let rest = &args[1..];
+    match first.as_str() {
+        "-h" | "--help" | "help" => Ok(Some(Invocation::Help)),
+        "-V" | "--version" | "version" => Ok(Some(Invocation::Version)),
+        "feed" => match rest.first() {
+            Some(name) => parse_feed(name, &rest[1..]),
+            None => Err(ue(
+                "feed requires a name (top, new, best, ask, show, jobs, pinned)",
+            )),
+        },
+        "thread" | "comments" => parse_thread(rest),
+        "open" | "item" => parse_item(rest),
+        "search" => parse_search(rest),
+        "article" | "read" => parse_article(rest),
+        other if FeedKind::from_name(other).is_some() => parse_feed(other, rest),
+        other if other.starts_with('-') => {
+            Err(ue(format!("unknown option: {other} (no subcommand given)")))
+        }
+        other => Err(ue(format!("unknown command: {other}"))),
+    }
+}
+
+/// Parses a feed listing (`hnt top …` / `hnt feed top …`).
+fn parse_feed(name: &str, flags: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let kind = FeedKind::from_name(name).ok_or_else(|| {
+        ue(format!(
+            "unknown feed: {name} (try top, new, best, ask, show, jobs, pinned)"
+        ))
+    })?;
+    let f = Flags::parse(flags)?;
+    if let Some(extra) = f.positionals.first() {
+        return Err(ue(format!("unexpected argument: {extra}")));
+    }
+    if f.max_depth.is_some() {
+        return Err(ue("--max-depth only applies to `thread`"));
+    }
+    let format = f.format()?;
+    Ok(Some(Invocation::Feed {
+        kind,
+        limit: f.limit.unwrap_or(DEFAULT_LIMIT),
+        format,
+    }))
+}
+
+/// Parses `hnt thread <id> …`.
+fn parse_thread(tokens: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let f = Flags::parse(tokens)?;
+    if f.digest {
+        return Err(ue("--digest applies only to feed listings"));
+    }
+    let id = single_id(&f.positionals, "thread")?;
+    Ok(Some(Invocation::Thread {
+        id,
+        max_depth: f.max_depth.unwrap_or(DEFAULT_MAX_DEPTH),
+        limit: f.limit,
+        json: f.json,
+    }))
+}
+
+/// Parses `hnt open <id> …`.
+fn parse_item(tokens: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let f = Flags::parse(tokens)?;
+    if f.digest {
+        return Err(ue("--digest applies only to feed listings"));
+    }
+    let id = single_id(&f.positionals, "open")?;
+    Ok(Some(Invocation::Item { id, json: f.json }))
+}
+
+/// Parses `hnt search <query…> …`.
+fn parse_search(tokens: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let f = Flags::parse(tokens)?;
+    if f.digest {
+        return Err(ue("--digest applies only to feed listings"));
+    }
+    if f.positionals.is_empty() {
+        return Err(ue("search requires a query"));
+    }
+    Ok(Some(Invocation::Search {
+        query: f.positionals.join(" "),
+        limit: f.limit.unwrap_or(DEFAULT_LIMIT),
+        json: f.json,
+    }))
+}
+
+/// Parses `hnt article <id|url>`.
+fn parse_article(tokens: &[String]) -> Result<Option<Invocation>, UsageError> {
+    let f = Flags::parse(tokens)?;
+    if f.json || f.digest || f.limit.is_some() || f.max_depth.is_some() {
+        return Err(ue("article takes no options, just an id or URL"));
+    }
+    match f.positionals.as_slice() {
+        [target] => Ok(Some(Invocation::Article {
+            target: target.clone(),
+        })),
+        [] => Err(ue("article requires an id or URL")),
+        _ => Err(ue("article takes a single id or URL")),
+    }
+}
+
+/// Runs a parsed [`Invocation`], returning the process exit code (`0` on
+/// success, `1` when a requested item could not be found). Network/IO
+/// failures propagate as `Err` for `main` to print.
+pub async fn run(inv: Invocation) -> Result<i32> {
+    match inv {
+        Invocation::Help => {
+            print!("{HELP_TEXT}");
+            Ok(0)
+        }
+        Invocation::Version => {
+            println!("hnt {}", env!("CARGO_PKG_VERSION"));
+            Ok(0)
+        }
+        Invocation::Feed {
+            kind,
+            limit,
+            format,
+        } => run_feed(kind, limit, format).await,
+        Invocation::Thread {
+            id,
+            max_depth,
+            limit,
+            json,
+        } => run_thread(id, max_depth, limit, json).await,
+        Invocation::Item { id, json } => run_item(id, json).await,
+        Invocation::Search { query, limit, json } => run_search(&query, limit, json).await,
+        Invocation::Article { target } => run_article(&target).await,
+    }
+}
+
+/// Fetches and prints a feed listing.
+async fn run_feed(kind: FeedKind, limit: usize, format: Format) -> Result<i32> {
+    let client = HnClient::new();
+    let items: Vec<Arc<Item>> = if kind == FeedKind::Pinned {
+        // Pinned is a virtual feed backed by the local pin store — no remote
+        // endpoint. Load ids from disk, then hydrate via the same item fetch.
+        let ids = crate::state::pin_store::PinStore::load().pinned_ids_newest_first();
+        let ids: Vec<u64> = ids.into_iter().take(limit).collect();
+        client
+            .fetch_items(&ids)
+            .await
+            .into_iter()
+            .flatten()
+            .filter(|i| !i.is_dead_or_deleted())
+            .collect()
+    } else {
+        let (items, _all_ids) = client
+            .fetch_stories(kind, 0, limit)
+            .await
+            .with_context(|| format!("failed to fetch {kind} feed"))?;
+        items
+    };
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    match format {
+        Format::Json => {
+            serde_json::to_writer_pretty(&mut out, &output::stories(&items))?;
+            writeln!(out)?;
+        }
+        Format::Digest => render::digest(&mut out, &items)?,
+        Format::Text => render::feed(&mut out, &items)?,
+    }
+    Ok(0)
+}
+
+/// Fetches and prints a story's comment thread.
+async fn run_thread(id: u64, max_depth: usize, limit: Option<usize>, json: bool) -> Result<i32> {
+    let client = HnClient::new();
+    let Some(story) = client
+        .fetch_item(id)
+        .await
+        .with_context(|| format!("failed to fetch story {id}"))?
+    else {
+        eprintln!("hnt: no item with id {id}");
+        return Ok(1);
+    };
+
+    let mut roots: Vec<u64> = story.kids.as_deref().unwrap_or(&[]).to_vec();
+    if let Some(n) = limit {
+        roots.truncate(n);
+    }
+    let mut flat: Vec<CommentWithDepth> = Vec::new();
+    client
+        .fetch_children_recursive(&roots, 0, max_depth, &mut flat)
+        .await;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        let payload = output::OutThread {
+            story: output::OutStory::from_item(story.as_ref()),
+            comments: flat.iter().map(output::OutComment::from_comment).collect(),
+        };
+        serde_json::to_writer_pretty(&mut out, &payload)?;
+        writeln!(out)?;
+    } else {
+        render::thread(&mut out, story.as_ref(), &flat)?;
+    }
+    Ok(0)
+}
+
+/// Fetches and prints a single item.
+async fn run_item(id: u64, json: bool) -> Result<i32> {
+    let client = HnClient::new();
+    let Some(item) = client
+        .fetch_item(id)
+        .await
+        .with_context(|| format!("failed to fetch item {id}"))?
+    else {
+        eprintln!("hnt: no item with id {id}");
+        return Ok(1);
+    };
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer_pretty(&mut out, &output::OutStory::from_item(item.as_ref()))?;
+        writeln!(out)?;
+    } else if item.title.is_some() {
+        render::feed(&mut out, std::slice::from_ref(&item))?;
+    } else {
+        // A comment (no title) — print author + body.
+        writeln!(
+            out,
+            "by {} · id {}",
+            crate::sanitize::sanitize_terminal(item.by.as_deref().unwrap_or("unknown")),
+            item.id,
+        )?;
+        for line in render::html_to_plain(item.text.as_deref(), TEXT_WIDTH).lines() {
+            writeln!(out, "{line}")?;
+        }
+    }
+    Ok(0)
+}
+
+/// Runs an Algolia search and prints the results.
+async fn run_search(query: &str, limit: usize, json: bool) -> Result<i32> {
+    let client = HnClient::new();
+    let (hits, _pages, _total) = client
+        .search_stories(query, 0, limit)
+        .await
+        .with_context(|| format!("search failed for {query:?}"))?;
+    let hits: Vec<Arc<Item>> = hits.into_iter().take(limit).map(Arc::new).collect();
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer_pretty(&mut out, &output::stories(&hits))?;
+        writeln!(out)?;
+    } else {
+        render::feed(&mut out, &hits)?;
+    }
+    Ok(0)
+}
+
+/// Extracts and prints article text for an id or URL.
+async fn run_article(target: &str) -> Result<i32> {
+    // A numeric target is an HN item id; resolve it to the story's external
+    // URL (or fall back to its text body for an HN-native post).
+    let url = if !target.is_empty() && target.bytes().all(|b| b.is_ascii_digit()) {
+        let id: u64 = target
+            .parse()
+            .with_context(|| format!("invalid id {target}"))?;
+        let client = HnClient::new();
+        let Some(item) = client
+            .fetch_item(id)
+            .await
+            .with_context(|| format!("failed to fetch item {id}"))?
+        else {
+            eprintln!("hnt: no item with id {id}");
+            return Ok(1);
+        };
+        match item.url.clone() {
+            Some(u) => u,
+            None => {
+                let body = render::html_to_plain(item.text.as_deref(), TEXT_WIDTH);
+                if body.trim().is_empty() {
+                    eprintln!("hnt: item {id} has no article URL or text body");
+                    return Ok(1);
+                }
+                let stdout = std::io::stdout();
+                let mut out = stdout.lock();
+                for line in body.lines() {
+                    writeln!(out, "{line}")?;
+                }
+                return Ok(0);
+            }
+        }
+    } else {
+        target.to_string()
+    };
+
+    let (lines, _links) = crate::article::fetch_and_extract_article(&url, TEXT_WIDTH)
+        .await
+        .with_context(|| format!("failed to extract article from {url}"))?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    render::article(&mut out, &lines)?;
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse helper taking string literals.
+    fn p(args: &[&str]) -> Result<Option<Invocation>, UsageError> {
+        let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        parse(&owned)
+    }
+
+    #[test]
+    fn no_args_falls_through_to_tui() {
+        assert_eq!(p(&[]), Ok(None));
+    }
+
+    #[test]
+    fn help_and_version() {
+        assert_eq!(p(&["--help"]), Ok(Some(Invocation::Help)));
+        assert_eq!(p(&["-h"]), Ok(Some(Invocation::Help)));
+        assert_eq!(p(&["help"]), Ok(Some(Invocation::Help)));
+        assert_eq!(p(&["--version"]), Ok(Some(Invocation::Version)));
+        assert_eq!(p(&["-V"]), Ok(Some(Invocation::Version)));
+    }
+
+    #[test]
+    fn feed_shorthand_defaults() {
+        assert_eq!(
+            p(&["top"]),
+            Ok(Some(Invocation::Feed {
+                kind: FeedKind::Top,
+                limit: DEFAULT_LIMIT,
+                format: Format::Text,
+            }))
+        );
+    }
+
+    #[test]
+    fn feed_explicit_with_flags() {
+        assert_eq!(
+            p(&["feed", "best", "--limit", "5", "--json"]),
+            Ok(Some(Invocation::Feed {
+                kind: FeedKind::Best,
+                limit: 5,
+                format: Format::Json,
+            }))
+        );
+    }
+
+    #[test]
+    fn feed_digest_and_equals_limit() {
+        assert_eq!(
+            p(&["new", "--limit=3", "--digest"]),
+            Ok(Some(Invocation::Feed {
+                kind: FeedKind::New,
+                limit: 3,
+                format: Format::Digest,
+            }))
+        );
+    }
+
+    #[test]
+    fn feed_json_and_digest_conflict() {
+        assert!(p(&["top", "--json", "--digest"]).is_err());
+    }
+
+    #[test]
+    fn feed_rejects_max_depth() {
+        assert!(p(&["top", "--max-depth", "3"]).is_err());
+    }
+
+    #[test]
+    fn feed_unknown_name_errors() {
+        assert!(p(&["bogusfeed"]).is_err());
+        assert!(p(&["feed", "bogus"]).is_err());
+        assert!(p(&["feed"]).is_err());
+    }
+
+    #[test]
+    fn pinned_feed_parses() {
+        assert_eq!(
+            p(&["pinned"]),
+            Ok(Some(Invocation::Feed {
+                kind: FeedKind::Pinned,
+                limit: DEFAULT_LIMIT,
+                format: Format::Text,
+            }))
+        );
+    }
+
+    #[test]
+    fn thread_defaults_and_flags() {
+        assert_eq!(
+            p(&["thread", "123"]),
+            Ok(Some(Invocation::Thread {
+                id: 123,
+                max_depth: DEFAULT_MAX_DEPTH,
+                limit: None,
+                json: false,
+            }))
+        );
+        assert_eq!(
+            p(&[
+                "thread",
+                "123",
+                "--json",
+                "--max-depth",
+                "3",
+                "--limit",
+                "10"
+            ]),
+            Ok(Some(Invocation::Thread {
+                id: 123,
+                max_depth: 3,
+                limit: Some(10),
+                json: true,
+            }))
+        );
+    }
+
+    #[test]
+    fn thread_allows_max_depth_zero_root_only() {
+        // depth 0 is a legitimate request (root comments, no recursion);
+        // only --limit rejects 0.
+        assert_eq!(
+            p(&["thread", "5", "--max-depth", "0"]),
+            Ok(Some(Invocation::Thread {
+                id: 5,
+                max_depth: 0,
+                limit: None,
+                json: false,
+            }))
+        );
+        assert!(p(&["thread", "5", "--limit", "0"]).is_err());
+    }
+
+    #[test]
+    fn thread_requires_numeric_id() {
+        assert!(p(&["thread", "abc"]).is_err());
+        assert!(p(&["thread"]).is_err());
+        assert!(p(&["comments", "1", "2"]).is_err());
+    }
+
+    #[test]
+    fn open_item_aliases() {
+        assert_eq!(
+            p(&["open", "42", "--json"]),
+            Ok(Some(Invocation::Item { id: 42, json: true }))
+        );
+        assert_eq!(
+            p(&["item", "42"]),
+            Ok(Some(Invocation::Item {
+                id: 42,
+                json: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn search_joins_query() {
+        assert_eq!(
+            p(&["search", "rust", "async", "--limit", "5"]),
+            Ok(Some(Invocation::Search {
+                query: "rust async".into(),
+                limit: 5,
+                json: false,
+            }))
+        );
+        assert!(p(&["search"]).is_err());
+    }
+
+    #[test]
+    fn article_id_or_url() {
+        assert_eq!(
+            p(&["article", "99"]),
+            Ok(Some(Invocation::Article {
+                target: "99".into(),
+            }))
+        );
+        assert_eq!(
+            p(&["read", "https://example.com"]),
+            Ok(Some(Invocation::Article {
+                target: "https://example.com".into(),
+            }))
+        );
+        assert!(p(&["article"]).is_err());
+        assert!(p(&["article", "1", "2"]).is_err());
+        assert!(p(&["article", "1", "--json"]).is_err());
+    }
+
+    #[test]
+    fn unknown_command_and_leading_flag() {
+        assert!(p(&["frobnicate"]).is_err());
+        assert!(p(&["--json"]).is_err());
+    }
+
+    #[test]
+    fn bad_limit_value() {
+        assert!(p(&["top", "--limit", "x"]).is_err());
+        assert!(p(&["top", "--limit", "0"]).is_err());
+        assert!(p(&["top", "--limit"]).is_err());
+    }
+}

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,191 @@
+//! Stable JSON output contract for headless mode.
+//!
+//! These [`serde::Serialize`] structs are intentionally decoupled from the
+//! wire-level `crate::api::types::Item` so the public `--json` shape stays
+//! stable even if the internal decode type evolves. Each carries a couple of
+//! computed conveniences (`hn_url`, `domain`) that scripts would otherwise
+//! have to derive themselves, and omits unset optional fields rather than
+//! emitting `null` so `jq` filters stay simple.
+
+use crate::api::types::{CommentWithDepth, Item, ItemType};
+use serde::Serialize;
+
+/// Render width for comment bodies that are flattened to plain text inside
+/// the JSON payload. Matches the headless text renderer's default.
+const PLAIN_TEXT_WIDTH: usize = 80;
+
+/// Canonical Hacker News permalink for an item id.
+fn hn_url(id: u64) -> String {
+    format!("https://news.ycombinator.com/item?id={id}")
+}
+
+/// Wire string for an item's type (`story`, `comment`, `job`, …), or `None`
+/// when the source item left `type` unset. Kept as an explicit match (rather
+/// than re-deriving `Serialize` on `ItemType`) so the JSON contract is
+/// independent of the internal enum's serde attributes.
+fn kind_str(item: &Item) -> Option<&'static str> {
+    item.item_type.map(|t| match t {
+        ItemType::Story => "story",
+        ItemType::Comment => "comment",
+        ItemType::Job => "job",
+        ItemType::Poll => "poll",
+        ItemType::Pollopt => "pollopt",
+        ItemType::Unknown => "unknown",
+    })
+}
+
+/// JSON view of a story / job / listing row.
+#[derive(Debug, Serialize)]
+pub struct OutStory {
+    /// HN item id.
+    pub id: u64,
+    /// Full title as posted (badge prefix preserved, e.g. `Ask HN: …`).
+    pub title: String,
+    /// Submitter username, omitted when unknown/deleted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by: Option<String>,
+    /// Net score, omitted for unscored items.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<i64>,
+    /// Total comment count (HN `descendants`), omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments: Option<i64>,
+    /// Submission time in Unix seconds, omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<i64>,
+    /// External link, omitted for HN-native text posts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Host of `url` (with `www.` stripped), omitted for text posts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// HN discussion permalink — always present.
+    pub hn_url: String,
+    /// Item type string, omitted when the source left it unset.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<&'static str>,
+}
+
+impl OutStory {
+    /// Projects an [`Item`] into the public story shape, computing `domain`
+    /// and `hn_url`.
+    pub fn from_item(item: &Item) -> Self {
+        Self {
+            id: item.id,
+            title: item.title.clone().unwrap_or_default(),
+            by: item.by.clone(),
+            score: item.score,
+            comments: item.descendants,
+            time: item.time,
+            url: item.url.clone(),
+            domain: item.domain(),
+            hn_url: hn_url(item.id),
+            kind: kind_str(item),
+        }
+    }
+}
+
+/// JSON view of a single comment in a flattened thread.
+#[derive(Debug, Serialize)]
+pub struct OutComment {
+    /// HN item id of the comment.
+    pub id: u64,
+    /// Tree depth — `0` is a top-level reply to the story.
+    pub depth: usize,
+    /// Author username, omitted when unknown/deleted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by: Option<String>,
+    /// Comment time in Unix seconds, omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<i64>,
+    /// Body rendered to terminal-safe plain text (HTML stripped).
+    pub text: String,
+}
+
+impl OutComment {
+    /// Projects a [`CommentWithDepth`] into the public comment shape,
+    /// rendering its HTML body to plain text.
+    pub fn from_comment(c: &CommentWithDepth) -> Self {
+        Self {
+            id: c.item.id,
+            depth: c.depth,
+            by: c.item.by.clone(),
+            time: c.item.time,
+            text: crate::cli::render::html_to_plain(c.item.text.as_deref(), PLAIN_TEXT_WIDTH),
+        }
+    }
+}
+
+/// JSON view of a story plus its flattened comment tree.
+#[derive(Debug, Serialize)]
+pub struct OutThread {
+    /// The story being discussed.
+    pub story: OutStory,
+    /// Comments in pre-order (parents before descendants); `depth` encodes
+    /// nesting.
+    pub comments: Vec<OutComment>,
+}
+
+/// Builds the JSON listing payload for a slice of stories.
+pub fn stories(items: &[std::sync::Arc<Item>]) -> Vec<OutStory> {
+    items
+        .iter()
+        .map(|i| OutStory::from_item(i.as_ref()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::Item;
+
+    fn story() -> Item {
+        Item {
+            id: 42,
+            title: Some("Ask HN: Test?".into()),
+            url: Some("https://example.com/p".into()),
+            text: None,
+            by: Some("alice".into()),
+            score: Some(100),
+            time: Some(1_700_000_000),
+            kids: None,
+            descendants: Some(7),
+            item_type: Some(ItemType::Story),
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    #[test]
+    fn out_story_computes_hn_url_and_domain() {
+        let s = OutStory::from_item(&story());
+        assert_eq!(s.id, 42);
+        assert_eq!(s.hn_url, "https://news.ycombinator.com/item?id=42");
+        assert_eq!(s.domain.as_deref(), Some("example.com"));
+        assert_eq!(s.kind, Some("story"));
+        assert_eq!(s.comments, Some(7));
+    }
+
+    #[test]
+    fn out_story_serializes_without_null_optionals() {
+        // A text post (no url) should omit `url`/`domain` entirely.
+        let mut item = story();
+        item.url = None;
+        let json = serde_json::to_string(&OutStory::from_item(&item)).unwrap();
+        assert!(!json.contains("\"url\""), "url should be omitted: {json}");
+        assert!(
+            !json.contains("\"domain\""),
+            "domain should be omitted: {json}"
+        );
+        assert!(json.contains("\"hn_url\""), "hn_url must always be present");
+        // Type field is renamed to `type`.
+        assert!(json.contains("\"type\":\"story\""), "got {json}");
+    }
+
+    #[test]
+    fn out_story_missing_title_is_empty_string() {
+        let mut item = story();
+        item.title = None;
+        assert_eq!(OutStory::from_item(&item).title, "");
+    }
+}

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -1,0 +1,253 @@
+//! Plain-text and digest renderers for headless mode.
+//!
+//! Output is colorless (pipe-safe) and every Hacker-News-supplied string is
+//! scrubbed through [`crate::sanitize::sanitize_terminal`] first: a value
+//! printed to a pipe can still reach a terminal later (via `cat`, an editor,
+//! a pager), so the same escape-stripping discipline the TUI applies on
+//! render applies here on write.
+
+use crate::api::types::{CommentWithDepth, Item};
+use crate::sanitize::sanitize_terminal;
+use crate::state::reader_state::StyledFragment;
+use std::io::{self, Write};
+use std::sync::Arc;
+
+/// Wrap width for HTML bodies flattened to plain text (comments, self-posts).
+const WRAP_WIDTH: usize = 80;
+
+/// Strips HTML to terminal-safe plain text at `width` — mirrors the TUI's
+/// comment rendering (`html2text` then [`sanitize_terminal`]). `None` or an
+/// empty body yields an empty string. `width` is floored at 20 because
+/// `html2text` refuses very narrow widths.
+pub fn html_to_plain(html: Option<&str>, width: usize) -> String {
+    let Some(text) = html else {
+        return String::new();
+    };
+    let rendered = html2text::from_read(text.as_bytes(), width.max(20)).unwrap_or_default();
+    sanitize_terminal(&rendered).into_owned()
+}
+
+/// Writes a human-readable, colorless story listing — three lines per story
+/// (title row, metadata row, permalink).
+pub fn feed(out: &mut impl Write, items: &[Arc<Item>]) -> io::Result<()> {
+    if items.is_empty() {
+        writeln!(out, "No stories.")?;
+        return Ok(());
+    }
+    for (i, item) in items.iter().enumerate() {
+        let badge = item
+            .badge()
+            .map(|b| format!("[{}] ", b.label()))
+            .unwrap_or_default();
+        let title = sanitize_terminal(item.title.as_deref().unwrap_or("[no title]"));
+        let domain = item
+            .domain()
+            .map(|d| format!("  ({})", sanitize_terminal(&d)))
+            .unwrap_or_default();
+        writeln!(out, "{:>3}. {badge}{title}{domain}", i + 1)?;
+        writeln!(
+            out,
+            "     {} points · {} comments · by {} · id {}",
+            item.score.unwrap_or(0),
+            item.descendants.unwrap_or(0),
+            sanitize_terminal(item.by.as_deref().unwrap_or("unknown")),
+            item.id,
+        )?;
+        writeln!(out, "     https://news.ycombinator.com/item?id={}", item.id)?;
+    }
+    Ok(())
+}
+
+/// Writes one compact line per story — rank, title, score, comments, domain.
+/// Suitable for a mailed/cron digest.
+pub fn digest(out: &mut impl Write, items: &[Arc<Item>]) -> io::Result<()> {
+    for (i, item) in items.iter().enumerate() {
+        let title = sanitize_terminal(item.title.as_deref().unwrap_or("[no title]"));
+        let domain = item
+            .domain()
+            .map(|d| sanitize_terminal(&d).into_owned())
+            .unwrap_or_else(|| "news.ycombinator.com".to_string());
+        writeln!(
+            out,
+            "{:>3}. {}  [{} pts · {} cmts · {}]",
+            i + 1,
+            title,
+            item.score.unwrap_or(0),
+            item.descendants.unwrap_or(0),
+            domain,
+        )?;
+    }
+    Ok(())
+}
+
+/// Writes a story header followed by its depth-indented comment tree. The
+/// story self-text (Ask/Show HN body, job description) is included when
+/// present; comments are indented two spaces per nesting level.
+pub fn thread(out: &mut impl Write, story: &Item, comments: &[CommentWithDepth]) -> io::Result<()> {
+    let title = sanitize_terminal(story.title.as_deref().unwrap_or("[no title]"));
+    writeln!(out, "{title}")?;
+    if let Some(url) = story.url.as_deref() {
+        // Already http(s)-validated at decode; sanitize defensively anyway.
+        writeln!(out, "{}", sanitize_terminal(url))?;
+    }
+    writeln!(
+        out,
+        "{} points · {} comments · by {} · id {}",
+        story.score.unwrap_or(0),
+        story.descendants.unwrap_or(0),
+        sanitize_terminal(story.by.as_deref().unwrap_or("unknown")),
+        story.id,
+    )?;
+    writeln!(out, "https://news.ycombinator.com/item?id={}", story.id)?;
+
+    let body = html_to_plain(story.text.as_deref(), WRAP_WIDTH);
+    if !body.trim().is_empty() {
+        writeln!(out)?;
+        for line in body.lines() {
+            writeln!(out, "{line}")?;
+        }
+    }
+    writeln!(out)?;
+
+    if comments.is_empty() {
+        writeln!(out, "(no comments)")?;
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    for c in comments {
+        let indent = "  ".repeat(c.depth);
+        let by = sanitize_terminal(c.item.by.as_deref().unwrap_or("unknown"));
+        let age = c
+            .item
+            .time
+            .map(|t| crate::ui::story_list::format_time_ago_since(t, now))
+            .unwrap_or_default();
+        writeln!(out, "{indent}— {by} ({age})")?;
+        let width = WRAP_WIDTH.saturating_sub(c.depth * 2).max(20);
+        for line in html_to_plain(c.item.text.as_deref(), width).lines() {
+            writeln!(out, "{indent}  {line}")?;
+        }
+        writeln!(out)?;
+    }
+    Ok(())
+}
+
+/// Writes article text extracted by `crate::article`, flattening each styled
+/// line to plain text. Fragment text is already terminal-safe (the extractor
+/// sanitizes on construction).
+pub fn article(out: &mut impl Write, lines: &[Vec<StyledFragment>]) -> io::Result<()> {
+    for line in lines {
+        let mut joined = String::new();
+        for frag in line {
+            joined.push_str(&frag.text);
+        }
+        writeln!(out, "{joined}")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::ItemType;
+
+    fn comment(id: u64, depth: usize, text: &str) -> CommentWithDepth {
+        CommentWithDepth {
+            item: Item {
+                id,
+                title: None,
+                url: None,
+                text: Some(text.into()),
+                by: Some("bob".into()),
+                score: None,
+                time: Some(1_700_000_000),
+                kids: None,
+                descendants: None,
+                item_type: Some(ItemType::Comment),
+                dead: None,
+                deleted: None,
+            },
+            depth,
+        }
+    }
+
+    fn story_item() -> Item {
+        Item {
+            id: 1,
+            title: Some("Show HN: Thing".into()),
+            url: Some("https://example.com".into()),
+            text: None,
+            by: Some("alice".into()),
+            score: Some(50),
+            time: Some(1_700_000_000),
+            kids: None,
+            descendants: Some(2),
+            item_type: Some(ItemType::Story),
+            dead: None,
+            deleted: None,
+        }
+    }
+
+    #[test]
+    fn html_to_plain_strips_tags() {
+        let out = html_to_plain(Some("<p>hello <b>world</b></p>"), 80);
+        assert!(out.contains("hello"));
+        assert!(out.contains("world"));
+        assert!(!out.contains('<'), "tags should be stripped: {out:?}");
+    }
+
+    #[test]
+    fn html_to_plain_none_is_empty() {
+        assert_eq!(html_to_plain(None, 80), "");
+    }
+
+    #[test]
+    fn html_to_plain_strips_terminal_escapes() {
+        // Entity-encoded ESC must not survive into the output stream.
+        let out = html_to_plain(Some("a&#x1b;]0;pwned&#x07;b"), 80);
+        assert!(!out.contains('\x1b'), "ESC must be stripped: {out:?}");
+        assert!(!out.contains('\x07'), "BEL must be stripped: {out:?}");
+    }
+
+    #[test]
+    fn feed_renders_rank_title_and_permalink() {
+        let items = vec![Arc::new(story_item())];
+        let mut buf = Vec::new();
+        feed(&mut buf, &items).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("1. [Show HN] Show HN: Thing"));
+        assert!(s.contains("50 points · 2 comments · by alice"));
+        assert!(s.contains("item?id=1"));
+        assert!(!s.contains('\x1b'), "output must be ANSI-free");
+    }
+
+    #[test]
+    fn digest_is_one_line_per_story() {
+        let items = vec![Arc::new(story_item()), Arc::new(story_item())];
+        let mut buf = Vec::new();
+        digest(&mut buf, &items).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert_eq!(s.lines().count(), 2);
+        assert!(s.contains("[50 pts · 2 cmts · example.com]"));
+    }
+
+    #[test]
+    fn thread_indents_by_depth_and_has_no_comments_marker() {
+        let mut buf = Vec::new();
+        thread(&mut buf, &story_item(), &[]).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Show HN: Thing"));
+        assert!(s.contains("(no comments)"));
+
+        let mut buf2 = Vec::new();
+        let comments = vec![comment(2, 0, "root"), comment(3, 1, "child")];
+        thread(&mut buf2, &story_item(), &comments).unwrap();
+        let s2 = String::from_utf8(buf2).unwrap();
+        // depth-1 comment body is indented by 2 (header) + 2 (body) spaces.
+        assert!(
+            s2.contains("\n    child"),
+            "child should be indented: {s2:?}"
+        );
+    }
+}

--- a/src/command/builtin.rs
+++ b/src/command/builtin.rs
@@ -336,9 +336,8 @@ fn register_hint(r: &mut CommandRegistry) {
 /// Maps a feed name (case-folded by caller) to its index in
 /// [`FeedKind::ALL`]. Returns `None` for unknown names.
 fn feed_index(name: &str) -> Option<usize> {
-    FeedKind::ALL
-        .iter()
-        .position(|f| f.to_string().eq_ignore_ascii_case(name))
+    let kind = FeedKind::from_name(name)?;
+    FeedKind::ALL.iter().position(|f| *f == kind)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod api;
 mod app;
 mod article;
+mod cli;
 mod clipboard;
 mod command;
 mod event;
@@ -43,6 +44,45 @@ use std::time::Duration;
 /// restores the terminal before the process exits non-zero.
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Headless / scriptable mode: a subcommand prints to stdout and exits
+    // without ever touching raw mode or the alternate screen. With no
+    // arguments, `cli::parse` returns `Ok(None)` and we fall through to the
+    // interactive TUI below.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match cli::parse(&args) {
+        Ok(Some(invocation)) => {
+            let code = match cli::run(invocation).await {
+                Ok(code) => code,
+                Err(e) => {
+                    eprintln!("hnt: {e:#}");
+                    1
+                }
+            };
+            // `process::exit` skips destructors, so flush the buffered stdout
+            // first — otherwise the tail of the output can be dropped.
+            use std::io::Write;
+            let _ = std::io::stdout().flush();
+            std::process::exit(code);
+        }
+        Ok(None) => {
+            // No subcommand. Refuse to paint the TUI into a non-terminal
+            // stdout (a pipe or file) — that would dump raw escape sequences
+            // into the captured stream. Point the user at headless mode.
+            use std::io::IsTerminal;
+            if !std::io::stdout().is_terminal() {
+                eprintln!("hnt: stdout is not a terminal — the TUI needs a real terminal.");
+                eprintln!("     For scriptable output run a subcommand, e.g. `hnt top --json`.");
+                eprintln!("     See `hnt --help`.");
+                std::process::exit(2);
+            }
+        }
+        Err(e) => {
+            eprintln!("hnt: {e}");
+            eprintln!("Try `hnt --help` for usage.");
+            std::process::exit(2);
+        }
+    }
+
     tui::install_panic_hook();
 
     let mut terminal = tui::init()?;


### PR DESCRIPTION
Closes #216

## Summary
- New `cli` module: `hnt <feed>`/`feed`, `thread` (alias `comments`), `open` (alias `item`), `search`, `article` (alias `read`), plus `--help`/`--version`. No args still launches the TUI.
- Output: `--json` (stable contract in `cli/output.rs`, decoupled from the wire `Item`, unset fields omitted), `--digest` (one line/story), default text. `--limit`, `--max-depth` (`0` = root-only).
- Branches in `main` before terminal setup; a `std::io::IsTerminal` guard refuses to paint the TUI into a pipe. Exit codes `0`/`1`/`2`; errors to stderr; stdout flushed before exit.
- Reuses `HnClient`, `fetch_and_extract_article` (incl. SSRF guard), `html2text`, and `sanitize_terminal` (every printed HN string scrubbed → ANSI-free output). Zero new dependencies.
- Factors `FeedKind::from_name` out of `:feed`'s `feed_index` so the TUI and CLI accept identical feed names.
- Docs: README "Scripting" section + `docs/scripting.md` reference.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo doc -D warnings` clean
- [x] `cargo test` — 566 pass (25 new parse/output/render/`from_name` tests, no network)
- [x] Live e2e: `top --json | jq`, `--digest`, `thread`, `open --json`, `article`, `search`
- [x] Piped output verified ANSI-free (0 ESC bytes); `hnt` with no args still launches the TUI
- [ ] Reviewer: `hnt top --limit 10 --json | jq -r '.[].title'` and `hnt article <id> | less`
