### PR TITLE
fix(ci): unbreak cargo audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
   audit:
     name: cargo audit (RUSTSEC)
     runs-on: ubuntu-latest
+    # The repo default token is read-only. audit-check publishes a check run
+    # on pull_request and opens an issue on push/schedule; without these it
+    # fails the job with "Resource not accessible by integration" even when
+    # the audit itself is clean.
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
       - uses: rustsec/audit-check@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +288,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -691,11 +711,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -705,10 +723,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1804,15 +1825,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1866,18 +1888,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1891,16 +1914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,11 +1924,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2341,7 +2360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 


### PR DESCRIPTION
The `cargo audit (RUSTSEC)` job has been red on every run (PRs and the Monday schedule). `Check & Lint` and both `Build` jobs were always green.

There were **two independent causes** — fixing either alone leaves CI red.

## 1. RUSTSEC-2026-0185 — vulnerable `quinn-proto` 0.11.14

Remote memory exhaustion via unbounded out-of-order stream reassembly (`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`). Patched in `>=0.11.15`; bumped to **0.11.16**.

Worth noting: `cargo tree -i quinn-proto --target all` returns nothing — this is reqwest's optional HTTP/3 path and is **never compiled** into `hnt`. It appears in `Cargo.lock` because lockfile resolution is feature-independent, and `cargo audit` reads the lockfile directly. So it was not actually exploitable here, but it still hard-failed CI. Bumping is preferred over an `audit.toml` ignore. The transitive `rand` 0.9 → 0.10 bump is likewise lockfile-only.

## 2. Missing token permissions — the cause that would have persisted

```
##[error]Unable to publish audit check! Resource not accessible by integration
##[error]Resource not accessible by integration - .../issues#create-an-issue
```

The repo default `GITHUB_TOKEN` is read-only (`contents`/`metadata`/`packages: read`). `rustsec/audit-check` publishes a check run on `pull_request` and opens an issue on `push`/`schedule` — both denied. This failed the job **regardless of the advisory**, so it would have stayed red even with a clean lockfile.

Added a `permissions` block scoped to that job only, so the secure read-only default is preserved everywhere else. The existing `dependabot-auto-merge.yml` confirms explicit `permissions` blocks are honored on Dependabot PRs.

## Verification

Ran the real check locally with `cargo-audit` 0.22.2 — the same version CI installs:

- `cargo audit` → **zero vulnerabilities, zero warnings**, exit 0
- `cargo fmt --check` and `cargo clippy -- -D warnings` → clean
- `cargo test --locked` → **566 passed, 0 failed**

Branched off current `main`, so the lockfile is consistent with the recently merged dependency bumps. (`anyhow` 1.0.104 already landed on `main` via #228, clearing RUSTSEC-2026-0190 — no change needed here.)